### PR TITLE
Make `storage.action_map.heuristicAction` default to `constants.NO_TRACKING`

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -145,6 +145,7 @@ BadgerPen.prototype = {
     function getScore(action) {
       switch (action) {
         case constants.NO_TRACKING:
+        case "":
           return 0;
         case constants.ALLOW:
           return 1;
@@ -301,7 +302,7 @@ var _newActionMapObject = function() {
   return {
     userAction: "",
     dnt: false,
-    heuristicAction: "",
+    heuristicAction: constants.NO_TRACKING,
     nextUpdateTime: 0
   };
 };


### PR DESCRIPTION
I came across this while messing with my crawler. New domains in the `action_map` were being given a `heuristicAction` value of `""`

example:
```
    "action_map": {
        "0.ecom.attccc.com": {
            "dnt": false,
            "heuristicAction": "",
            "nextUpdateTime": 1492243392128,
            "userAction": ""
        },
        "0.gravatar.com": {
            "dnt": false,
            "heuristicAction": "",
            "nextUpdateTime": 1492169461562,
            "userAction": ""
        },
...
```
I followed this through the code to look for potential bugs and consequences. [Here](https://github.com/EFForg/privacybadger/blob/master/src/js/storage.js#L145-L162) we have a switch statement which has no case for `""`, so it returns `undefined`. Then later we do some comparisons against this  `undefined`. In Javascript undefined isn't really orderable, and both `undefined >= 1` and `1 >= undefined` equal `false`. The value we'd expect instead of `undefined` is `0` so we have the potential to get comparisons wrong like `constants.ANYTHING >= constants.NO_TRACKING`.

Surprisingly the code we have [here](https://github.com/EFForg/privacybadger/blob/master/src/js/storage.js#L167-L177) behaves as expected, but this is an accident. I didn't find any other side effects. 

This should be backwards compatible with existing user data, so a migration isn't strictly necessary. But it might be wise do it anyway if we think the `""` values are causing bugs.