### PR TITLE
Prevent DNT checking from setting cookies

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -230,15 +230,12 @@ function onHeadersReceived(details) {
     return {};
   }
 
-
   var requestAction = checkAction(tab_id, url, false, details.frameId);
   if (requestAction) {
     if (requestAction == constants.COOKIEBLOCK || requestAction == constants.USER_COOKIE_BLOCK) {
       var newHeaders = details.responseHeaders.filter(function(header) {
         return (header.name.toLowerCase() != "set-cookie");
       });
-      newHeaders.push({name:'x-marks-the-spot', value:'foo'});
-      //TODO don't return this unless we modified headers
       return {responseHeaders: newHeaders};
     }
   }

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -42,11 +42,13 @@ https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
 
         # directly visit a DNT policy URL known to set cookies
         self.load_url(TEST_URL + ".well-known/dnt-policy.txt")
+        self.assertEqual(len(self.driver.get_cookies()), 1,
+            "DNT policy URL set a cookie")
 
         # verify we got a cookie
         self.load_url(TEST_URL)
         self.assertEqual(len(self.driver.get_cookies()), 1,
-            "DNT policy URL set a cookie")
+            "We still have just one cookie")
 
         # clear cookies and verify
         self.driver.delete_all_cookies()

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -22,9 +22,8 @@ THIRD_PARTY_TRACKER = "eff-tracker-test.s3-website-us-west-2.amazonaws.com"
 class CookieTest(pbtest.PBSeleniumTest):
     """Basic test to make sure the PB doesn't mess up with the cookies."""
 
-    def XXX_test_dnt_check_should_not_set_cookies(self):
-        # TODO update to EFF URL
-        TEST_DOMAIN = "localhost"
+    def test_dnt_check_should_not_set_cookies(self):
+        TEST_DOMAIN = "dnt-test.trackersimulator.org"
         TEST_URL = "https://{}/".format(TEST_DOMAIN)
 
         RUN_DNT_JS = """badger.checkForDNTPolicy(

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-import unittest
+import os
 import pbtest
 import time
+import unittest
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
@@ -22,6 +23,9 @@ THIRD_PARTY_TRACKER = "eff-tracker-test.s3-website-us-west-2.amazonaws.com"
 class CookieTest(pbtest.PBSeleniumTest):
     """Basic test to make sure the PB doesn't mess up with the cookies."""
 
+    @unittest.skipIf(os.environ.get('BROWSER') == 'firefox', """
+Disabled until Firefox fixes bug:
+https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
     def test_dnt_check_should_not_set_cookies(self):
         TEST_DOMAIN = "dnt-test.trackersimulator.org"
         TEST_URL = "https://{}/".format(TEST_DOMAIN)

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-import os
 import unittest
 
 from selenium.webdriver.common.action_chains import ActionChains

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -181,6 +181,14 @@ class PBSeleniumTest(unittest.TestCase):
         return WebDriverWait(self.driver, timeout).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, css_selector)))
 
+    def wait_for_script(self, script, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
+        """Variant of self.js that executes script continuously until it
+        returns True."""
+        return WebDriverWait(self.driver, timeout).until(
+            lambda driver: driver.execute_script(script),
+            "Timed out waiting for execute_script to eval to True"
+        )
+
     @property
     def bg_url(self):
         return self.base_url + "_generated_background_page.html"


### PR DESCRIPTION
Fixes #1330.
- [x] Write test
- [x] Write fix
- [x] Get test URLs running
- [x] Document test URL logic
- [x] Enable test, verify test fails
- [x] Commit fix, verify test passes. Update: test passes in Chrome, fails in Firefox.
- [x] Confirm Firefox bug, disable test in Firefox, open ticket to track Firefox bug
- [x] Note [Channel ID](https://github.com/EFForg/privacybadger/issues/1135) connection