### PR TITLE
Add EditorConfig settings file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,11 @@ charset = utf-8
 [*.js]
 indent_style = space
 indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) is a way to auto-configure compatible editors to use project-specific indentation settings. This config file declares Privacy Badger uses two spaces for `.js` files.