### PR TITLE
Remove leftover uses of noBlockingLink

### DIFF
--- a/skin/popup.css
+++ b/skin/popup.css
@@ -213,14 +213,6 @@ font-size: 16px;
   background-color: #EC9329;
   color: #333;
 }
-#noBlockingLink{
-  text-align: center;
-  z-index: 20;
-  margin: auto;
-}
-#noBlockingLink a {
-  color:#4183c4;
-}
 .clickerContainer {
   max-height: 290px;
   overflow-y: auto;

--- a/src/background.js
+++ b/src/background.js
@@ -440,25 +440,6 @@ Badger.prototype = {
   },
 
   /**
-   * Counts the actively blocked trackers
-   * TODO: move to popup.js and refactor
-   *
-   * @param tabId Tab ID to count for
-   * @returns {Integer} The number of blocked trackers
-   */
-  activelyBlockedOriginCount: function(tabId){
-    var self = this;
-    return self.getAllOriginsForTab(tabId)
-      .reduce(function(memo,origin){
-        var action = self.storage.getBestAction(origin);
-        if(action && action !== "noaction"){
-          memo+=1;
-        }
-        return memo;
-      }, 0);
-  },
-
-  /**
    * Counts total blocked trackers and blocked cookies trackers
    * TODO: ugly code, refactor
    *
@@ -479,24 +460,6 @@ Badger.prototype = {
       }, 0);
   },
 
-  /**
-   * Counts trackers blocked by the user
-   *
-   * TODO: ugly code refactor
-   * @param tabId Tab ID to count for
-   * @returns {Integer} The number of blocked trackers
-   */
-  userConfiguredOriginCount: function(tabId){
-    var self = this;
-    return self.getAllOriginsForTab(tabId)
-      .reduce(function(memo,origin){
-        var action = self.storage.getBestAction(origin);
-        if(action && action.lastIndexOf("user", 0) === 0){
-          memo+=1;
-        }
-        return memo;
-      }, 0);
-  },
   /**
    * Update page action badge with current count
    * @param {Integer} tabId chrome tab id

--- a/src/popup.js
+++ b/src/popup.js
@@ -257,7 +257,6 @@ function refreshPopup(tabId) {
   //TODO this is calling get action and then being used to call get Action
   var origins = badger.getAllOriginsForTab(tabId);
   if (!origins || origins.length === 0) {
-    hideNoInitialBlockingLink();
     $("#blockedResources").html(i18n.getMessage("popup_blocked"));
     $('#number_trackers').text('0');
     return;
@@ -341,7 +340,6 @@ function refreshPopup(tabId) {
       slider.slider("value",radios.filter(':checked').val());
     });
   });
-  adjustNoInitialBlockingLink();
 
   // Hide elements for removing origins (controlled from the options page).
   // Popup shows what's loaded for the current page so it doesn't make sense
@@ -371,29 +369,6 @@ function updateOrigin(event){
   var origin = $clicker.data('origin');
   $clicker.attr('tooltip', htmlUtils.getActionDescription(action, origin));
   $clicker.children('.tooltipContainer').html(htmlUtils.getActionDescription(action, origin));
-  hideNoInitialBlockingLink();
-}
-
-/**
-* Hide #noBlockingLink
-*/
-function hideNoInitialBlockingLink() {
-  $("#noBlockingLink").hide();
-}
-
-/**
-* Hide or show additional info depending on if there is any additional info
-*/
-function adjustNoInitialBlockingLink() {
-  var tabId = parseInt($('#associatedTab').attr('data-tab-id'), 10);
-  var origins = badger.blockedOriginCount(tabId);
-  var totalBlocked = badger.activelyBlockedOriginCount(tabId);
-  var userBlocked = badger.userConfiguredOriginCount(tabId);
-  if (origins > 0 && totalBlocked === 0 && userBlocked === 0) {
-    $("#noBlockingLink").show();
-  } else {
-    $("#noBlockingLink").hide();
-  }
 }
 
 var tooltipDelay = 300;


### PR DESCRIPTION
The functions `activelyBLockedOriginCount`, `userConfiguredOriginCount`,
`hideNoInitialBlockingLink`, and `adjustNoInitialBlockingLink` are used to set
a `<p>` tag that was removed in d1d2494fad087e442912b606801ac2e2d3067167.

Since the element they are hiding and showing doesn't exist anymore, they
should be able to be removed.