### PR TITLE
wip: Log blocked and replaced resources to content page console

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,8 @@
         "src/clobbercookie.js",
         "src/clobberlocalstorage.js",
         "src/fingerprinting.js",
-        "src/supercookie.js"
+        "src/supercookie.js",
+        "src/console.js"
       ],
       "matches": [
         "<all_urls>"

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -30,9 +30,25 @@ window.log = function (/*...*/) {
 /**
  * Log a message to the console of an active tab
  */
-window.consoleBroadcast = function (tab_id, text) {
-  chrome.tabs.sendMessage(tab_id, { type: 'LOG', text: text });
-};
+window.logToTab = logToTabConstructor();
+function logToTabConstructor() {
+  var tabs = {};
+  var _logToTab = debounce(function (tab_id) {
+    setTimeout(function () {
+      chrome.tabs.sendMessage(tab_id, { type: 'LOGS', logs: tabs[tab_id] });
+      delete tabs[tab_id];
+    }, 0);
+  }, 1000);
+  return function (tab_id, text) {
+    if (!tabs[tab_id]) {
+      tabs[tab_id] = [];
+    }
+    if (tabs[tab_id].indexOf(text) === -1) {
+      tabs[tab_id].push(text);
+      _logToTab(tab_id);
+    }
+  };
+}
 
 /**
  * Basic implementation of requirejs
@@ -42,3 +58,36 @@ function require(module) {
   return require.scopes[module];
 }
 require.scopes = {};
+
+// from Underscore v1.6.0
+function debounce(func, wait, immediate) {
+  var timeout, args, context, timestamp, result;
+
+  var later = function () {
+    var last = Date.now() - timestamp;
+    if (last < wait) {
+      timeout = setTimeout(later, wait - last);
+    } else {
+      timeout = null;
+      if (!immediate) {
+        result = func.apply(context, args);
+        context = args = null;
+      }
+    }
+  };
+  return function () {
+    context = this;
+    args = arguments;
+    timestamp = Date.now();
+    var callNow = immediate && !timeout;
+    if (!timeout) {
+      timeout = setTimeout(later, wait);
+    }
+    if (callNow) {
+      result = func.apply(context, args);
+      context = args = null;
+    }
+
+    return result;
+  };
+}

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -30,8 +30,8 @@ window.log = function (/*...*/) {
 /**
  * Log a message to the console of an active tab
  */
-window.consoleBroadcast = function (tab_id, message) {
-  chrome.tabs.sendMessage(tab_id, message);
+window.consoleBroadcast = function (tab_id, text) {
+  chrome.tabs.sendMessage(tab_id, { type: 'LOG', text: text });
 }
 
 /**

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -32,7 +32,7 @@ window.log = function (/*...*/) {
  */
 window.consoleBroadcast = function (tab_id, text) {
   chrome.tabs.sendMessage(tab_id, { type: 'LOG', text: text });
-}
+};
 
 /**
  * Basic implementation of requirejs

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -31,8 +31,8 @@ window.log = function (/*...*/) {
  * Log a message to the console of an active tab
  */
 window.consoleBroadcast = function (tab_id, message) {
-  chrome.tabs.sendMessage(tab_id, message)
-};
+  chrome.tabs.sendMessage(tab_id, message);
+}
 
 /**
  * Basic implementation of requirejs

--- a/src/console.js
+++ b/src/console.js
@@ -15,55 +15,18 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function logMessage () {
-  var messages = [];
-  var _log = debounce(function () {
-    setTimeout(function () {
-      messages.forEach(function (message) {
-        console.log(message);
-      });
-      messages = [];
-    }, 0);
-  }, 1000);
+function logMessages () {
+  var pastLogs = [];
   return function (message) {
-    if (message.type === 'LOG' && messages.indexOf(message.text) === -1) {
-      messages.push(message.text);
-      _log();
+    if (message.logs && message.type && message.type === 'LOGS') {
+      message.logs.forEach(function (log) {
+        if (pastLogs.indexOf(log) === -1) {
+          pastLogs.push(log);
+          console.log(log);
+        }
+      });
     }
   };
 }
 
-chrome.runtime.onMessage.addListener(logMessage());
-
-// from Underscore v1.6.0
-function debounce(func, wait, immediate) {
-  var timeout, args, context, timestamp, result;
-
-  var later = function () {
-    var last = Date.now() - timestamp;
-    if (last < wait) {
-      timeout = setTimeout(later, wait - last);
-    } else {
-      timeout = null;
-      if (!immediate) {
-        result = func.apply(context, args);
-        context = args = null;
-      }
-    }
-  };
-  return function () {
-    context = this;
-    args = arguments;
-    timestamp = Date.now();
-    var callNow = immediate && !timeout;
-    if (!timeout) {
-      timeout = setTimeout(later, wait);
-    }
-    if (callNow) {
-      result = func.apply(context, args);
-      context = args = null;
-    }
-
-    return result;
-  };
-}
+chrome.runtime.onMessage.addListener(logMessages());

--- a/src/console.js
+++ b/src/console.js
@@ -24,12 +24,12 @@ window.logMessage = function () {
       })
       messages = [];
     }, 0);
-  }, 100)
-    return function (message) {
-      if (message.type === 'LOG') {
-        messages.push(message.text);
-        _log();
-      }
+  }, 1000)
+  return function (message) {
+    if (message.type === 'LOG' && messages.indexOf(message.text) === -1) {
+      messages.push(message.text);
+      _log();
+    }
   }
 }
 

--- a/src/console.js
+++ b/src/console.js
@@ -15,8 +15,53 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function logMessage (message) {
-  console.log(message);
+window.logMessage = function () {
+  var messages = [];
+  var _log = debounce(function () {
+    setTimeout(function () {
+      messages.forEach(function (message) {
+        console.log(message);
+      })
+      messages = [];
+    }, 0);
+  }, 100)
+  return function (message) {
+    messages.push(message);
+    _log();
+  }
 }
 
-chrome.runtime.onMessage.addListener(logMessage);
+chrome.runtime.onMessage.addListener(logMessage());
+
+// from Underscore v1.6.0
+function debounce(func, wait, immediate) {
+  var timeout, args, context, timestamp, result;
+
+  var later = function () {
+    var last = Date.now() - timestamp;
+    if (last < wait) {
+      timeout = setTimeout(later, wait - last);
+    } else {
+      timeout = null;
+      if (!immediate) {
+        result = func.apply(context, args);
+        context = args = null;
+      }
+    }
+  };
+  return function () {
+    context = this;
+    args = arguments;
+    timestamp = Date.now();
+    var callNow = immediate && !timeout;
+    if (!timeout) {
+      timeout = setTimeout(later, wait);
+    }
+    if (callNow) {
+      result = func.apply(context, args);
+      context = args = null;
+    }
+
+    return result;
+  }
+}

--- a/src/console.js
+++ b/src/console.js
@@ -15,22 +15,22 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-window.logMessage = function () {
+function logMessage () {
   var messages = [];
   var _log = debounce(function () {
     setTimeout(function () {
       messages.forEach(function (message) {
         console.log(message);
-      })
+      });
       messages = [];
     }, 0);
-  }, 1000)
+  }, 1000);
   return function (message) {
     if (message.type === 'LOG' && messages.indexOf(message.text) === -1) {
       messages.push(message.text);
       _log();
     }
-  }
+  };
 }
 
 chrome.runtime.onMessage.addListener(logMessage());
@@ -65,5 +65,5 @@ function debounce(func, wait, immediate) {
     }
 
     return result;
-  }
+  };
 }

--- a/src/console.js
+++ b/src/console.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Privacy Badger <https://www.eff.org/privacybadger>
- * Copyright (C) 2014 Electronic Frontier Foundation
+ * Copyright (C) 2015 Electronic Frontier Foundation
  *
  * Privacy Badger is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -15,30 +15,8 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-window.DEBUG = false;
-window.badger = {};
-
-/**
-* Log a message to the console if debugging is enabled
-*/
-window.log = function (/*...*/) {
-  if(window.DEBUG) {
-    console.log.apply(console, arguments);
-  }
-};
-
-/**
- * Log a message to the console of an active tab
- */
-window.consoleBroadcast = function (tab_id, message) {
-  chrome.tabs.sendMessage(tab_id, message)
-};
-
-/**
- * Basic implementation of requirejs
- * for requiring other javascript files
- */
-function require(module) {
-  return require.scopes[module];
+function logMessage (message) {
+  console.log(message);
 }
-require.scopes = {};
+
+chrome.runtime.onMessage.addListener(logMessage);

--- a/src/console.js
+++ b/src/console.js
@@ -25,9 +25,11 @@ window.logMessage = function () {
       messages = [];
     }, 0);
   }, 100)
