### PR TITLE
Work around incorrect main frame ID in Firefox

### DIFF
--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -56,6 +56,11 @@ function onBeforeRequest(details){
   }
 
   if (type == "main_frame" || type == "sub_frame"){
+    // Firefox workaround: https://bugzilla.mozilla.org/show_bug.cgi?id=1329299
+    // TODO remove after Firefox 51 is no longer in use
+    if (type == "main_frame" && frame_id != 0) {
+      frame_id = 0;
+    }
     recordFrame(tab_id, frame_id, details.parentFrameId, url);
   }
 


### PR DESCRIPTION
This should fix #1078 and  #1101.

A concern for the code review: Do we have any places in the code where we want to do something for a main frame that could have a non-zero frame ID in Firefox? If there are, those places will break because of this patch. If there are none, great, no problem.