### PR TITLE
Fix broken selenium cookie tracker tests.

### DIFF
--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -58,14 +58,13 @@ class CookieTest(pbtest.PBSeleniumTest):
         window_utils.close_windows_with_url( self.driver, SITE1_URL )
         self.load_pb_ui( SITE2_URL )
         self.get_tracker_state()
-        self.assertTrue(THIRD_PARTY_TRACKER  in self.nonTrackers)
+        self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
         # go to third site
         self.load_url( SITE3_URL )
         window_utils.close_windows_with_url( self.driver, SITE2_URL )
         self.load_pb_ui( SITE3_URL )
         self.get_tracker_state()
-        
         self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
         # reloading the first site should now cause the cookie to be blocked

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -3,15 +3,7 @@
 
 import unittest
 import pbtest
-import re
-#import sys
 import time
-
-from selenium.webdriver.common.action_chains import ActionChains
-#from selenium.webdriver.common.keys import Keys
-from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 import window_utils
 
@@ -22,14 +14,16 @@ SITE3_URL = "http://eff-tracker-site3-test.s3-website-us-west-2.amazonaws.com"
 THIRD_PARTY_TRACKER = "eff-tracker-test.s3-website-us-west-2.amazonaws.com"
 
 
+
 class CookieTest(pbtest.PBSeleniumTest):
     """Basic test to make sure the PB doesn't mess up with the cookies."""
 
     def assert_pass_opera_cookie_test(self, url, test_name):
         self.load_url(url)
