### PR TITLE
Reduce impact of DNT rechecking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ before_script:
   - npm install # install JS dependencies (eslint) from package.json
   - . ./scripts/setup_travis.sh
   - cd tests
-script:  travis_retry ./run_selenium_tests.sh
+script: ./run_selenium_tests.sh

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -274,13 +274,9 @@ Badger.prototype = {
   },
 
   /**
-  * Initialize DNT Setup:
-  * * download acceptable hashes from EFF
-  * * set up listener to recheck blocked domains and DNT domains
+  * Initialize DNT policy subsystem by downloading acceptable hashes from EFF
   */
   initializeDNT: function(){
-    setInterval(this.recheckDNTPolicyForDomains.bind(this), utils.oneHour());
-
     this.updateDNTPolicyHashes();
     setInterval(this.updateDNTPolicyHashes.bind(this), utils.oneDay() * 4);
   },
@@ -310,27 +306,6 @@ Badger.prototype = {
         return;
       }
       self.storage.updateDNTHashes(JSON.parse(response));
-    });
-  },
-
-  /**
-  * Loop through blocked domains and recheck any that need to be rechecked for a dnt-policy file
-  */
-  recheckDNTPolicyForDomains: function () {
-    const ACTIONS_TO_RECHECK = [
-      constants.BLOCK,
-      constants.COOKIEBLOCK,
-      constants.DNT,
-    ];
-    let action_map = this.storage.getBadgerStorageObject('action_map');
-
-    // arrow functions bind "this",
-    // no need to bind it ourselves or enclose it in local var
-    _.each(action_map.getItemClones(), (domainMap, domain) => {
-      let action = this.storage.getActionForFqdn(domainMap);
-      if (ACTIONS_TO_RECHECK.indexOf(action) != -1) {
-        this.checkForDNTPolicy(domain, domainMap.nextUpdateTime);
-      }
     });
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -279,9 +279,9 @@ Badger.prototype = {
   * * set up listener to recheck blocked domains and DNT domains
   */
   initializeDNT: function(){
-    this.updateDNTPolicyHashes();
-    this.recheckDNTPolicyForDomains();
     setInterval(this.recheckDNTPolicyForDomains.bind(this), utils.oneHour());
+
+    this.updateDNTPolicyHashes();
     setInterval(this.updateDNTPolicyHashes.bind(this), utils.oneDay() * 4);
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -313,18 +313,26 @@ Badger.prototype = {
     });
   },
 
-
-
   /**
-  * Loop through all known domains and recheck any that need to be rechecked for a dnt-policy file
+  * Loop through blocked domains and recheck any that need to be rechecked for a dnt-policy file
   */
-  recheckDNTPolicyForDomains: function(){
-    var action_map = this.storage.getBadgerStorageObject('action_map');
-    for(var domain in action_map.getItemClones()){
-      this.checkForDNTPolicy(domain, this.storage.getNextUpdateForDomain(domain));
-    }
-  },
+  recheckDNTPolicyForDomains: function () {
+    const ACTIONS_TO_RECHECK = [
+      constants.BLOCK,
+      constants.COOKIEBLOCK,
+      constants.DNT,
+    ];
+    let action_map = this.storage.getBadgerStorageObject('action_map');
 
+    // arrow functions bind "this",
+    // no need to bind it ourselves or enclose it in local var
+    _.each(action_map.getItemClones(), (domainMap, domain) => {
+      let action = this.storage.getActionForFqdn(domainMap);
+      if (ACTIONS_TO_RECHECK.indexOf(action) != -1) {
+        this.checkForDNTPolicy(domain, domainMap.nextUpdateTime);
+      }
+    });
+  },
 
   /**
   * Checks a domain for the EFF DNT policy.

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -288,7 +288,7 @@ Badger.prototype = {
   initializeUserAllowList: function() {
     var action_map = this.storage.getBadgerStorageObject('action_map');
     for(var domain in action_map.getItemClones()){
-      if(this.storage.getActionForFqdn(domain) === constants.USER_ALLOW){
+      if(this.storage.getAction(domain) === constants.USER_ALLOW){
         this.userAllow.push(domain);
       }
     }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -274,9 +274,14 @@ Badger.prototype = {
   },
 
   /**
-  * Initialize DNT policy subsystem by downloading acceptable hashes from EFF
+  * Initialize DNT policy subsystem:
+  * * download acceptable hashes from EFF
+  * * set up listener to recheck DNT-respecting domains
   */
-  initializeDNT: function(){
+  initializeDNT: function () {
+    this.recheckDNTPolicyForDomains();
+    setInterval(this.recheckDNTPolicyForDomains.bind(this), utils.oneHour());
+
     this.updateDNTPolicyHashes();
     setInterval(this.updateDNTPolicyHashes.bind(this), utils.oneDay() * 4);
   },
@@ -306,6 +311,22 @@ Badger.prototype = {
         return;
       }
       self.storage.updateDNTHashes(JSON.parse(response));
+    });
+  },
+
+  /**
+  * Loop through DNT-respecting domains, and recheck any that need to be
+  * rechecked for a DNT policy file.
+  */
+  recheckDNTPolicyForDomains: function () {
+    let action_map = this.storage.getBadgerStorageObject('action_map');
+
+    // arrow functions bind "this",
+    // no need to bind it ourselves or enclose it in local var
+    _.each(action_map.getItemClones(), (domainMap, domain) => {
+      if (this.storage.getActionForFqdn(domainMap) == constants.DNT) {
+        this.checkForDNTPolicy(domain, domainMap.nextUpdateTime);
+      }
     });
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -274,14 +274,9 @@ Badger.prototype = {
   },
 
   /**
-  * Initialize DNT policy subsystem:
-  * * download acceptable hashes from EFF
-  * * set up listener to recheck DNT-respecting domains
+  * Initialize DNT policy subsystem by downloading acceptable hashes from EFF
   */
   initializeDNT: function () {
-    this.recheckDNTPolicyForDomains();
-    setInterval(this.recheckDNTPolicyForDomains.bind(this), utils.oneHour());
-
     this.updateDNTPolicyHashes();
     setInterval(this.updateDNTPolicyHashes.bind(this), utils.oneDay() * 4);
   },
@@ -311,22 +306,6 @@ Badger.prototype = {
         return;
       }
       self.storage.updateDNTHashes(JSON.parse(response));
-    });
-  },
-
-  /**
-  * Loop through DNT-respecting domains, and recheck any that need to be
-  * rechecked for a DNT policy file.
-  */
-  recheckDNTPolicyForDomains: function () {
-    let action_map = this.storage.getBadgerStorageObject('action_map');
-
-    // arrow functions bind "this",
-    // no need to bind it ourselves or enclose it in local var
-    _.each(action_map.getItemClones(), (domainMap, domain) => {
-      if (this.storage.getActionForFqdn(domainMap) == constants.DNT) {
-        this.checkForDNTPolicy(domain, domainMap.nextUpdateTime);
-      }
     });
   },
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -37,7 +37,7 @@ var exports = {
   TRACKING_THRESHOLD: 3,
   MAX_COOKIE_ENTROPY: 12,
 
-  DNT_POLICY_CHECK_INTERVAL: 3000, // three seconds
+  DNT_POLICY_CHECK_INTERVAL: 1000, // one second
 };
 
 return exports;

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -37,7 +37,7 @@ var exports = {
   TRACKING_THRESHOLD: 3,
   MAX_COOKIE_ENTROPY: 12,
 
-  DNT_POLICY_CHECK_INTERVAL: 1000, // one second
+  DNT_POLICY_CHECK_INTERVAL: 3000, // three seconds
 };
 
 return exports;

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -158,7 +158,7 @@ HeuristicBlocker.prototype = {
     }, 10);
 
     // abort if we already made a decision for this FQDN
