### PR TITLE
Changing export to use UTF-8 instead of Base64

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -166,7 +166,7 @@ function exportUserData() {
   chrome.storage.local.get(["action_map", "snitch_map", "settings_map"], function(maps) {
 
     var mapJSON = JSON.stringify(maps);
-    var downloadURL = 'data:application/json;base64,' + btoa(mapJSON);
+    var downloadURL = 'data:application/json;charset=utf-8,' + encodeURIComponent(mapJSON);
 
     // Append the formatted date to the exported file name
     var currDate = new Date().toLocaleString();


### PR DESCRIPTION
@ghostwords 

As per #1063, Base64 doesn't support a wide enough character set to handle all possible URLs (e.g. URLs can now be in non-Latin alphabets). This changes the generated download URL to be in UTF-8 encoding and uses the relevant conversion function to support this set of characters.