### PR TITLE
add openlibrary.org and archive.org to mdfp list. 

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -387,6 +387,7 @@ player.ooyala.com
 tile.opencyclemap.org
 tile2.opencyclemap.org
 openlayers.org
+openlibrary.org
 nominatim.openstreetmap.org
 tile.openstreetmap.fr
 tile.openstreetmap.org

--- a/doc/sample_cookieblocklist_legacy.txt
+++ b/doc/sample_cookieblocklist_legacy.txt
@@ -387,6 +387,7 @@
 @@||tile.opencyclemap.org^$third-party
 @@||tile2.opencyclemap.org^$third-party
 @@||openlayers.org^$third-party
+@@||openlibrary.org^$third-party
 @@||nominatim.openstreetmap.org^$third-party
 @@||tile.openstreetmap.fr^$third-party
 @@||tile.openstreetmap.org^$third-party

--- a/src/multiDomainFirstParties.js
+++ b/src/multiDomainFirstParties.js
@@ -155,6 +155,7 @@ var _multiDomainFirstPartiesArray = [
   ["xiami.com", "alipay.com"],
   ["zendesk.com", "zopim.com"],
   ["zonealarm.com", "zonelabs.com"],
+  ["archive.org", "openlibrary.org"],
   ["dummy"]
 ];
 


### PR DESCRIPTION
temp fix while archive.org figures out DNT. adding to cookie block list as well to fix on any other sites it may be embedded on. 
fixes #1219