### PR TITLE
fix #1120: calc width for entire pop-up body

### DIFF
--- a/skin/popup.css
+++ b/skin/popup.css
@@ -28,7 +28,7 @@ body {
   padding-right: 7px;
   overflow-y: hidden;
   overflow-x: hidden;
-  width: 400px;
+  width: calc(100% - 30px);
 }
 
 a { text-decoration: none }


### PR DESCRIPTION
This makes the entire pop-up body width dynamic so it looks right in either pageAction pop-up context ...

![privacybadger-pageaction-popup](https://cloud.githubusercontent.com/assets/71928/21742117/afb8ed1c-d4ad-11e6-9ea7-89230c751765.png)

or menu pop-up context ...

![privacybadger-menu-popup](https://cloud.githubusercontent.com/assets/71928/21742122/b8b723ca-d4ad-11e6-90e3-e76a9652fc5b.png)
