### PR TITLE
Refactor cookie parsing

### DIFF
--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -506,17 +506,11 @@ var hasCookieTracking = function(details, origin) {
   if (!cookies) {
     return false;
   }
-  cookies = cookies.split(";");
-  var hasCookies = false;
+  cookies = utils.parseCookies(cookies);
   var estimatedEntropy = 0;
   for (var i = 0; i < cookies.length; i++) {
-    // TODO urgh I can't believe we're parsing cookies.  Probably wrong
-    // what if the value has spaces in it?
-    hasCookies = true;
-    var c = cookies[i].trim();
-    var cut = c.indexOf("=");
-    //var name = c.slice(0,cut);
-    var value = c.slice(cut+1);
+    //var name = cookies[i].name;
+    var value = cookies[i].value;
     var lvalue = value.toLowerCase();
     if (!(lvalue in lowEntropyCookieValues)) {
       return true;
@@ -525,10 +519,10 @@ var hasCookieTracking = function(details, origin) {
       estimatedEntropy += lowEntropyCookieValues[lvalue];
     }
   }
-  if (hasCookies) {
+  if (cookies.length) {
     log("All cookies for " + origin + " deemed low entropy...");
     for (var n = 0; n < cookies.length; n++) {
-      log("    " + cookies[n]);
+      log("    " + cookies[n].name + "=" + cookies[n].value);
     }
     if (estimatedEntropy > constants.MAX_COOKIE_ENTROPY) {
       log("But total estimated entropy is " + estimatedEntropy + " bits, so blocking");

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -503,6 +503,11 @@ function hasCookieTracking(details, origin) {
         continue;
       }
 
+      // ignore CloudFlare
+      if (name == "__cfduid") {
+        continue;
+      }
+
       let value = cookie[name].toLowerCase();
 
       if (!(value in lowEntropyCookieValues)) {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -495,7 +495,10 @@ function hasCookieTracking(details, origin) {
 
   // loop over every cookie
   for (let i = 0; i < cookies.length; i++) {
-    let cookie = utils.parseCookie(cookies[i], { skipAttributes: true });
+    let cookie = utils.parseCookie(cookies[i], {
+      skipAttributes: true,
+      skipNonValues: true
+    });
 
     // loop over every name/value pair in every cookie
     for (let name in cookie) {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -496,6 +496,7 @@ function hasCookieTracking(details, origin) {
   // loop over every cookie
   for (let i = 0; i < cookies.length; i++) {
     let cookie = utils.parseCookie(cookies[i], {
+      noDecode: true,
       skipAttributes: true,
       skipNonValues: true
     });

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -503,29 +503,20 @@ function hasCookieTracking(details, origin) {
         continue;
       }
 
-      let value = cookie[name];
+      let value = cookie[name].toLowerCase();
 
-      let lvalue = value.toLowerCase();
-
-      if (!(lvalue in lowEntropyCookieValues)) {
+      if (!(value in lowEntropyCookieValues)) {
         return true;
       }
 
-      estimatedEntropy += lowEntropyCookieValues[lvalue];
+      estimatedEntropy += lowEntropyCookieValues[value];
     }
   }
 
-  if (cookies.length) {
-    log("All cookies for " + origin + " deemed low entropy...");
-    for (let i = 0; i < cookies.length; i++) {
-      log("    " + cookies[i]);
-    }
-    if (estimatedEntropy > constants.MAX_COOKIE_ENTROPY) {
-      log("But total estimated entropy is " + estimatedEntropy + " bits, so blocking");
-      return true;
-    }
-  } else {
-    log(origin, "has no cookies!");
+  log("All cookies for " + origin + " deemed low entropy...");
+  if (estimatedEntropy > constants.MAX_COOKIE_ENTROPY) {
+    log("But total estimated entropy is " + estimatedEntropy + " bits, so blocking");
+    return true;
   }
 
   return false;

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -495,7 +495,7 @@ function hasCookieTracking(details, origin) {
 
   // loop over every cookie
   for (let i = 0; i < cookies.length; i++) {
-    let cookie = utils.parseCookie(cookies[i]);
+    let cookie = utils.parseCookie(cookies[i], { skipAttributes: true });
 
     // loop over every name/value pair in every cookie
     for (let name in cookie) {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -460,11 +460,11 @@ var lowEntropyCookieValues = {
  * @param details Details for onBeforeSendHeaders
  * @returns {*} False or a string combining all Cookies
  */
-var extractCookieString = function(details) {
+function _extractCookieString(details) {
   // @details are those from onBeforeSendHeaders
   // The RFC allows cookies to be separated by ; or , (!!@$#!) but chrome uses ;
-  var cookies = "";
-  var headers;
+  let cookies = "";
+  let headers;
 
   if(details.requestHeaders) {
     headers = details.requestHeaders;
@@ -477,8 +477,8 @@ var extractCookieString = function(details) {
   }
 
 
-  for (var i = 0; i < headers.length; i++) {
-    var header = headers[i];
+  for (let i = 0; i < headers.length; i++) {
+    let header = headers[i];
     if (header.name.toLowerCase() == "cookie" || header.name.toLowerCase() == "set-cookie" ) {
       if (!cookies) {
         cookies = header.value;
@@ -490,7 +490,7 @@ var extractCookieString = function(details) {
   }
 
   return cookies;
-};
+}
 
 /**
  * Check if page is doing cookie tracking. Doing this by estimating the entropy of the cookies
@@ -499,29 +499,30 @@ var extractCookieString = function(details) {
  * @param {String} origin URL
  * @returns {boolean} true if it has cookie tracking
  */
-var hasCookieTracking = function(details, origin) {
+function hasCookieTracking(details, origin) {
   // @details are those from onBeforeSendHeaders
 
-  var cookies = extractCookieString(details);
+  let cookies = _extractCookieString(details);
   if (!cookies) {
     return false;
   }
   cookies = utils.parseCookies(cookies);
-  var estimatedEntropy = 0;
-  for (var i = 0; i < cookies.length; i++) {
-    //var name = cookies[i].name;
-    var value = cookies[i].value;
-    var lvalue = value.toLowerCase();
+  let estimatedEntropy = 0;
+  for (let i = 0; i < cookies.length; i++) {
+    //let name = cookies[i].name;
+    let value = cookies[i].value;
+
+    let lvalue = value.toLowerCase();
+
     if (!(lvalue in lowEntropyCookieValues)) {
       return true;
     }
-    if(lvalue in lowEntropyCookieValues){
-      estimatedEntropy += lowEntropyCookieValues[lvalue];
-    }
+
+    estimatedEntropy += lowEntropyCookieValues[lvalue];
   }
   if (cookies.length) {
     log("All cookies for " + origin + " deemed low entropy...");
-    for (var n = 0; n < cookies.length; n++) {
+    for (let n = 0; n < cookies.length; n++) {
       log("    " + cookies[n].name + "=" + cookies[n].value);
     }
     if (estimatedEntropy > constants.MAX_COOKIE_ENTROPY) {
@@ -531,8 +532,9 @@ var hasCookieTracking = function(details, origin) {
   } else {
     log(origin, "has no cookies!");
   }
+
   return false;
-};
+}
 
 function startListeners() {
   /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -244,17 +244,17 @@ function sha1(input, callback) {
 }
 
 function parseCookies(str) {
-  var parsed = [];
+  let parsed = [];
 
-  var cookies = str.split(";");
+  let cookies = str.split(";");
 
-  for (var i = 0; i < cookies.length; i++) {
+  for (let i = 0; i < cookies.length; i++) {
     // TODO urgh I can't believe we're parsing cookies.  Probably wrong
     // what if the value has spaces in it?
-    var c = cookies[i].trim();
-    var cut = c.indexOf("=");
-    var name = c.slice(0, cut);
-    var value = c.slice(cut + 1);
+    let c = cookies[i].trim();
+    let cut = c.indexOf("=");
+    let name = c.slice(0, cut);
+    let value = c.slice(cut + 1);
     parsed.push({
       name: name,
       value: value

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -250,6 +250,15 @@ function parseCookie(str, opts) {
 
   opts = opts || {};
 
+  let COOKIE_ATTRIBUTES = [
+    "domain",
+    "expires",
+    "httponly",
+    "max-age",
+    "path",
+    "secure",
+  ];
+
   let parsed = {},
     cookies = str.replace(/\n/g, ";").split(";");
 
@@ -268,6 +277,11 @@ function parseCookie(str, opts) {
       }
       name = cookie.trim();
       value = "";
+    }
+
+    if (opts.skipAttributes &&
+        COOKIE_ATTRIBUTES.indexOf(name.toLowerCase()) != -1) {
+      continue;
     }
 
     if (value[0] == '"') {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -243,6 +243,27 @@ function sha1(input, callback) {
   });
 }
 
+function parseCookies(str) {
+  var parsed = [];
+
+  var cookies = str.split(";");
+
+  for (var i = 0; i < cookies.length; i++) {
+    // TODO urgh I can't believe we're parsing cookies.  Probably wrong
+    // what if the value has spaces in it?
+    var c = cookies[i].trim();
+    var cut = c.indexOf("=");
+    var name = c.slice(0, cut);
+    var value = c.slice(cut + 1);
+    parsed.push({
+      name: name,
+      value: value
+    });
+  }
+
+  return parsed;
+}
+
 /************************************** exports */
 var exports = {};
 
@@ -256,6 +277,7 @@ exports.oneDay = oneDay;
 exports.oneHour = oneHour;
 exports.oneMinute = oneMinute;
 exports.oneSecond = oneSecond;
+exports.parseCookies = parseCookies;
 exports.rateLimit = rateLimit;
 exports.removeElementFromArray = removeElementFromArray;
 exports.sha1 = sha1;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -263,7 +263,7 @@ function parseCookie(str, opts) {
     cookies = str.replace(/\n/g, ";").split(";");
 
   for (let i = 0; i < cookies.length; i++) {
-    let cookie = cookies[i].trim(),
+    let cookie = cookies[i],
       name,
       value,
       cut = cookie.indexOf("=");

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -22,56 +22,6 @@
 
 require.scopes.utils = (function() {
   
-
-function Utils() {
-}
-
-Utils.prototype = {
-  systemPrincipal: null,
-  getString: function(id)
-  {
-    return id;
-  },
-  runAsync: function(callback, thisPtr)
-  {
-    var params = Array.prototype.slice.call(arguments, 2);
-    window.setTimeout(function()
-    {
-      callback.apply(thisPtr, params);
-    }, 0);
-  },
-  get appLocale()
-  {
-    var locale = chrome.i18n.getMessage("@@ui_locale").replace(/_/g, "-");
-    this.__defineGetter__("appLocale", function() {return locale;});
-    return this.appLocale;
-  },
-
-  checkLocalePrefixMatch: function(prefixes)
-  {
-    if (!prefixes){
-      return null;
-    }
-
-    var list = prefixes.split(",");
-    for (var i = 0; i < list.length; i++) {
-      if (new RegExp("^" + list[i] + "\\b").test(this.appLocale)) {
-        return list[i];
-      }
-    }
-
-    return null;
-  },
-
-  /**
-  * Shortcut for document.getElementById(id)
-  */
-  E: function(id) {
-    return document.getElementById(id);
-  }
-
-};
-
 /**
 * Generic interface to make an XHR request
 *
@@ -309,7 +259,6 @@ exports.oneSecond = oneSecond;
 exports.rateLimit = rateLimit;
 exports.removeElementFromArray = removeElementFromArray;
 exports.sha1 = sha1;
-exports.Utils = Utils;
 exports.xhrRequest = xhrRequest;
 
 return exports;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -243,8 +243,8 @@ function sha1(input, callback) {
   });
 }
 
-function parseCookies(str) {
-  let parsed = [];
+function parseCookie(str) {
+  let parsed = {};
 
   let cookies = str.split(";");
 
@@ -255,10 +255,8 @@ function parseCookies(str) {
     let cut = c.indexOf("=");
     let name = c.slice(0, cut);
     let value = c.slice(cut + 1);
-    parsed.push({
-      name: name,
-      value: value
-    });
+
+    parsed[name] = value;
   }
 
   return parsed;
@@ -277,7 +275,7 @@ exports.oneDay = oneDay;
 exports.oneHour = oneHour;
 exports.oneMinute = oneMinute;
 exports.oneSecond = oneSecond;
-exports.parseCookies = parseCookies;
+exports.parseCookie = parseCookie;
 exports.rateLimit = rateLimit;
 exports.removeElementFromArray = removeElementFromArray;
 exports.sha1 = sha1;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -292,22 +292,24 @@ function parseCookie(str, opts) {
       continue;
     }
 
-    let decode = opts.decode || decodeURIComponent;
-    try {
-      name = decode(name);
-    } catch (e) {
-      // invalid URL encoding probably (URIError: URI malformed)
-      if (opts.skipInvalid) {
-        continue;
-      }
-    }
-    if (value) {
+    if (!opts.noDecode) {
+      let decode = opts.decode || decodeURIComponent;
       try {
-        value = decode(value);
+        name = decode(name);
       } catch (e) {
-        // ditto
+        // invalid URL encoding probably (URIError: URI malformed)
         if (opts.skipInvalid) {
           continue;
+        }
+      }
+      if (value) {
+        try {
+          value = decode(value);
+        } catch (e) {
+          // ditto
+          if (opts.skipInvalid) {
+            continue;
+          }
         }
       }
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -268,9 +268,17 @@ function parseCookie(str, opts) {
       value,
       cut = cookie.indexOf("=");
 
+    // it's a key=value pair
     if (cut != -1) {
       name = cookie.slice(0, cut).trim();
       value = cookie.slice(cut + 1).trim();
+
+      // handle value quoting
+      if (value[0] == '"') {
+        value = value.slice(1, -1);
+      }
+
+    // not a key=value pair
     } else {
       if (opts.skipNonValues) {
         continue;
@@ -284,10 +292,6 @@ function parseCookie(str, opts) {
       continue;
     }
 
-    if (value[0] == '"') {
-      value = value.slice(1, -1);
-    }
-
     let decode = opts.decode || decodeURIComponent;
     try {
       name = decode(name);
@@ -297,12 +301,14 @@ function parseCookie(str, opts) {
         continue;
       }
     }
-    try {
-      value = decode(value);
-    } catch (e) {
-      // ditto
-      if (opts.skipInvalid) {
-        continue;
+    if (value) {
+      try {
+        value = decode(value);
+      } catch (e) {
+        // ditto
+        if (opts.skipInvalid) {
+          continue;
+        }
       }
     }
 

--- a/src/tests/tests/heuristic.js
+++ b/src/tests/tests/heuristic.js
@@ -104,9 +104,18 @@
     // set it to a low-entropy value
     details.requestHeaders[CHROME_COOKIE_INDEX] = {
       name: "Cookie",
-      value: "ab"
+      value: "key=ab"
     };
     assert.notOk(hb.hasCookieTracking(details), "Low-entropy cookie header");
+
+    // check when individual entropy is low but overall entropy is over threshold
+    // add another low entropy cookie
+    details.requestHeaders.push({
+      name: "Cookie",
+      value: "key=ab"
+    });
+    assert.ok(hb.hasCookieTracking(details),
+      "Two low-entropy cookies combine to cross tracking threshold");
   });
 
   QUnit.test("HTTP header names are case-insensitive", (assert) => {

--- a/src/tests/tests/heuristic.js
+++ b/src/tests/tests/heuristic.js
@@ -33,6 +33,9 @@
     type: "script",
     url: "http://eff-tracker-test.s3-website-us-west-2.amazonaws.com/third-party.js"
   };
+  const CHROME_COOKIE_INDEX = chromeDetails.requestHeaders.findIndex(
+    i => i.name == "Cookie"
+  );
 
   let firefoxDetails = {
     requestId: "13",
@@ -89,10 +92,9 @@
 
   QUnit.test("HTTP cookie tracking detection", (assert) => {
     let details = JSON.parse(JSON.stringify(chromeDetails));
-    const COOKIE_INDEX = 5;
 
     // remove cookie header
-    let cookieHeader = details.requestHeaders.splice(COOKIE_INDEX, 1);
+    let cookieHeader = details.requestHeaders.splice(CHROME_COOKIE_INDEX, 1);
     assert.notOk(hb.hasCookieTracking(details), "No cookie header");
 
     // restore it
@@ -100,7 +102,7 @@
     assert.ok(hb.hasCookieTracking(details), "High-entropy cookie header");
 
     // set it to a low-entropy value
-    details.requestHeaders[COOKIE_INDEX] = {
+    details.requestHeaders[CHROME_COOKIE_INDEX] = {
       name: "Cookie",
       value: "ab"
     };
@@ -116,6 +118,25 @@
       hb.hasCookieTracking(firefoxDetails),
       "Cookie tracking detected with lowercase (Firefox) headers"
     );
+  });
+
+  QUnit.test("Cookie attributes shouldn't add to entropy", (assert) => {
+    let ATTR_COOKIES = [
+      'test-cookie=true; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Path=/; Domain=.parrable.com',
+      '__usd_latimes.com=; expires=Wed, 03-May-2017 01:20:20 GMT; domain=.go.sonobi.com; path=/',
+      'ses55=; Domain=.rubiconproject.com; Path=/; Expires=Wed, 03-May-2017 11:59:59 GMT; Max-Age=38407',
+      'vf=5;Version=1;Comment=;Domain=.contextweb.com;Path=/;Max-Age=9583',
+      'PUBMDCID=2; domain=pubmatic.com; expires=Tue, 01-Aug-2017 01:20:21 GMT; path=/',
+      'tc=; path=/; Max-Age=31536000; expires=Thu, 03 May 2018 01:20:21 GMT',
+      'uid=; path=/; expires=Wed, 03 May 2017 01:20:31 GMT; domain=medium.com; secure; httponly',
+    ];
+
+    let details = JSON.parse(JSON.stringify(chromeDetails));
+    for (let i = 0; i < ATTR_COOKIES.length; i++) {
+      details.requestHeaders[CHROME_COOKIE_INDEX].value = ATTR_COOKIES[i];
+      assert.notOk(hb.hasCookieTracking(details),
+        "cookie attributes test #" + i);
+    }
   });
 
 }());

--- a/src/tests/tests/heuristic.js
+++ b/src/tests/tests/heuristic.js
@@ -139,4 +139,19 @@
     }
   });
 
+  QUnit.test("CloudFlare cookies should get ignored", (assert) => {
+    let CLOUDFLARE_COOKIES = [
+      '__cfduid=d3c728f97e01b1ab6969828f24b42ab111493693758',
+      '__cfduid=d9758e8613dd4acbba3248dde15e74f8d1493774432; expires=Thu, 03-May-18 01:20:32 GMT; path=/; domain=.medium.com; HttpOnly',
+      '__cfduid=de8a1734f91060dba20e2833705018b911493771353; expires=Thu, 03-May-18 02:25:53 GMT; path=/; domain=.fightforthefuture.org; HttpOnly',
+    ];
+
+    let details = JSON.parse(JSON.stringify(chromeDetails));
+    for (let i = 0; i < CLOUDFLARE_COOKIES.length; i++) {
+      details.requestHeaders[CHROME_COOKIE_INDEX].value = CLOUDFLARE_COOKIES[i];
+      assert.notOk(hb.hasCookieTracking(details),
+        "CloudFlare cookie test #" + i);
+    }
+  });
+
 }());

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -327,7 +327,7 @@
 
         let actual = utils.parseCookie(
           cookieString, {
-            decode: _.identity,
+            noDecode: true,
             skipAttributes: true,
             skipNonValues: true
           }

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -317,9 +317,6 @@
       "1ASIE": "T"
     };
 
-    // TODO move COOKIE_ATTRIBUTES to constants
-    let COOKIE_ATTRIBUTES = ["expires", "max-age", "domain", "path", "secure", "httponly"];
-
     // compare actual to expected
     let test_number = 0;
     for (let cookieString in COOKIES) {
@@ -331,20 +328,9 @@
         let actual = utils.parseCookie(
           cookieString, {
             decode: _.identity,
+            skipAttributes: true,
             skipNonValues: true
           }
-        );
-        // strip cookie attributes to match legacy Firefox implementation
-        // https://github.com/EFForg/privacybadgerfirefox-legacy/blob/00d88bbf42649d31bba181b49a7886c8381682ae/lib/cookieUtils.js#L93-L98
-        actual = _.reduce(
-          actual,
-          (memo, val, key) => {
-            if (COOKIE_ATTRIBUTES.indexOf(key.toLowerCase()) == -1) {
-              memo[key] = val;
-            }
-            return memo;
-          },
-          {}
         );
 
         assert.deepEqual(actual, expected, "cookie test #" + test_number);

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -34,25 +34,28 @@
     assert.ok(subs[3] == 'eff.org');
   });
 
-  QUnit.test("send xhrRequest", function (assert) {
-    let done = assert.async();
-    assert.expect(3);
-    utils.xhrRequest("https://www.eff.org/files/badgertest.txt", function(err,resp){
-      assert.ok(true, "xhr calls callback");
-      assert.ok(err === null, "there was no error");
-      assert.ok(resp === "test passed\n", "got response text");
-      done();
+  QUnit.test("xhrRequest", function (assert) {
+    // set up fake server to simulate XMLHttpRequests
+    let server = sinon.fakeServer.create({
+      respondImmediately: true
     });
-  });
+    server.respondWith("GET", "https://www.eff.org/files/badgertest.txt",
+      [200, {}, "test passed\n"]);
 
-  QUnit.test("send faling xhrRequest", function (assert) {
     let done = assert.async();
-    assert.expect(3);
-    utils.xhrRequest("https://www.eff.org/nonexistent-page", function(err/*,resp*/){
-      assert.ok(true, "xhr calls callback");
-      assert.ok(err, "there was an error");
-      assert.ok(err.status === 404, "error was 404");
-      done();
+    assert.expect(4);
+
+    utils.xhrRequest("https://www.eff.org/files/badgertest.txt", function (err1, resp) {
+      assert.strictEqual(err1, null, "there was no error");
+      assert.equal(resp, "test passed\n", "got expected response text");
+
+      utils.xhrRequest("https://www.eff.org/nonexistent-page", function(err2/*, resp*/) {
+        assert.ok(err2, "there was an error");
+        assert.equal(err2.status, 404, "error was 404");
+
+        server.restore();
+        done();
+      });
     });
   });
 

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -1,6 +1,7 @@
 /* globals badger:false */
 
 (function() {
+
   QUnit.module("Utils");
 
   var utils = require('utils');
@@ -176,4 +177,256 @@
 
     clock.restore();
   });
+
+  // the following cookie parsing tests are derived from
+  // https://github.com/jshttp/cookie/blob/81bd3c77db6a8dcb23567de94b3beaef6c03e97a/test/parse.js
+  QUnit.test("cookie parsing", function (assert) {
+
+    assert.deepEqual(utils.parseCookie('foo=bar'), { foo: 'bar' },
+      "simple cookie");
+
+    assert.deepEqual(
+      utils.parseCookie('foo=bar;bar=123'),
+      {
+        foo: 'bar',
+        bar: '123'
+      },
+      "simple cookie with two values"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('FOO    = bar;   baz  =   raz'),
+      {
+        FOO: 'bar',
+        baz: 'raz'
+      },
+      "ignore spaces"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('foo="bar=123456789&name=Magic+Mouse"'),
+      { foo: 'bar=123456789&name=Magic+Mouse' },
+      "escaped value"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('email=%20%22%2c%3b%2f'),
+      { email: ' ",;/' },
+      "encoded value"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('foo=%1;bar=bar'),
+      {
+        foo: '%1',
+        bar: 'bar'
+      },
+      "ignore escaping error and return original value"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('foo=%1;bar=bar;HttpOnly;Secure', { skipNonValues: true }),
+      {
+        foo: '%1',
+        bar: 'bar'
+      },
+      "ignore non values"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('priority=true; expires=Wed, 29 Jan 2014 17:43:25 GMT; Path=/'),
+      {
+        priority: 'true',
+        expires: 'Wed, 29 Jan 2014 17:43:25 GMT',
+        Path: '/'
+      },
+      "dates"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('foo=%1;bar=bar;foo=boo', { noOverwrite: true}),
+      {
+        foo: '%1',
+        bar: 'bar'
+      },
+      "duplicate names #1"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('foo=false;bar=bar;foo=true', { noOverwrite: true}),
+      {
+        foo: 'false',
+        bar: 'bar'
+      },
+      "duplicate names #2"
+    );
+
+    assert.deepEqual(
+      utils.parseCookie('foo=;bar=bar;foo=boo', { noOverwrite: true}),
+      {
+        foo: '',
+        bar: 'bar'
+      },
+      "duplicate names #3"
+    );
+
+  });
+
+  QUnit.test("cookie parsing (legacy Firefox add-on)", function (assert) {
+    // raw cookies (input)
+    let optimizelyCookie = 'optimizelyEndUserId=oeu1394241144653r0.538161732205'+
+      '5392; optimizelySegments=%7B%22237061344%22%3A%22none%22%2C%22237321400%'+
+      '22%3A%22ff%22%2C%22237335298%22%3A%22search%22%2C%22237485170%22%3A%22fa'+
+      'lse%22%7D; optimizelyBuckets=%7B%7D';
+    let googleCookie = 'PREF=ID=d93d4e842d10e12a:U=3838eaea5cd40d37:FF=0:TM=139'+
+      '4232126:LM=1394235924:S=rKP367ac3aAdDzAS; NID=67=VwhHOGQunRmNsm9WwJyK571'+
+      'OGqb3RtvUmH987K5DXFgKFAxFwafA_5VPF5_bsjhrCoM0BjyQdxyL2b-qs9b-fmYCQ_1Uqjt'+
+      'qTeidAJBnc2ecjewJia6saHrcJ6yOVVgv';
+    let hackpadCookie = 'acctIds=%5B%22mIqZhIPMu7j%22%2C%221394477194%22%2C%22u'+
+      'T/ayZECO0g/+hHtQnjrdEZivWA%3D%22%5D; expires=Wed, 01-Jan-3000 08:00:01 G'+
+      'MT; domain=.hackpad.com; path=/; secure; httponly\nacctIds=%5B%22mIqZhIP'+
+      'Mu7j%22%2C%221394477194%22%2C%22uT/ayZECO0g/+hHtQnjrdEZivWA%3D%22%5D; ex'+
+      'pires=Wed, 01-Jan-3000 08:00:00 GMT; domain=.hackpad.com; path=/; secure'+
+      '; httponly\n1ASIE=T; expires=Wed, 01-Jan-3000 08:00:00 GMT; domain=hackp'+
+      'ad.com; path=/\nPUAS3=3186efa7f8bca99c; expires=Wed, 01-Jan-3000 08:00:0'+
+      '0 GMT; path=/; secure; httponly';
+    let emptyCookie = '';
+    let testCookie = ' notacookiestring; abc=123 ';
+
+    // parsed cookies (expected output)
+    let COOKIES = {};
+    COOKIES[optimizelyCookie] = {
+      'optimizelyEndUserId': 'oeu1394241144653r0.5381617322055392',
+      'optimizelySegments': '%7B%22237061344%22%3A%22none%22%2C%22237321400%2' +
+        '2%3A%22ff%22%2C%22237335298%22%3A%22search%22%2C%22237485170%22%3A%2' +
+        '2false%22%7D',
+      'optimizelyBuckets': '%7B%7D'
+    };
+    COOKIES[emptyCookie] = {};
+    COOKIES[testCookie] = {'abc': '123'};
+    COOKIES[googleCookie] = {
+      'PREF': 'ID=d93d4e842d10e12a:U=3838eaea5cd40d37:FF=0:TM=1394232126:LM=1'+
+        '394235924:S=rKP367ac3aAdDzAS',
+      'NID': '67=VwhHOGQunRmNsm9WwJyK571OGqb3RtvUmH987K5DXFgKFAxFwafA_5VPF5_b'+
+        'sjhrCoM0BjyQdxyL2b-qs9b-fmYCQ_1UqjtqTeidAJBnc2ecjewJia6saHrcJ6yOVVgv'
+    };
+    COOKIES[hackpadCookie] = {
+      'acctIds': '%5B%22mIqZhIPMu7j%22%2C%221394477194%22%2C%22uT/ayZECO0g/+h'+
+        'HtQnjrdEZivWA%3D%22%5D',
+      'PUAS3': '3186efa7f8bca99c',
+      "1ASIE": "T"
+    };
+
+    // TODO move COOKIE_ATTRIBUTES to constants
+    let COOKIE_ATTRIBUTES = ["expires", "max-age", "domain", "path", "secure", "httponly"];
+
+    // compare actual to expected
+    let test_number = 0;
+    for (let cookieString in COOKIES) {
+      if (COOKIES.hasOwnProperty(cookieString)) {
+        test_number++;
+
+        let expected = COOKIES[cookieString];
+
+        let actual = utils.parseCookie(
+          cookieString, {
+            decode: _.identity,
+            skipNonValues: true
+          }
+        );
+        // strip cookie attributes to match legacy Firefox implementation
+        // https://github.com/EFForg/privacybadgerfirefox-legacy/blob/00d88bbf42649d31bba181b49a7886c8381682ae/lib/cookieUtils.js#L93-L98
+        actual = _.reduce(
+          actual,
+          (memo, val, key) => {
+            if (COOKIE_ATTRIBUTES.indexOf(key.toLowerCase()) == -1) {
+              memo[key] = val;
+            }
+            return memo;
+          },
+          {}
+        );
+
+        assert.deepEqual(actual, expected, "cookie test #" + test_number);
+      }
+    }
+  });
+
+  // the following cookie parsing tests are derived from
+  // https://github.com/yui/yui3/blob/25264e3629b1c07fb779d203c4a25c0879ec862c/src/cookie/tests/cookie-tests.js
+  QUnit.test("cookie parsing (YUI3)", function (assert) {
+
+    let cookieString = "a=b";
+    let cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("a"), "Cookie 'a' is present.");
+    assert.equal(cookies.a, "b", "Cookie 'a' should have value 'b'.");
+
+    cookieString = "12345=b";
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("12345"), "Cookie '12345' is present.");
+    assert.equal(cookies["12345"], "b", "Cookie '12345' should have value 'b'.");
+
+    cookieString = "a=b; c=d; e=f; g=h";
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("a"), "Cookie 'a' is present.");
+    assert.ok(cookies.hasOwnProperty("c"), "Cookie 'c' is present.");
+    assert.ok(cookies.hasOwnProperty("e"), "Cookie 'e' is present.");
+    assert.ok(cookies.hasOwnProperty("g"), "Cookie 'g' is present.");
+    assert.equal(cookies.a, "b", "Cookie 'a' should have value 'b'.");
+    assert.equal(cookies.c, "d", "Cookie 'c' should have value 'd'.");
+    assert.equal(cookies.e, "f", "Cookie 'e' should have value 'f'.");
+    assert.equal(cookies.g, "h", "Cookie 'g' should have value 'h'.");
+
+    cookieString = "name=Nicholas%20Zakas; title=front%20end%20engineer";
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("name"), "Cookie 'name' is present.");
+    assert.ok(cookies.hasOwnProperty("title"), "Cookie 'title' is present.");
+    assert.equal(cookies.name, "Nicholas Zakas", "Cookie 'name' should have value 'Nicholas Zakas'.");
+    assert.equal(cookies.title, "front end engineer", "Cookie 'title' should have value 'front end engineer'.");
+
+    cookieString = "B=2nk0a3t3lj7cr&b=3&s=13; LYC=l_v=2&l_lv=10&l_l=94ddoa70d&l_s=qz54t4qwrsqquyv51w0z4xxwtx31x1t0&l_lid=146p1u6&l_r=4q&l_lc=0_0_0_0_0&l_mpr=50_0_0&l_um=0_0_1_0_0;YMRAD=1215072198*0_0_7318647_1_0_40123839_1; l%5FPD3=840";
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("B"), "Cookie 'B' is present.");
+    assert.ok(cookies.hasOwnProperty("LYC"), "Cookie 'LYC' is present.");
+    assert.ok(cookies.hasOwnProperty("l_PD3"), "Cookie 'l_PD3' is present.");
+
+    let cookieName = "something[1]";
+    let cookieValue = "123";
+    cookieString = encodeURIComponent(cookieName) + "=" + encodeURIComponent(cookieValue);
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty(cookieName), "Cookie '" + cookieName + "' is present.");
+    assert.equal(cookies[cookieName], cookieValue, "Cookie value for '" + cookieName + "' is " + cookieValue + ".");
+
+    cookieString = "SESSION=27bedbdf3d35252d0db07f34d81dcca6; STATS=OK; SCREEN=1280x1024; undefined; ys-bottom-preview=o%3Aheight%3Dn%253A389";
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("SCREEN"), "Cookie 'SCREEN' is present.");
+    assert.ok(cookies.hasOwnProperty("STATS"), "Cookie 'STATS' is present.");
+    assert.ok(cookies.hasOwnProperty("SESSION"), "Cookie 'SESSION' is present.");
+    assert.ok(cookies.hasOwnProperty("ys-bottom-preview"), "Cookie 'ys-bottom-preview' is present.");
+    assert.ok(cookies.hasOwnProperty("undefined"), "Cookie 'undefined' is present.");
+
+    // Tests that cookie parsing deals with cookies that contain an invalid
+    // encoding. It shouldn't error, but should treat the cookie as if it
+    // doesn't exist (return null).
+    cookieString = "DetailInfoList=CPN03022194=@|@=CPN03#|#%B4%EB%C3%B5%C7%D8%BC%F6%BF%E5%C0%E5#|#1016026000#|#%BD%C5%C8%E6%B5%BF#|##|#";
+    cookies = utils.parseCookie(cookieString, { skipInvalid: true });
+    assert.equal(cookies.DetailInfoList, null, "Cookie 'DetailInfoList' should not have a value.");
+
+    // Tests that a Boolean cookie, one without an equals sign of value,
+    // is represented as an empty string.
+    cookieString = "info";
+    cookies = utils.parseCookie(cookieString);
+    assert.equal(cookies.info, "", "Cookie 'info' should be an empty string.");
+
+    cookieString = "name=Nicholas%20Zakas; hash=a=b&c=d&e=f&g=h; title=front%20end%20engineer";
+    cookies = utils.parseCookie(cookieString);
+    assert.ok(cookies.hasOwnProperty("name"), "Cookie 'name' is present.");
+    assert.ok(cookies.hasOwnProperty("hash"), "Cookie 'hash' is present.");
+    assert.ok(cookies.hasOwnProperty("title"), "Cookie 'title' is present.");
+    assert.equal(cookies.name, "Nicholas Zakas", "Cookie 'name' should have value 'Nicholas Zakas'.");
+    assert.equal(cookies.hash, "a=b&c=d&e=f&g=h", "Cookie 'hash' should have value 'a=b&c=d&e=f&g=h'.");
+    assert.equal(cookies.title, "front end engineer", "Cookie 'title' should have value 'front end engineer'.");
+
+  });
+
 })();


### PR DESCRIPTION
Will fix #1237.

Plan:
- [x] Refactor cookie parsing into own function for readability and testability
- [x] Fix handling of multiple cookies (which are not the same as one big concatenated cookie!)
- [x] Fix any other obvious cookie parsing issues (white space, quoting, encoding, ...)
- [x] Ignore cookie attributes ("expires", "path", etc.); Badger incorrectly catches low-entropy cookies because of their expiration dates, for example. Regression from legacy Firefox add-on.
- [x] Ignore `__cfduid` cookie values to avoid catching CloudFlare-backed CDNs
- [x] Add lots of tests for all the above
- [ ] Plan to follow up with monitoring for `__cfduid` abuse
- [ ] Review performance impact (especially on Firefox)