### PR TITLE
Whitelist map images from OpenStreetMap

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -334,3 +334,6 @@
 @@||stripe.com^$third-party
 @@||kh.google.com^$third-party
 @@||tile.openstreetmap.org^$third-party
+@@||tile.openstreetmap.fr^$third-party
+@@||tile.opencyclemap.org^$third-party
+@@||tile2.opencyclemap.org^$third-party


### PR DESCRIPTION
OpenStreetMap provides map tiles, which are used by multiple websites. At present, PrivacyBadger makes the maps disappear from those third-party sites. This should fix it I hope. (This is analogous to the case of google maps)