-  return function (message) {
-    messages.push(message);
-    _log();
+    return function (message) {
+      if (message.type === 'LOG') {
+        messages.push(message.text);
+        _log();
+      }
   }
 }
 

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -101,6 +101,7 @@ function onBeforeRequest(details){
       if (type == 'script') {
         var surrogate = getSurrogateURI(url, requestDomain);
         if (surrogate) {
+          log('[Privacy Badger] replaced ' + url + ' with ' + surrogate);
           return {redirectUrl: surrogate};
         }
       }
@@ -112,6 +113,7 @@ function onBeforeRequest(details){
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
+      log('[Privacy Badger] blocked ' + url);
       return {cancel: true};
     }
   }

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -102,7 +102,10 @@ function onBeforeRequest(details){
         var surrogate = getSurrogateURI(url, requestDomain);
         if (surrogate) {
           log('[Privacy Badger] replaced ' + url + ' with ' + surrogate);
-          consoleBroadcast(tab_id, '[Privacy Badger] replaced ' + url + ' with ' + surrogate);
+          consoleBroadcast(tab_id, {
+            type: 'LOG',
+            text: '[Privacy Badger] replaced ' + url + ' with ' + surrogate
+          });
           return {redirectUrl: surrogate};
         }
       }
@@ -115,7 +118,10 @@ function onBeforeRequest(details){
       chrome.tabs.sendMessage(tab_id, msg);
 
       log('[Privacy Badger] blocked ' + url);
-      consoleBroadcast(tab_id, '[Privacy Badger] blocked ' + url);
+      consoleBroadcast(tab_id, {
+        type: 'LOG',
+        text: '[Privacy Badger] blocked ' + url
+      });
       return {cancel: true};
     }
   }

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -22,7 +22,7 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* globals badger:false, log:false, consoleBroadcast:false */
+/* globals badger:false, log:false, logToTab:false */
 
 var constants = require('constants');
 var getSurrogateURI = require('surrogates').getSurrogateURI;
