### PR TITLE
Starts basic unit test for `cookieblocklist`.

### DIFF
--- a/src/cookieblocklist.js
+++ b/src/cookieblocklist.js
@@ -14,25 +14,27 @@
  * You should have received a copy of the GNU General Public License
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
-require.scopes["cookieblocklist"] = (function() {
-  
-var exports = {};
+require.scopes.cookieblocklist = (function() {
 
-var Utils = require('utils').Utils;
+var exports = {};
+var Utils   = require('utils').Utils;
 
 var CookieBlockList = exports.CookieBlockList = {
   domains: [],
+
   updateDomains: function(){
-    var self = this;
+    var _this = this;
+
     chrome.storage.local.get('cookieblocklist', function(items){
       if(chrome.runtime.lastError || !items.cookieblocklist){
         //cookie block list has never been set so we initialize it with an empty array
-        chrome.storage.local.set({cookieblocklist: self.domains});
+        chrome.storage.local.set({cookieblocklist: _this.domains});
         return;
       }
-      self.domains = items.cookieblocklist;
+      _this.domains = items.cookieblocklist;
     });
   },
+
   addDomain: function(domain, cb){
     if(!this.hasDomain(domain)){
       this.domains.push(domain);
@@ -43,21 +45,24 @@ var CookieBlockList = exports.CookieBlockList = {
       });
     }
   },
+
   removeDomain: function(domain){
     if(this.hasDomain(domain)){
       Utils.removeElementFromArray(this.domains,this.domains.indexOf(domain));
       chrome.storage.local.set({cookieblocklist: this.domains});
     }
   },
-  hasDomain: function(domain){
 
+  hasDomain: function(domain){
     var idx = this.domains.indexOf(domain);
+
     if(idx < 0){
       return false;
     } else {
       return true;
     }
   },
+
   hasBaseDomain: function(baseDomain){
     for(var i = 0; i < this.domains.length; i++){
       if(getBaseDomain(this.domains[i]) == baseDomain){
@@ -66,6 +71,6 @@ var CookieBlockList = exports.CookieBlockList = {
     }
     return false;
   }
-}
+};
 return exports;
 })(); //require scopes

--- a/tests/index.html
+++ b/tests/index.html
@@ -26,6 +26,7 @@
     <script src="../lib/compat.js"></script>
     <script src="../lib/io.js"></script>
     <script src="../src/utils.js"></script>
+    <script src="../src/cookieblocklist.js"></script>
     <script src="../lib/adblockplus.js"></script>
     <script src="../lib/publicSuffixList.js"></script>
     <script src="../lib/punycode.js"></script>
@@ -34,6 +35,7 @@
     <script src="../lib/jsbn.js"></script>
     <script src="../lib/rsa.js"></script>
     <script src="common.js"></script>
+    <script src="tests/cookieblocklist.js"></script>
     <script src="tests/versionComparator.js"></script>
     <script src="tests/baseDomain.js"></script>
     <script src="tests/signatures.js"></script>

--- a/tests/tests/baseDomain.js
+++ b/tests/tests/baseDomain.js
@@ -1,7 +1,4 @@
-/*
- * This file is part of Adblock Plus <http://adblockplus.org/>,
- * Copyright (C) 2006-2013 Eyeo GmbH
- *
+/* * This file is part of Adblock Plus <http://adblockplus.org/>, * Copyright (C) 2006-2013 Eyeo GmbH *
  * Adblock Plus is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
  * published by the Free Software Foundation.

--- a/tests/tests/cookieblocklist.js
+++ b/tests/tests/cookieblocklist.js
@@ -1,0 +1,45 @@
+var Utils           = require('utils').Utils;
+var CookieBlockList = require('cookieblocklist').CookieBlockList;
+var cookieBlockList;
+
+module('Cookie Block List', {
+  setup: function() {
+    cookieBlockList = QUnit.extend(CookieBlockList, {
+      domains: []
+    });
+  }
+});
+
+test('`addDomain` correctly adds a domain to the `domains` property.', function() {
+  expect(2);
+
+  var noDomains       = [];
+  var expectedDomains = ['com'];
+
+  deepEqual(cookieBlockList.domains, noDomains, '`domains` does not contain a domain.');
+
+  cookieBlockList.addDomain('com');
+
+  deepEqual(cookieBlockList.domains, expectedDomains, '`domains` contains a domain.');
+});
+
+test('`removeDomain` removes a given domain', function() {
+  expect(2);
+  var expectedDomains = ['net'];
+  var noDomains  = [];
+
+  cookieBlockList.addDomain('net');
+  deepEqual(cookieBlockList.domains, expectedDomains, '`cookieBlockList` conatins domains.');
+
+  cookieBlockList.removeDomain('net');
+  deepEqual(cookieBlockList.domains, noDomains, '`cookieBlockList` does not contain a domain.');
+});
+
+test('`hasDomain` returns `false` if a given domain is not found.', function() {
+  expect(1);
+
+  cookieBlockList.addDomain('net');
+  var invalidDomain = cookieBlockList.hasDomain('com');
+
+  ok(!invalidDomain, 'cookieBlockList does not contain this domain.');
+});


### PR DESCRIPTION
- Uses `_this` instead of `self`, because `self` exists as a reference to
  the `window`.
