### PR TITLE
Use some of the RTC components early on to see if they work

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -179,6 +179,19 @@ Badger.prototype = {
     if (!chrome.privacy) {return;}
     var cpn = chrome.privacy.network;
 
+    // Chrome still has various RTC mechanisms when webRTC is disabled
+    // at build time. Check to see if we can actually use some of them.
+    try {
+      var RTCPC = window.webkitRTCPeerConnection;
+      var pc = new RTCPC(null);
+    } catch(err) {
+      return;
+    }
+
+    if (pc != null && pc.close) {
+      pc.close();
+    }
+
     var settings = this.storage.getBadgerStorageObject("settings_map");
     cpn.webRTCIPHandlingPolicy.get({}, function(result) {
       if (result.value === 'disable_non_proxied_udp') {


### PR DESCRIPTION
Chrome seems to expose the WebRTC api even if it is disabled at compile time.
This extra check attempts to create a peer connection to see if the components
actually work.

This resolves #1047 for me, but I don't have a good setup to test
other (webrtc enabled) boxes.

This check is similar to what [uBlock Origin](https://github.com/gorhill/uBlock/blob/master/platform/chromium/is-webrtc-supported.js) does.