@@ -102,7 +102,7 @@ function onBeforeRequest(details){
         var surrogate = getSurrogateURI(url, requestDomain);
         if (surrogate) {
           log('[Privacy Badger] replaced ' + url + ' with ' + surrogate);
-          consoleBroadcast(tab_id, '[Privacy Badger] replaced ' + url + ' with ' + surrogate);
+          logToTab(tab_id, '[Privacy Badger] replaced ' + url + ' with ' + surrogate);
           return {redirectUrl: surrogate};
         }
       }
@@ -115,7 +115,7 @@ function onBeforeRequest(details){
       chrome.tabs.sendMessage(tab_id, msg);
 
       log('[Privacy Badger] blocked ' + url);
-      consoleBroadcast(tab_id, '[Privacy Badger] blocked ' + url);
+      logToTab(tab_id, '[Privacy Badger] blocked ' + url);
       return {cancel: true};
     }
   }

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -102,10 +102,7 @@ function onBeforeRequest(details){
         var surrogate = getSurrogateURI(url, requestDomain);
         if (surrogate) {
           log('[Privacy Badger] replaced ' + url + ' with ' + surrogate);
-          consoleBroadcast(tab_id, {
-            type: 'LOG',
-            text: '[Privacy Badger] replaced ' + url + ' with ' + surrogate
-          });
+          consoleBroadcast(tab_id, '[Privacy Badger] replaced ' + url + ' with ' + surrogate);
           return {redirectUrl: surrogate};
         }
       }
@@ -118,10 +115,7 @@ function onBeforeRequest(details){
       chrome.tabs.sendMessage(tab_id, msg);
 
       log('[Privacy Badger] blocked ' + url);
-      consoleBroadcast(tab_id, {
-        type: 'LOG',
-        text: '[Privacy Badger] blocked ' + url
-      });
+      consoleBroadcast(tab_id, '[Privacy Badger] blocked ' + url);
       return {cancel: true};
     }
   }

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -102,6 +102,7 @@ function onBeforeRequest(details){
         var surrogate = getSurrogateURI(url, requestDomain);
         if (surrogate) {
           log('[Privacy Badger] replaced ' + url + ' with ' + surrogate);
+          consoleBroadcast(tab_id, '[Privacy Badger] replaced ' + url + ' with ' + surrogate);
           return {redirectUrl: surrogate};
         }
       }
@@ -114,6 +115,7 @@ function onBeforeRequest(details){
       chrome.tabs.sendMessage(tab_id, msg);
 
       log('[Privacy Badger] blocked ' + url);
+      consoleBroadcast(tab_id, '[Privacy Badger] blocked ' + url);
       return {cancel: true};
     }
   }

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -22,7 +22,7 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* globals badger:false, log:false */
+/* globals badger:false, log:false, consoleBroadcast:false */
 
 var constants = require('constants');
 var getSurrogateURI = require('surrogates').getSurrogateURI;


### PR DESCRIPTION
Commonly, when using Privacy Badger with the console open (on localhost while developing personal/client work or even on a website like cnn.com during reverse engineering), a front end web developer will see messages like "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT"

It is enough that PB shows up in the toolbar and lists the blocked scripts when clicked to pull up the popup, and the developer can quickly disable PB for the site right there, but it would be nice if alongside the "Failed to load resource..." message PB could log something like "[Privacy Badger] blocked {url}" directly into the console of localhost or cnn.com to remind the developer to click on the toolbar icon and disable PB for the site under inspection.

This pull requests implements #1110 and should be reviewed with #1221 in mind.