### PR TITLE
Removing download permission and adding workaround from uBlock

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,8 +20,7 @@
     "unlimitedStorage",
     "storage",
     "cookies",
-    "privacy",
-    "downloads"
+    "privacy"
   ],
   "background": {
     "scripts": [

--- a/src/options.js
+++ b/src/options.js
@@ -178,10 +178,12 @@ function exportUserData() {
       .replace(/[, ]+/g, '_');
     var filename = 'PrivacyBadger_user_data-' + escapedDate + '.json';
 
-    chrome.downloads.download({
-      url: downloadURL,
-      filename: filename
-    });
+    // Download workaround taken from uBlock Origin:
+    // https://github.com/gorhill/uBlock/blob/40a85f8c04840ae5f5875c1e8b5fa17578c5bd1a/platform/chromium/vapi-common.js
+    var a = document.createElement('a');
+    a.href = downloadURL;
+    a.setAttribute('download', filename || '');
+    a.dispatchEvent(new MouseEvent('click'));
   });
 }
 


### PR DESCRIPTION
This reverts the permission that was added in `81c8fbb3fcc5a48e726c91d175587b55beddac42` and adds a workaround from uBlock that allows downloading of a file without going through `chrome.downloads`.