### PR TITLE
Add a debug log.

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -38,6 +38,7 @@ var incognito = require("incognito");
 */
 function Badger() {
   var badger = this;
+  this.debugLog = new utils.DebugLog();
   this.userAllow = [];
   this.webRTCAvailable = checkWebRTCBrowserSupport();
   this.storage = new pbStorage.BadgerPen(function(thisStorage) {

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -25,6 +25,10 @@ window.log = function (/*...*/) {
   if(window.DEBUG) {
     console.log.apply(console, arguments);
   }
+  if(window.badger && window.badger.debugLog) {
+    let msg = Array.from(arguments).map(e => e.toString());
+    window.badger.debugLog.doLog(msg);
+  }
 };
 
 /**

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -238,10 +238,9 @@ BadgerPen.prototype = {
     }
     actionObj[actionType] = action;
 
-    if (window.DEBUG) { // to avoid needless JSON.stringify calls
-      log(msg, domain, actionType, JSON.stringify(action));
-    }
     action_map.setItem(domain, actionObj);
+
+    log(msg, domain, actionType, action);
   },
 
   /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -356,7 +356,7 @@ DebugLog.prototype = {
    * 4
    */
   mod: function(num) {
-    var remainder = (num % this.maxSize);
+    let remainder = (num % this.maxSize);
     if (remainder < 0) {
       return this.maxSize + remainder;
     } else {
@@ -369,11 +369,11 @@ DebugLog.prototype = {
    * recent entry is at index zero.
    */
   output: function() {
-    var out = [];
-    var maxSize = this.maxSize;
-    var start = this.mod(this.index - 1);
-    for (var i = 0; i < maxSize; i++) {
-      var entry = this.logBook[this.mod(start - i)];
+    let out = [];
+    let maxSize = this.maxSize;
+    let start = this.mod(this.index - 1);
+    for (let i = 0; i < maxSize; i++) {
+      let entry = this.logBook[this.mod(start - i)];
       if ("undefined" == typeof entry) {
         break;
       } else {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -322,6 +322,68 @@ function parseCookie(str, opts) {
   return parsed;
 }
 
+function DebugLog(maxSize) {
+  this.index = 0;
+  if (maxSize) {
+    this.maxSize = maxSize;
+  }
+  this.logBook = new Array(this.maxSize);
+}
+
+/**
+ * Logging utility. Addinding an entry is always O(1). We keep the last entries
+ * up to `maxSize`.
+ */
+DebugLog.prototype = {
+  // The maximum number of entries the log stores.
+  maxSize: 1000,
+
+   // Add an entry to the logBook. This is always O(1).
+  doLog: function(toLog) {
+    if (typeof toLog == 'undefined') {
+      return;
+    }
+    this.logBook[this.index] = toLog;
+    this.index = this.mod(this.index + 1);
+  },
+
+  /**
+   * Modulus function - since % in js actually a remainder. This is used to
+   * wrap an index around the log book. For example if maxSize is 5:
+   * > mod(4)
+   * 4
+   * > mod(-1)  // but -1 % 5 == -1
+   * 4
+   */
+  mod: function(num) {
+    var remainder = (num % this.maxSize);
+    if (remainder < 0) {
+      return this.maxSize + remainder;
+    } else {
+      return remainder;
+    }
+  },
+
+  /**
+   * Dump entries from the log in reverse chronological order. So the most
+   * recent entry is at index zero.
+   */
+  output: function() {
+    var out = [];
+    var maxSize = this.maxSize;
+    var start = this.mod(this.index - 1);
+    for (var i = 0; i < maxSize; i++) {
+      var entry = this.logBook[this.mod(start - i)];
+      if ("undefined" == typeof entry) {
+        break;
+      } else {
+        out.push(entry);
+      }
+    }
+    return out;
+  }
+};
+
 /************************************** exports */
 var exports = {};
 
@@ -340,6 +402,7 @@ exports.rateLimit = rateLimit;
 exports.removeElementFromArray = removeElementFromArray;
 exports.sha1 = sha1;
 exports.xhrRequest = xhrRequest;
+exports.DebugLog = DebugLog;
 
 return exports;
 /************************************** exports */

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -336,7 +336,7 @@ function DebugLog(maxSize) {
  */
 DebugLog.prototype = {
   // The maximum number of entries the log stores.
-  maxSize: 1000,
+  maxSize: 300,
 
    // Add an entry to the logBook. This is always O(1).
   doLog: function(toLog) {

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -402,27 +402,27 @@
 
   });
   QUnit.test('test DebugLog', function(assert) {
-    var msg = 'Oh brave new world that has such people in it.'.split(' ');
-    var dl = new utils.DebugLog();
+    let msg = 'Oh brave new world that has such people in it.'.split(' ');
+    let dl = new utils.DebugLog();
     dl.maxSize = 5; // decrease maxSize for testing
 
     // test log that isn't filled up all the way
     dl.doLog('foo');
     dl.doLog('bar');
 
-    var res1 = dl.output();
+    let res1 = dl.output();
     assert.ok(res1.indexOf('bar') === 0, 'last entry is first');
     assert.ok(res1.indexOf('foo') === 1, '2nd to last entry is 2nd');
     assert.equal(res1.length, 2, 'debug log is a long as number of entries, if it has had less than maxSize entries');
 
     // test log that wraps around
-    for (var i = 0; i < msg.length; i++) {
+    for (let i = 0; i < msg.length; i++) {
       dl.doLog(msg[i]);
     }
 
-    var res = dl.output();
+    let res = dl.output();
     msg.reverse();
-    for (var j = 0; j < 5; j++) {
+    for (let j = 0; j < 5; j++) {
       assert.ok(msg[j] === res[j], 'output is in correct order');
     }
     assert.ok(res.length === 5, 'output is maxSize');

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -401,5 +401,31 @@
     assert.equal(cookies.title, "front end engineer", "Cookie 'title' should have value 'front end engineer'.");
 
   });
+  QUnit.test('test DebugLog', function(assert) {
+    var msg = 'Oh brave new world that has such people in it.'.split(' ');
+    var dl = new utils.DebugLog();
+    dl.maxSize = 5; // decrease maxSize for testing
+
+    // test log that isn't filled up all the way
+    dl.doLog('foo');
+    dl.doLog('bar');
+
+    var res1 = dl.output();
+    assert.ok(res1.indexOf('bar') === 0, 'last entry is first');
+    assert.ok(res1.indexOf('foo') === 1, '2nd to last entry is 2nd');
+    assert.equal(res1.length, 2, 'debug log is a long as number of entries, if it has had less than maxSize entries');
+
+    // test log that wraps around
+    for (var i = 0; i < msg.length; i++) {
+      dl.doLog(msg[i]);
+    }
+
+    var res = dl.output();
+    msg.reverse();
+    for (var j = 0; j < 5; j++) {
+      assert.ok(msg[j] === res[j], 'output is in correct order');
+    }
+    assert.ok(res.length === 5, 'output is maxSize');
+  });
 
 })();


### PR DESCRIPTION
This stores messages passed to the `log` function. 

I think this might be useful to help debug user's issues that we can't reproduce. Or we could ask users to include it in their bug reports.

If we decide to more vocally ask user to post debugging info with their issues (like with an `ISSUE_TEMPLATE.md`)  then the debug log should be exposed through the option menu, along with some basic redaction to hide URL's the user has visited.

The log messages are stored in a ring buffer (`DebugLog.logBook`), and adding an entry is O(1). 

