### PR TITLE
Fix crashes on browsers with WebRTC disabled

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -38,6 +38,7 @@ var incognito = require("incognito");
 function Badger() {
   var badger = this;
   this.userAllow = [];
+  this.webRTCAvailable = checkWebRTCBrowserSupport();
   this.storage = new pbStorage.BadgerPen(function(thisStorage) {
     if (badger.INITIALIZED) { return; }
     badger.heuristicBlocking = new HeuristicBlocking.HeuristicBlocker(thisStorage);
@@ -66,6 +67,27 @@ function Badger() {
 
     badger.INITIALIZED = true;
   });
+
+  /**
+  * WebRTC availability check
+  */
+  function checkWebRTCBrowserSupport(){
+    var available = true;
+    var connection = null;
+    try{
+      var RTCPeerConnection = window.RTCPeerConnection || window.webkitRTCPeerConnection;
+      if(RTCPeerConnection){
+        connection = new RTCPeerConnection(null);
+      }
+    } catch (ex){
+      available = false;
+    }
+
+    if(connection !== null && connection.close){
+      connection.close();
+    }
+    return available;
+  }
 }
 
 Badger.prototype = {
@@ -175,11 +197,12 @@ Badger.prototype = {
    * Only update if user does not have the strictest setting enabled
    **/
   enableWebRTCProtection: function(){
-    // Return early if browser doesn't implement chrome.privacy
-    if (!chrome.privacy) {return;}
-    var cpn = chrome.privacy.network;
+    // Return early with non-supporting browsers
+    if (!chrome.privacy || !badger.webRTCAvailable) { return; }
 
+    var cpn = chrome.privacy.network;
     var settings = this.storage.getBadgerStorageObject("settings_map");
+
     cpn.webRTCIPHandlingPolicy.get({}, function(result) {
       if (result.value === 'disable_non_proxied_udp') {
         // TODO is there case where other extension controls this and PB
@@ -580,6 +603,10 @@ Badger.prototype = {
    */
   isWebRTCIPProtectionEnabled: function() {
     var self = this;
+
+    // Return early with non-supporting browsers
+    if (!chrome.privacy || !badger.webRTCAvailable) { return; }
+
     chrome.privacy.network.webRTCIPHandlingPolicy.get({}, function(result) {
       self.getSettings().setItem("webRTCIPProtection",
           (result.value === "disable_non_proxied_udp"));

--- a/src/options.js
+++ b/src/options.js
@@ -76,13 +76,13 @@ function loadOptions() {
   $("#show_counter_checkbox").prop("checked", badger.showCounter());
   $("#replace_social_widgets_checkbox").click(updateSocialWidgetReplacement);
   $("#replace_social_widgets_checkbox").prop("checked", badger.isSocialWidgetReplacementEnabled());
-  if(chrome.privacy){
+  if(chrome.privacy && badger.webRTCAvailable){
     $("#toggle_webrtc_mode").click(toggleWebRTCIPProtection);
     $("#toggle_webrtc_mode").prop("checked", badger.isWebRTCIPProtectionEnabled());
   }
 
-  // Hide WebRTC-related settings for non-Chrome browsers
-  if (!chrome.privacy) {
+  // Hide WebRTC-related settings for non-supporting browsers
+  if (!chrome.privacy || !badger.webRTCAvailable) {
     $("#webRTCToggle").css({"visibility": "hidden", "height": 0});
     $("#settingsSuffix").css({"visibility": "hidden", "height": 0});
   }
@@ -458,8 +458,10 @@ function registerToggleHandlers(element) {
  * value means policy is set to Mode 4 (disable_non_proxied_udp).
  */
 function toggleWebRTCIPProtection() {
-  if (!chrome.privacy) { return; } // Return early if user's browser does not support chrome.privacy
+  // Return early with non-supporting browsers
+  if (!chrome.privacy || !badger.webRTCAvailable) { return; }
   var cpn = chrome.privacy.network;
+
   cpn.webRTCIPHandlingPolicy.get({}, function(result) {
     var newVal;
 


### PR DESCRIPTION
This should fix crashes related to reading and writing WebRTC settings on browsers that do not support it. Fix also includes disabling Privacy Badger's WebRTC option on such browsers. See #1047 for discussion.