-    let action = this.storage.getActionForFqdn(fqdn);
+    let action = this.storage.getAction(fqdn);
     if (action != constants.NO_TRACKING && action != constants.ALLOW) {
       return {};
     }
@@ -181,7 +181,7 @@ HeuristicBlocker.prototype = {
    */
   updateTrackerPrevalence: function(tracker_fqdn, page_origin) {
     // abort if we already made a decision for this fqdn
-    let action = this.storage.getActionForFqdn(tracker_fqdn);
+    let action = this.storage.getAction(tracker_fqdn);
     if (action != constants.NO_TRACKING && action != constants.ALLOW) {
       return;
     }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -129,42 +129,46 @@ HeuristicBlocker.prototype = {
    * @param details are those from onBeforeSendHeaders
    * @returns {*}
    */
-  heuristicBlockingAccounting: function(details) {
+  heuristicBlockingAccounting: function (details) {
     // ignore requests that are outside a tabbed window
-    if(details.tabId < 0 || incognito.tabIsIncognito(details.tabId)){
-      return { };
+    if (details.tabId < 0 || incognito.tabIsIncognito(details.tabId)) {
+      return {};
     }
 
-    var fqdn = utils.makeURI(details.url).host;
-    var origin = window.getBaseDomain(fqdn);
+    let fqdn = utils.makeURI(details.url).host,
+      origin = window.getBaseDomain(fqdn);
 
-    // abort if we already made a decision for this fqdn
-    var action = this.storage.getActionForFqdn(fqdn);
-    if(action != constants.NO_TRACKING && action != constants.ALLOW){
-      return { };
+    // abort if we already made a decision for this FQDN
+    let action = this.storage.getActionForFqdn(fqdn);
+    if (action != constants.NO_TRACKING && action != constants.ALLOW) {
+      return {};
     }
 
-    // Save the origin associated with the tab if this is a main window request
-    if(details.type == "main_frame") {
+    // if this is a main window request
+    if (details.type == "main_frame") {
+      // save the origin associated with the tab
       log("Origin: " + origin + "\tURL: " + details.url);
       tabOrigins[details.tabId] = origin;
-      return { };
+      return {};
     }
-    else {
-      var tabOrigin = tabOrigins[details.tabId];
-      // Ignore first-party requests
-      if (!tabOrigin || origin == tabOrigin){
-        return { };
-      }
-      window.setTimeout(function(){
-        badger.checkForDNTPolicy(fqdn, badger.storage.getNextUpdateForDomain(fqdn));
-      }, 10);
-      // if there are no tracking cookies or similar things, ignore
-      if (!this.hasTracking(details, origin)){
-        return { };
-      }
-      this._recordPrevalence(fqdn, origin, tabOrigin);
+
+    let tabOrigin = tabOrigins[details.tabId];
+
+    // ignore first-party requests
+    if (!tabOrigin || origin == tabOrigin) {
+      return {};
     }
+
+    window.setTimeout(function () {
+      badger.checkForDNTPolicy(fqdn, badger.storage.getNextUpdateForDomain(fqdn));
+    }, 10);
+
+    // if there are no tracking cookies or similar things, ignore
+    if (!this.hasTracking(details, origin)) {
+      return {};
+    }
+
+    this._recordPrevalence(fqdn, origin, tabOrigin);
   },
 
   /**

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -138,12 +138,6 @@ HeuristicBlocker.prototype = {
     let fqdn = utils.makeURI(details.url).host,
       origin = window.getBaseDomain(fqdn);
 
-    // abort if we already made a decision for this FQDN
-    let action = this.storage.getActionForFqdn(fqdn);
-    if (action != constants.NO_TRACKING && action != constants.ALLOW) {
-      return {};
-    }
-
     // if this is a main window request
     if (details.type == "main_frame") {
       // save the origin associated with the tab
@@ -162,6 +156,12 @@ HeuristicBlocker.prototype = {
     window.setTimeout(function () {
       badger.checkForDNTPolicy(fqdn, badger.storage.getNextUpdateForDomain(fqdn));
     }, 10);
+
+    // abort if we already made a decision for this FQDN
+    let action = this.storage.getActionForFqdn(fqdn);
+    if (action != constants.NO_TRACKING && action != constants.ALLOW) {
+      return {};
+    }
 
     // if there are no tracking cookies or similar things, ignore
     if (!this.hasTracking(details, origin)) {

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -158,8 +158,6 @@ BadgerPen.prototype = {
         case constants.USER_BLOCK:
         case constants.USER_COOKIE_BLOCK:
           return 5;
-        default:
-          return -1;
       }
     }
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -141,7 +141,6 @@ BadgerPen.prototype = {
     let best_action = constants.NO_TRACKING;
     let subdomains = utils.explodeSubdomains(fqdn);
     let action_map = this.getBadgerStorageObject('action_map');
-    let relevantDomains = [];
 
     function getScore(action) {
       switch (action) {
@@ -164,27 +163,20 @@ BadgerPen.prototype = {
       }
     }
 
-    // First collect the actions for any domains or subdomains of the FQDN
-    // Order from base domain to FQDN
-    for (let i = subdomains.length; i >= 0; i--) {
-      if (action_map.hasItem(subdomains[i])) {
-        relevantDomains.push({
-          map: action_map.getItem(subdomains[i]),
-          domain: subdomains[i]
-        });
-      }
-    }
-
-    // Loop through each subdomain we have a rule for from least to most specific
+    // Loop through each subdomain we have a rule for
+    // from least (base domain) to most (FQDN) specific
     // and keep the one which has the best score.
-    for (let i = 0, count = relevantDomains.length; i < count; i++) {
-      var action = this.getAction(
-        relevantDomains[i].map,
-        // ignore DNT unless it's directly on the FQDN being checked
-        relevantDomains[i].domain != fqdn
-      );
-      if (getScore(action) >= getScore(best_action)) {
-        best_action = action;
+    for (let i = subdomains.length; i >= 0; i--) {
+      let domain = subdomains[i];
+      if (action_map.hasItem(domain)) {
+        let action = this.getAction(
+          action_map.getItem(domain),
+          // ignore DNT unless it's directly on the FQDN being checked
+          domain != fqdn
+        );
+        if (getScore(action) >= getScore(best_action)) {
+          best_action = action;
+        }
       }
     }
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -98,7 +98,7 @@ BadgerPen.prototype = {
    * @param {Object|String} domain domain object from action_map
    * @returns {String} the presumed action for this FQDN
    **/
-  getActionForFqdn: function(domain){
+  getAction: function(domain){
     if (_.isString(domain)) {
       domain = this.getBadgerStorageObject('action_map').getItem(domain) || {};
     }
@@ -139,7 +139,7 @@ BadgerPen.prototype = {
    **/
   getBestAction: function (fqdn) {
     // if FQDN itself has DNT and no user action set, DNT is the best action
-    if (this.getActionForFqdn(fqdn) == constants.DNT) {
+    if (this.getAction(fqdn) == constants.DNT) {
       return constants.DNT;
     }
 
@@ -170,7 +170,7 @@ BadgerPen.prototype = {
     // Loop through each subdomain we have a rule for from least to most specific
     // and keep the one which has the best score.
     for (let i = 0; i < relevantDomains.length; i++) {
-      var action = this.getActionForFqdn(relevantDomains[i]);
+      var action = this.getAction(relevantDomains[i]);
       if (getScore(action) >= getScore(best_action)) {
         best_action = action;
       }
@@ -189,7 +189,7 @@ BadgerPen.prototype = {
     var action_map = this.getBadgerStorageObject('action_map');
     var relevantDomains = [];
     for(var domain in action_map.getItemClones()){
-      if(selector == this.getActionForFqdn(domain)){
+      if(selector == this.getAction(domain)){
         relevantDomains.push(domain);
       }
     }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -138,6 +138,11 @@ BadgerPen.prototype = {
    * @returns {String} the best action for the FQDN
    **/
   getBestAction: function (fqdn) {
+    // if FQDN itself has DNT and no user action set, DNT is the best action
+    if (this.getActionForFqdn(fqdn) == constants.DNT) {
+      return constants.DNT;
+    }
+
     let best_action = constants.NO_TRACKING;
     let subdomains = utils.explodeSubdomains(fqdn);
     let action_map = this.getBadgerStorageObject('action_map');
@@ -145,11 +150,11 @@ BadgerPen.prototype = {
 
     function getScore(action) {
       switch (action) {
+        case constants.DNT: return -1; // never prefer DNT: should not cascade
         case constants.NO_TRACKING: return 0;
         case constants.ALLOW: return 1;
         case constants.BLOCK: return 2;
         case constants.COOKIEBLOCK: return 3;
-        case constants.DNT: return 4;
         default: return 5; // user allow/block/cookieblock
       }
     }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -137,15 +137,25 @@ BadgerPen.prototype = {
    * @param {String} fqdn the FQDN we want to determine the action for
    * @returns {String} the best action for the FQDN
    **/
-  getBestAction: function(fqdn) {
-    var best_action = constants.NO_TRACKING;
-    var subdomains = utils.explodeSubdomains(fqdn);
-    var action_map = this.getBadgerStorageObject('action_map');
-    var relevantDomains = [];
-    var i;
+  getBestAction: function (fqdn) {
+    let best_action = constants.NO_TRACKING;
+    let subdomains = utils.explodeSubdomains(fqdn);
+    let action_map = this.getBadgerStorageObject('action_map');
+    let relevantDomains = [];
 
-    for( i = 0; i < subdomains.length; i++ ){
-      if(action_map.hasItem(subdomains[i])){
+    function getScore(action) {
+      switch (action) {
+        case constants.NO_TRACKING: return 0;
+        case constants.ALLOW: return 1;
+        case constants.BLOCK: return 2;
+        case constants.COOKIEBLOCK: return 3;
+        case constants.DNT: return 4;
+        default: return 5; // user allow/block/cookieblock
+      }
+    }
+
+    for (let i = 0; i < subdomains.length; i++) {
+      if (action_map.hasItem(subdomains[i])) {
         // First collect the actions for any domains or subdomains of the FQDN
         // Order from base domain to FQDN
         relevantDomains.unshift(action_map.getItem(subdomains[i]));
@@ -154,9 +164,9 @@ BadgerPen.prototype = {
 
     // Loop through each subdomain we have a rule for from least to most specific
     // and keep the one which has the best score.
-    for( i = 0; i < relevantDomains.length; i++ ){
+    for (let i = 0; i < relevantDomains.length; i++) {
       var action = this.getActionForFqdn(relevantDomains[i]);
-      if(getScore(action) >= getScore(best_action)){
+      if (getScore(action) >= getScore(best_action)) {
         best_action = action;
       }
     }
@@ -273,18 +283,6 @@ BadgerPen.prototype = {
     if (index > -1) {
       badger.userAllow.splice(index, 1);
     }
-  }
-};
-
-
-var getScore = function(action){
-  switch(action){
-    case constants.NO_TRACKING: return 0;
-    case constants.ALLOW: return 1;
-    case constants.BLOCK: return 2;
-    case constants.COOKIEBLOCK: return 3;
-    case constants.DNT: return 4;
-    default: return 5;
   }
 };
 

--- a/src/tests/index.html
+++ b/src/tests/index.html
@@ -30,14 +30,6 @@
 
     <script src="../lib/jquery-ui/js/jquery-2.2.4.min.js"></script>
 
-    <script src="lib/vendor/qunit-2.2.0.js"></script>
-    <script src="lib/qunit_config.js"></script>
-    <script src="lib/vendor/sinon-2.0.0.js"></script>
-  </head>
-  <body>
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
-
     <script src="../js/bootstrap.js"></script>
     <script src="../data/surrogates.js"></script>
     <script src="../js/surrogates.js"></script>
@@ -56,6 +48,14 @@
     <script src="../js/htmlutils.js"></script>
     <script src="../js/migrations.js"></script>
     <script src="../js/background.js"></script>
+  </head>
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+
+    <script src="lib/vendor/qunit-2.2.0.js"></script>
+    <script src="lib/qunit_config.js"></script>
+    <script src="lib/vendor/sinon-2.0.0.js"></script>
 
     <script src="tests/background.js"></script>
     <script src="tests/baseDomain.js"></script>

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -21,12 +21,6 @@
       utils.xhrRequest(POLICY_URL, function (err, data) {
         dnt_policy_txt = data;
 
-        // disable recheckDNTPolicyForDomains
-        // to prevent it from messing with tests below
-        sinon.stub(badger, "recheckDNTPolicyForDomains");
-        // clear out any domains waiting to be checked
-        badger._checkPrivacyBadgerPolicy.cancel();
-
         // set up fake server to simulate XMLHttpRequests
         server = sinon.fakeServer.create({
           respondImmediately: true
@@ -57,7 +51,6 @@
     after: (/*assert*/) => {
       clock.restore();
       server.restore();
-      badger.recheckDNTPolicyForDomains.restore();
     }
   });
 

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -21,6 +21,12 @@
       utils.xhrRequest(POLICY_URL, function (err, data) {
         dnt_policy_txt = data;
 
+        // disable recheckDNTPolicyForDomains
+        // to prevent it from messing with tests below
+        sinon.stub(badger, "recheckDNTPolicyForDomains");
+        // clear out any domains waiting to be checked
+        badger._checkPrivacyBadgerPolicy.cancel();
+
         // set up fake server to simulate XMLHttpRequests
         server = sinon.fakeServer.create({
           respondImmediately: true
@@ -51,6 +57,7 @@
     after: (/*assert*/) => {
       clock.restore();
       server.restore();
+      badger.recheckDNTPolicyForDomains.restore();
     }
   });
 

--- a/src/tests/tests/heuristic.js
+++ b/src/tests/tests/heuristic.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
 
   let hb = require('heuristicblocking');
 

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -312,7 +312,7 @@
   });
 
   QUnit.test("user actions overrule everything else", (assert) => {
-    storage.setupHeuristicAction(DOMAIN, constants.USER_BLOCK);
+    storage.setupUserAction(DOMAIN, constants.USER_BLOCK);
     storage.setupHeuristicAction(SUBDOMAIN, constants.COOKIEBLOCK);
     storage.setupDNT(SUBSUBDOMAIN);
 
@@ -356,9 +356,9 @@
   // all three user actions are equally important
   // but the one closest to the FQDN being checked should win
   QUnit.test("specificity of rules of equal priority", (assert) => {
-    storage.setupHeuristicAction(DOMAIN, constants.USER_BLOCK);
-    storage.setupHeuristicAction(SUBDOMAIN, constants.USER_ALLOW);
-    storage.setupHeuristicAction(SUBSUBDOMAIN, constants.USER_COOKIE_BLOCK);
+    storage.setupUserAction(DOMAIN, constants.USER_BLOCK);
+    storage.setupUserAction(SUBDOMAIN, constants.USER_ALLOW);
+    storage.setupUserAction(SUBSUBDOMAIN, constants.USER_COOKIE_BLOCK);
 
     // check domain itself
     assert.equal(

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -125,7 +125,7 @@
 
     // check domain itself
     assert.equal(
-      badger.storage.getActionForFqdn(DOMAIN),
+      badger.storage.getAction(DOMAIN),
       constants.BLOCK,
       "domain is marked for blocking directly"
     );
@@ -137,7 +137,7 @@
 
     // check that subdomain inherits blocking
     assert.equal(
-      badger.storage.getActionForFqdn(SUBDOMAIN),
+      badger.storage.getAction(SUBDOMAIN),
       constants.NO_TRACKING,
       "subdomain is not marked for blocking directly"
     );
@@ -153,7 +153,7 @@
 
     // check domain itself
     assert.equal(
-      badger.storage.getActionForFqdn(DOMAIN),
+      badger.storage.getAction(DOMAIN),
       constants.DNT,
       "domain is marked as DNT-respecting directly"
     );
@@ -165,7 +165,7 @@
 
     // check that subdomain does not inherit DNT
     assert.equal(
-      badger.storage.getActionForFqdn(SUBDOMAIN),
+      badger.storage.getAction(SUBDOMAIN),
       constants.NO_TRACKING,
       "subdomain is not marked as DNT-respecting directly"
     );

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -179,7 +179,7 @@
     );
   });
 
-  QUnit.todo("blocking still cascades after domain declares DNT", (assert) => {
+  QUnit.test("blocking still cascades after domain declares DNT", (assert) => {
     storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
     storage.setupDNT(DOMAIN);
 
@@ -263,10 +263,10 @@
     );
   });
 
-  QUnit.todo("user actions overrule everything else", (assert) => {
+  QUnit.test("user actions overrule everything else", (assert) => {
     storage.setupHeuristicAction(DOMAIN, constants.USER_BLOCK);
     storage.setupHeuristicAction(SUBDOMAIN, constants.COOKIEBLOCK);
-    storage.setupHeuristicAction(SUBSUBDOMAIN, constants.DNT);
+    storage.setupDNT(SUBSUBDOMAIN);
 
     // check domain itself
     assert.equal(

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -148,7 +148,7 @@
     );
   });
 
-  QUnit.todo("DNT does not cascade", (assert) => {
+  QUnit.test("DNT does not cascade", (assert) => {
     badger.storage.setupDNT(DOMAIN);
 
     // check domain itself

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -1,5 +1,10 @@
-/* globals badger:false */
-(function() {
+/* globals badger:false, constants:false */
+
+(function () {
+
+  const DOMAIN = "example.com",
+    SUBDOMAIN = "widgets.example.com";
+
   let BACKUP = {};
 
   QUnit.module("Storage", {
@@ -114,4 +119,61 @@
     assert.ok(action_map.getItem('testsite.com').heuristicAction === "block");
   });
 
-})();
+  QUnit.test("blocking cascades", (assert) => {
+    // mark a domain for blocking
+    badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
+
+    // check domain itself
+    assert.equal(
+      badger.storage.getActionForFqdn(DOMAIN),
+      constants.BLOCK,
+      "domain is marked for blocking directly"
+    );
+    assert.equal(
+      badger.storage.getBestAction(DOMAIN),
+      constants.BLOCK,
+      "domain is marked for blocking"
+    );
+
+    // check that subdomain inherits blocking
+    assert.equal(
+      badger.storage.getActionForFqdn(SUBDOMAIN),
+      constants.NO_TRACKING,
+      "subdomain is not marked for blocking directly"
+    );
+    assert.equal(
+      badger.storage.getBestAction(SUBDOMAIN),
+      constants.BLOCK,
+      "subdomain is marked for blocking (via parent domain)"
+    );
+  });
+
+  QUnit.todo("DNT does not cascade", (assert) => {
+    badger.storage.setupDNT(DOMAIN);
+
+    // check domain itself
+    assert.equal(
+      badger.storage.getActionForFqdn(DOMAIN),
+      constants.DNT,
+      "domain is marked as DNT-respecting directly"
+    );
+    assert.equal(
+      badger.storage.getBestAction(DOMAIN),
+      constants.DNT,
+      "domain is marked as DNT-respecting"
+    );
+
+    // check that subdomain does not inherit DNT
+    assert.equal(
+      badger.storage.getActionForFqdn(SUBDOMAIN),
+      constants.NO_TRACKING,
+      "subdomain is not marked as DNT-respecting directly"
+    );
+    assert.equal(
+      badger.storage.getBestAction(SUBDOMAIN),
+      constants.NO_TRACKING,
+      "subdomain is not marked as DNT-respecting (via parent domain)"
+    );
+  });
+
+}());

--- a/tests/selenium/pbtest_org_test.py
+++ b/tests/selenium/pbtest_org_test.py
@@ -63,9 +63,9 @@ class PBTest_Org_test(pbtest.PBSeleniumTest):
         if self.env.get('BROWSER') == 'firefox' and failed_tests == firefox_failures:
             return
 
-        fail_msg = "%d tests failed: %s" % (
+        fail_msg = "%d tests failed:\n  * %s" % (
             len(failed_tests),
-            ", ".join(failed_tests).replace(u'\u2717', 'x'),
+            "\n  * ".join(failed_tests).replace(u'\u2717', 'x'),
         )
         self.assertTrue(len(failed_tests) == 0, msg=fail_msg)
 

--- a/tests/selenium/pbtest_org_test.py
+++ b/tests/selenium/pbtest_org_test.py
@@ -63,7 +63,10 @@ class PBTest_Org_test(pbtest.PBSeleniumTest):
         if self.env.get('BROWSER') == 'firefox' and failed_tests == firefox_failures:
             return
 
-        fail_msg = "%d tests failed: %s" % (len(failed_tests), ", ".join(failed_tests))
+        fail_msg = "%d tests failed: %s" % (
+            len(failed_tests),
+            ", ".join(failed_tests).replace(u'\u2717', 'x'),
+        )
         self.assertTrue(len(failed_tests) == 0, msg=fail_msg)
 
 if __name__ == "__main__":

--- a/tests/selenium/qunit_test.py
+++ b/tests/selenium/qunit_test.py
@@ -15,18 +15,26 @@ class Test(pbtest.PBSeleniumTest):
         # Probably related to Chromium bugs 129181 & 132148
         self.load_url(self.bg_url)
         self.load_url(self.test_url)
+
         try:
             failed = self.txt_by_css("#qunit-testresult-display > span.failed",
                                      timeout=120)
         except TimeoutException as exc:
             self.fail("Cannot find the results of QUnit tests %s" % exc)
+
         passed = self.txt_by_css("#qunit-testresult-display > span.passed")
         total = self.txt_by_css("#qunit-testresult-display > span.total")
         print("QUnits tests: Failed: %s Passed: %s Total: %s" % (failed,
                                                                  passed,
                                                                  total))
-        self.assertEqual("0", failed)
-        # TODO: Report failed QUnit tests
+        failed_test_els = self.driver.find_elements_by_css_selector(
+            ".fail .test-name"
+        )
+        fail_msg = "The following QUnit tests failed:\n  * {}".format(
+            "\n  * ".join([el.text for el in failed_test_els])
+        )
+
+        self.assertTrue(failed == "0", msg=fail_msg)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/selenium/qunit_test.py
+++ b/tests/selenium/qunit_test.py
@@ -17,16 +17,17 @@ class Test(pbtest.PBSeleniumTest):
         self.load_url(self.test_url)
 
         try:
-            failed = self.txt_by_css("#qunit-testresult-display > span.failed",
-                                     timeout=120)
+            # this text appears when tests finish running
+            _ = self.txt_by_css(
+                "#qunit-testresult-display > span.total",
+                timeout=120
+            )
         except TimeoutException as exc:
             self.fail("Cannot find the results of QUnit tests %s" % exc)
 
-        passed = self.txt_by_css("#qunit-testresult-display > span.passed")
-        total = self.txt_by_css("#qunit-testresult-display > span.total")
-        print("QUnits tests: Failed: %s Passed: %s Total: %s" % (failed,
-                                                                 passed,
-                                                                 total))
+        print("QUnit summary:")
+        print(self.txt_by_css("#qunit-testresult-display"))
+
         failed_test_els = self.driver.find_elements_by_css_selector(
             ".fail .test-name"
         )
@@ -34,7 +35,7 @@ class Test(pbtest.PBSeleniumTest):
             "\n  * ".join([el.text for el in failed_test_els])
         )
 
-        self.assertTrue(failed == "0", msg=fail_msg)
+        self.assertTrue(len(failed_test_els) == 0, msg=fail_msg)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Should fix #1303.

~~Hourly scheduled Do Not Track policy re-checking still happens, but only for domains that declared DNT compliance.~~ Checking ~~of all other third-party domains~~ is handled as you surf, via `heuristicBlockingAccounting`.

~~We need periodic DNT checking for DNT domains because DNT cascades from domains to their subdomains (when Badger decides what to block), but those second-level/higher-level domains aren't guaranteed to show up on the page in order to get re-checked.~~

~~DNT checks are now spaced at least three seconds apart (up from one second).~~

Still want to follow up on why a bunch of XHRs result in major CPU usage in Firefox (they're fine in Chrome), and why Firefox profiling tools don't seem to capture this CPU usage.