### PR TITLE
fix #1050: monkey-patch captureStackTrace

### DIFF
--- a/src/fingerprinting.js
+++ b/src/fingerprinting.js
@@ -25,6 +25,24 @@ function getFpPageScript() {
   // return a string
   return "(" + function (ERROR) {
 
+    // monkey patch captureStackTrace for 6to5 - this isn't a polyfill at all!
+    ERROR.captureStackTrace = ERROR.captureStackTrace || function (obj) {
+      if (ERROR.prepareStackTrace) {
+        var frame = {
+          isEval: function () { return false; },
+          getFileName: function () { return "filename"; },
+          getLineNumber: function () { return 1; },
+          getColumnNumber: function () { return 1; },
+          getFunctionName: function () { return "functionName"; }
+        };
+
+        obj.stack = ERROR.prepareStackTrace(obj, [frame, frame, frame]);
+      } else {
+        obj.stack = obj.stack || obj.name || "Error";
+      }
+    };
+
+
     ERROR.stackTraceLimit = Infinity; // collect all frames
 
     var event_id = document.currentScript.getAttribute('data-event-id');


### PR DESCRIPTION
`captureStackTrace` is a V8-only method, so calling it for fingerprint source detection breaks other browsers.

This monkey-patch gets past the error, but it doesn't provide the same details as the full `captureStackTrace` implementation. (it's a monkey-patch, not a poly-fill)

This seems like a break-fix for now, but we may want to file a follow-up issue to restore full fingerprinting-source-detection for Firefox?