### PR TITLE
Remove Selenium bindings downgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 before_script:
-  - npm install # install JS dependencies (eslint) from package.json
+  - travis_retry npm install # install JS dependencies (eslint) from package.json
   - . ./scripts/setup_travis.sh
   - cd tests
 script: ./run_selenium_tests.sh

--- a/tests/sel_requirements.txt
+++ b/tests/sel_requirements.txt
@@ -1,3 +1,3 @@
-selenium<3.4.0
+selenium
 xvfbwrapper 
 pytest

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -92,6 +92,9 @@ def firefox_manager():
     proc = subprocess.Popen(cmd)
     time.sleep(2)
     ffcaps = DesiredCapabilities.FIREFOX
+    # workaround for our wacky selenium/web-ext/geckodriver setup
+    # https://github.com/SeleniumHQ/selenium/issues/3915#issuecomment-297530793
+    ffcaps.pop('marionette', None)
     try:
         url = get_base_url()
 


### PR DESCRIPTION
Following up on https://github.com/EFForg/privacybadger/pull/1343.

We need to remove `marionette` from the list of Firefox capabilities to use latest Selenium bindings (3.4.0).

More info in https://github.com/SeleniumHQ/selenium/issues/3915.