-        self.assertEqual("PASS",
-             self.js("return document.getElementById('result').innerHTML"),
-             "Cookie test failed: %s" % test_name)
+        self.assertEqual(
+                "PASS",
+                self.js("return document.getElementById('result').innerHTML"),
+                "Cookie test failed: %s" % test_name)
 
     def test_should_pass_std_cookie_test(self):
         self.assert_pass_opera_cookie_test("https://gistcdn.githack.com/gunesacar/79aa14bac95694d38425d458843dacd6/raw/3d17cc07e071a45c0bf536b907b6848786090c8a/cookie.html",  # noqa
@@ -48,22 +42,22 @@ class CookieTest(pbtest.PBSeleniumTest):
         # fixme: check for chrome settings for third party cookies?
 
         # load the first site with the third party code that reads and writes a cookie
-        self.load_url( SITE1_URL )
-        self.load_pb_ui( SITE1_URL )
+        self.load_url(SITE1_URL)
+        self.load_pb_ui(SITE1_URL)
         self.get_tracker_state()
         self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
         # go to second site
-        self.load_url( SITE2_URL )
-        window_utils.close_windows_with_url( self.driver, SITE1_URL )
-        self.load_pb_ui( SITE2_URL )
+        self.load_url(SITE2_URL)
+        window_utils.close_windows_with_url(self.driver, SITE1_URL)
+        self.load_pb_ui(SITE2_URL)
         self.get_tracker_state()
         self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
         # go to third site
-        self.load_url( SITE3_URL )
-        window_utils.close_windows_with_url( self.driver, SITE2_URL )
-        self.load_pb_ui( SITE3_URL )
+        self.load_url(SITE3_URL)
+        window_utils.close_windows_with_url(self.driver, SITE2_URL)
+        self.load_pb_ui(SITE3_URL)
         self.get_tracker_state()
         self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
@@ -71,22 +65,23 @@ class CookieTest(pbtest.PBSeleniumTest):
         # it can take a long time for the UI to be updated, so retry a number of
         # times before giving up. See bug #702.
         print("this is checking for a dnt file at a site without https, so we'll just have to wait for the connection to timeout before we proceed")
-        self.load_url( SITE1_URL )
-        window_utils.close_windows_with_url( self.driver, SITE3_URL )
+        self.load_url(SITE1_URL)
+        window_utils.close_windows_with_url(self.driver, SITE3_URL)
         for i in range(60):
-                self.load_pb_ui( SITE1_URL )
+                self.load_pb_ui(SITE1_URL)
                 self.get_tracker_state()
                 
                 if THIRD_PARTY_TRACKER in self.cookieBlocked:
                     print("Popup UI has been updated. Yay!")
                     break
-                window_utils.close_windows_with_url( self.driver, self.popup_url)
+                window_utils.close_windows_with_url(self.driver, self.popup_url)
+                window_utils.close_windows_with_url(self.driver, PU_URL)
                 print("popup UI has not been updated yet. try again in 10 seconds")
                 time.sleep(10)
 
         self.assertTrue(THIRD_PARTY_TRACKER in self.cookieBlocked)
 
-    def load_pb_ui(self, target_scheme_and_host ):
+    def load_pb_ui(self, target_scheme_and_host):
         """Show the PB popup as a new tab.
 
         If Selenium would let us just programmatically launch an extension from its icon,
@@ -108,17 +103,17 @@ class CookieTest(pbtest.PBSeleniumTest):
         # open a new tab. And if you inject javascript to open a window and you have the
         # popup blocker turned on, it won't work. Workaround: embed a button on the target page
         # that opens a new window when clicked.
-        window_utils.switch_to_window_with_url( self.driver, target_scheme_and_host )
+        window_utils.switch_to_window_with_url(self.driver, target_scheme_and_host)
         button = self.driver.find_element_by_id("newwindowbutton")
         button.click()
-        window_utils.switch_to_window_with_url( self.driver, "about:blank" )
+        window_utils.switch_to_window_with_url(self.driver, "about:blank")
         self.load_url(self.popup_url)
 
         # use the new convenience function to get the popup populated with status information for the correct url
         window_utils.switch_to_window_with_url(self.driver, self.popup_url)
         target_url = target_scheme_and_host + "/*"
         javascript_src = "setTabToUrl('" + target_url + "');"
-        self.js( javascript_src )
+        self.js(javascript_src)
         #print "executed " + javascript_src
 
     def get_tracker_state(self):
@@ -128,7 +123,7 @@ class CookieTest(pbtest.PBSeleniumTest):
         self.blocked = {}
         try:
                 clickerContainer = self.driver.find_element_by_class_name("clickerContainer")
-                self.assertTrue( clickerContainer )
+                self.assertTrue(clickerContainer)
         except:
                 print("no action state information was found")
                 return

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -51,21 +51,22 @@ class CookieTest(pbtest.PBSeleniumTest):
         self.load_url( SITE1_URL )
         self.load_pb_ui( SITE1_URL )
         self.get_tracker_state()
-        self.assertTrue( self.nonTrackers.has_key( THIRD_PARTY_TRACKER ) )
+        self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
         # go to second site
         self.load_url( SITE2_URL )
         window_utils.close_windows_with_url( self.driver, SITE1_URL )
         self.load_pb_ui( SITE2_URL )
         self.get_tracker_state()
-        self.assertTrue( self.nonTrackers.has_key( THIRD_PARTY_TRACKER ) )
+        self.assertTrue(THIRD_PARTY_TRACKER  in self.nonTrackers)
 
         # go to third site
         self.load_url( SITE3_URL )
         window_utils.close_windows_with_url( self.driver, SITE2_URL )
         self.load_pb_ui( SITE3_URL )
         self.get_tracker_state()
-        self.assertTrue( self.nonTrackers.has_key( THIRD_PARTY_TRACKER ) )
+        
+        self.assertTrue(THIRD_PARTY_TRACKER in self.nonTrackers)
 
         # reloading the first site should now cause the cookie to be blocked
         # it can take a long time for the UI to be updated, so retry a number of
@@ -76,13 +77,15 @@ class CookieTest(pbtest.PBSeleniumTest):
         for i in range(60):
                 self.load_pb_ui( SITE1_URL )
                 self.get_tracker_state()
-                if self.cookieBlocked.has_key( THIRD_PARTY_TRACKER ):
+                
+                if THIRD_PARTY_TRACKER in self.cookieBlocked:
                     print("Popup UI has been updated. Yay!")
                     break
                 window_utils.close_windows_with_url( self.driver, self.popup_url)
                 print("popup UI has not been updated yet. try again in 10 seconds")
                 time.sleep(10)
-        self.assertTrue( self.cookieBlocked.has_key( THIRD_PARTY_TRACKER ) )
+
+        self.assertTrue(THIRD_PARTY_TRACKER in self.cookieBlocked)
 
     def load_pb_ui(self, target_scheme_and_host ):
         """Show the PB popup as a new tab.
@@ -136,9 +139,9 @@ class CookieTest(pbtest.PBSeleniumTest):
                 origin = t.get_attribute('data-origin')
 
                 # assert that this origin is never duplicated in the UI
-                self.assertTrue( not self.nonTrackers.has_key(origin) )
-                self.assertTrue( not self.cookieBlocked.has_key(origin) )
-                self.assertTrue( not self.blocked.has_key(origin) )
+                self.assertTrue(origin not in self.nonTrackers)
+                self.assertTrue(origin not in self.cookieBlocked)
+                self.assertTrue(origin not in self.blocked)
 
                 action_type = t.get_attribute('data-original-action')
                 if action_type == 'allow':

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -28,8 +28,8 @@ class CookieTest(pbtest.PBSeleniumTest):
     def test_should_pass_std_cookie_test(self):
         self.assert_pass_opera_cookie_test("https://gistcdn.githack.com/gunesacar/79aa14bac95694d38425d458843dacd6/raw/3d17cc07e071a45c0bf536b907b6848786090c8a/cookie.html",  # noqa
                                            "Set 1st party cookie")
-    # TODO: FIXME!
-    def FIXMEtest_cookie_tracker_detection(self):
+
+    def test_cookie_tracker_detection(self):
         """Tests basic cookie tracking. The tracking site has no DNT file,
         and gets blocked by PB.
 

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -14,7 +14,6 @@ SITE3_URL = "http://eff-tracker-site3-test.s3-website-us-west-2.amazonaws.com"
 THIRD_PARTY_TRACKER = "eff-tracker-test.s3-website-us-west-2.amazonaws.com"
 
 
-
 class CookieTest(pbtest.PBSeleniumTest):
     """Basic test to make sure the PB doesn't mess up with the cookies."""
 
@@ -70,12 +69,12 @@ class CookieTest(pbtest.PBSeleniumTest):
         for i in range(60):
                 self.load_pb_ui(SITE1_URL)
                 self.get_tracker_state()
-                
+
                 if THIRD_PARTY_TRACKER in self.cookieBlocked:
                     print("Popup UI has been updated. Yay!")
                     break
                 window_utils.close_windows_with_url(self.driver, self.popup_url)
-                window_utils.close_windows_with_url(self.driver, PU_URL)
+                window_utils.close_windows_with_url(self.driver, self.popup_url)
                 print("popup UI has not been updated yet. try again in 10 seconds")
                 time.sleep(10)
 
@@ -114,7 +113,6 @@ class CookieTest(pbtest.PBSeleniumTest):
         target_url = target_scheme_and_host + "/*"
         javascript_src = "setTabToUrl('" + target_url + "');"
         self.js(javascript_src)
-        #print "executed " + javascript_src
 
     def get_tracker_state(self):
         """Parse the UI to group all third party origins into their respective action states."""


### PR DESCRIPTION
This fixes `tests/selenium/cookie_test.py::CookieTest.test_cookie_tracker_detection` and cleans up the test file. In theory should work on top of #1168, but should probably be re-tested with it when it is merged, or vice-versa.

The main issue seemed to be the test was not python3 compatible.