### PR TITLE
Revert "fix #1120: calc width for entire pop-up body"

### DIFF
--- a/skin/popup.css
+++ b/skin/popup.css
@@ -28,7 +28,7 @@ body {
   padding-right: 7px;
   overflow-y: hidden;
   overflow-x: hidden;
-  width: calc(100% - 30px);
+  width: 400px;
 }
 
 a { text-decoration: none }


### PR DESCRIPTION
Undoing change to width of popup to fix issue in standard Chrome popup. The change fixed it for the popup in the Firefox menu, but resulted in the revert and 'x' icons being hidden by the slider in the default Chrome setup.