### PR TITLE
Reverting change from 4124c86 to fix issue with toggle switch (#1197)

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -421,23 +421,23 @@ function showTrackingDomains(domains) {
     var value = $(this).children('input:checked').val();
 
     var slider = $('<div></div>').slider({
-        min: 0,
-        max: 2,
-        value: value,
-        create: function(/*event, ui*/) {
-            $(this).children('.ui-slider-handle').css('margin-left', -16 * value + 'px');
-        },
-        slide: function(event, ui) {
-            radios.filter('[value=' + ui.value + ']').click();
-        },
-        stop: function(event, ui) {
-            $(ui.handle).css('margin-left', -16 * ui.value + 'px');
+      min: 0,
+      max: 2,
+      value: value,
+      create: function(/*event, ui*/) {
+        $(this).children('.ui-slider-handle').css('margin-left', -16 * value + 'px');
+      },
+      slide: function(event, ui) {
+        radios.filter('[value=' + ui.value + ']').click();
+      },
+      stop: function(event, ui) {
+        $(ui.handle).css('margin-left', -16 * ui.value + 'px');
 
-            // Save change for origin.
-            var origin = radios.filter('[value=' + ui.value + ']')[0].name;
-            var action = htmlUtils.getCurrentClass($(this).parents('.clicker'));
-            syncSettings(origin, action);
-        },
+        // Save change for origin.
+        var origin = radios.filter('[value=' + ui.value + ']')[0].name;
+        var action = htmlUtils.getCurrentClass($(this).parents('.clicker'));
+        syncSettings(origin, action);
+      },
     }).appendTo(this);
 
     radios.change(function() {

--- a/src/options.js
+++ b/src/options.js
@@ -435,13 +435,13 @@ function showTrackingDomains(domains) {
 
         // Save change for origin.
         var origin = radios.filter('[value=' + ui.value + ']')[0].name;
-        var action = htmlUtils.getCurrentClass($(this).parents('.clicker'));
-        syncSettings(origin, action);
+        var setting = htmlUtils.getCurrentClass($(this).parents('.clicker'));
+        syncSettings(origin, setting);
       },
     }).appendTo(this);
 
     radios.change(function() {
-        slider.slider('value', radios.filter(':checked').val());
+      slider.slider('value', radios.filter(':checked').val());
     });
   });
 }

--- a/src/options.js
+++ b/src/options.js
@@ -414,39 +414,35 @@ function showTrackingDomains(domains) {
   $('#blockedResourcesInner').html(trackingDetails);
   $('#blockedResourcesInner').off('scroll');
   $('#blockedResourcesInner').scroll(domains, addOrigins);
-  $('.switch-toggle').each(function() { registerToggleHandlers(this); });
-}
 
-/**
- * Registers handlers for tracking domain toggle controls.
- * @param element HTML element containing toggle control.
- */
-function registerToggleHandlers(element) {
-  var radios = $(element).children('input');
-  var value = $(element).children('input:checked').val();
+  // Register handlers for tracking domain toggle controls.
+  $('.switch-toggle').each(function() {
+    var radios = $(this).children('input');
+    var value = $(this).children('input:checked').val();
 
-  var slider = $('<div></div>').slider({
-    min: 0,
-    max: 2,
-    value: value,
-    create: function(/*event, ui*/) {
-      $(element).children('.ui-slider-handle').css('margin-left', -16 * value + 'px');
-    },
-    slide: function(event, ui) {
-      radios.filter('[value=' + ui.value + ']').click();
-    },
-    stop: function(event, ui) {
-      $(ui.handle).css('margin-left', -16 * ui.value + 'px');
+    var slider = $('<div></div>').slider({
+        min: 0,
+        max: 2,
+        value: value,
+        create: function(/*event, ui*/) {
+            $(this).children('.ui-slider-handle').css('margin-left', -16 * value + 'px');
+        },
+        slide: function(event, ui) {
+            radios.filter('[value=' + ui.value + ']').click();
+        },
+        stop: function(event, ui) {
+            $(ui.handle).css('margin-left', -16 * ui.value + 'px');
 
-      // Save change for origin.
-      var origin = radios.filter('[value=' + ui.value + ']')[0].name;
-      var action = htmlUtils.getCurrentClass($(element).parents('.clicker'));
-      syncSettings(origin, action);
-    },
-  }).appendTo(element);
+            // Save change for origin.
+            var origin = radios.filter('[value=' + ui.value + ']')[0].name;
+            var action = htmlUtils.getCurrentClass($(this).parents('.clicker'));
+            syncSettings(origin, action);
+        },
+    }).appendTo(this);
 
-  radios.change(function() {
-    slider.slider('value', radios.filter(':checked').val());
+    radios.change(function() {
+        slider.slider('value', radios.filter(':checked').val());
+    });
   });
 }
 


### PR DESCRIPTION
As per #1197, the sliders were broken quite a while back. I tracked this down finally to an issue with the extraction of the anonymous function in `$('.switch-toggle').each(...)` into an externally defined function. It isn't exactly clear to me what in this change actually affected the slider, so it's not at all surprising that this got overlooked. Maybe a closer look into this will yield some further information, though until then this simple reversion seems to fix the issue.

Here's an updated image to compare with that from the original issue:
![slider-fixed](https://cloud.githubusercontent.com/assets/11308076/23114608/e25d5f64-f6f4-11e6-84da-4dea4152df5f.png)