### PR TITLE
Strip DNT request cookies

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -309,6 +309,8 @@ function getHostForTab(tabId){
   if (!badger.tabData[tabId]) {
     return '';
   }
+  // TODO what does this actually do?
+  // meant to address https://github.com/EFForg/privacybadger/issues/136
   if (_isTabAnExtension(tabId)) {
     // If the tab is an extension get the url of the first frame for its implied URL
     // since the url of frame 0 will be the hash of the extension key
@@ -553,14 +555,13 @@ function checkAction(tabId, url, quiet, frameId){
  * Check if the url of the tab starts with the given string
  *
  * @param {Integer} tabId Id of the tab
- * @param {String} piece String to check against
+ * @param {String} str String to check against
  * @returns {boolean} true if starts with string
  * @private
  */
-function _frameUrlStartsWith(tabId, piece){
-  return badger.tabData[tabId] &&
-    badger.tabData[tabId].frames[0] &&
-    (badger.tabData[tabId].frames[0].url.indexOf(piece) === 0);
+function _frameUrlStartsWith(tabId, str) {
+  let frameData = getFrameData(tabId, 0);
+  return frameData && frameData.url.indexOf(str) === 0;
 }
 
 /**
@@ -570,7 +571,7 @@ function _frameUrlStartsWith(tabId, piece){
  * @returns {boolean} Returns true if the tab is chrome internal
  * @private
  */
-function _isTabChromeInternal(tabId){
+function _isTabChromeInternal(tabId) {
   return tabId < 0 || !_frameUrlStartsWith(tabId, "http");
 }
 
@@ -581,8 +582,11 @@ function _isTabChromeInternal(tabId){
  * @returns {boolean} Returns true if the tab is from a chrome-extension
  * @private
  */
-function _isTabAnExtension(tabId){
-  return _frameUrlStartsWith(tabId, "chrome-extension://");
+function _isTabAnExtension(tabId) {
+  return (
+    _frameUrlStartsWith(tabId, "chrome-extension://") ||
+    _frameUrlStartsWith(tabId, "moz-extension://")
+   );
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -571,7 +571,7 @@ function _frameUrlStartsWith(tabId, piece){
  * @private
  */
 function _isTabChromeInternal(tabId){
-  return tabId < 0 || _frameUrlStartsWith(tabId, "chrome");
+  return tabId < 0 || !_frameUrlStartsWith(tabId, "http");
 }
 
 /**

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -65,8 +65,8 @@ https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
         self.assertEqual(len(self.driver.get_cookies()), 0,
             "Shouldn't have any cookies after the DNT check")
 
-    def XXX_test_dnt_check_should_not_send_cookies(self):
-        TEST_DOMAIN = "localhost"
+    def test_dnt_check_should_not_send_cookies(self):
+        TEST_DOMAIN = "dnt-request-cookies-test.trackersimulator.org"
         TEST_URL = "https://{}/".format(TEST_DOMAIN)
 
         # directly visit a DNT policy URL known to set cookies

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -19,6 +19,9 @@ SITE3_URL = "http://eff-tracker-site3-test.s3-website-us-west-2.amazonaws.com"
 
 THIRD_PARTY_TRACKER = "eff-tracker-test.s3-website-us-west-2.amazonaws.com"
 
+CHECK_FOR_DNT_POLICY_JS = """badger.checkForDNTPolicy(
+'{}', 0, r => window.DNT_CHECK_RESULT = r
+);"""
 
 class CookieTest(pbtest.PBSeleniumTest):
     """Basic test to make sure the PB doesn't mess up with the cookies."""
@@ -29,11 +32,6 @@ https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
     def test_dnt_check_should_not_set_cookies(self):
         TEST_DOMAIN = "dnt-test.trackersimulator.org"
         TEST_URL = "https://{}/".format(TEST_DOMAIN)
-
-        RUN_DNT_JS = """badger.checkForDNTPolicy(
-  '{}', 0, r => window.DNT_CHECK_RESULT = r
-);""".format(TEST_DOMAIN)
-        CHECK_FINISHED_JS = "return window.DNT_CHECK_RESULT === false"
 
         # verify that the domain itself doesn't set cookies
         self.load_url(TEST_URL)
@@ -58,14 +56,39 @@ https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
 
         # perform a DNT policy check
         self.load_url(self.bg_url, wait_on_site=1)
-        self.js(RUN_DNT_JS)
+        self.js(CHECK_FOR_DNT_POLICY_JS.format(TEST_DOMAIN))
         # wait until checkForDNTPolicy completed
-        self.wait_for_script(CHECK_FINISHED_JS)
+        self.wait_for_script("return window.DNT_CHECK_RESULT === false")
 
         # check that we didn't get cookied by the DNT URL
         self.load_url(TEST_URL)
         self.assertEqual(len(self.driver.get_cookies()), 0,
             "Shouldn't have any cookies after the DNT check")
+
+    def test_dnt_check_should_not_send_cookies(self):
+        TEST_DOMAIN = "localhost"
+        TEST_URL = "https://{}/".format(TEST_DOMAIN)
+
+        # directly visit a DNT policy URL known to set cookies
+        self.load_url(TEST_URL + ".well-known/dnt-policy.txt")
+        self.assertEqual(len(self.driver.get_cookies()), 1,
+            "DNT policy URL set a cookie")
+
+        # how to check we didn't send a cookie along with request?
+        # the DNT policy URL used by this test returns "cookies=X"
+        # where X is the number of cookies it got
+        # MEGAHACK: make sha1 of "cookies=0" a valid DNT hash
+        self.load_url(self.bg_url, wait_on_site=1)
+        self.js("""badger.storage.updateDNTHashes(
+{ "cookies=0 test policy": "f63ee614ebd77f8634b92633c6bb809a64b9a3d7" });""")
+
+        # perform a DNT policy check
+        self.js(CHECK_FOR_DNT_POLICY_JS.format(TEST_DOMAIN))
+        # wait until checkForDNTPolicy completed
+        self.wait_for_script("return typeof window.DNT_CHECK_RESULT != 'undefined';")
+        # get the result
+        result = self.js("return window.DNT_CHECK_RESULT;")
+        self.assertTrue(result, "No cookies were sent")
 
     def assert_pass_opera_cookie_test(self, url, test_name):
         self.load_url(url)

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -65,7 +65,7 @@ https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
         self.assertEqual(len(self.driver.get_cookies()), 0,
             "Shouldn't have any cookies after the DNT check")
 
-    def test_dnt_check_should_not_send_cookies(self):
+    def XXX_test_dnt_check_should_not_send_cookies(self):
         TEST_DOMAIN = "localhost"
         TEST_URL = "https://{}/".format(TEST_DOMAIN)
 

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -119,9 +119,6 @@ def chrome_manager():
     opts.add_extension(get_extension_path())  # will fail if ext can't be found
     if browser_bin:  # otherwise will use webdriver's default binary
         opts.binary_location = browser_bin  # set binary location
-    # Fix for https://code.google.com/p/chromedriver/issues/detail?id=799
-    opts.add_experimental_option("excludeSwitches",
-                                 ["ignore-certificate-errors"])
     prefs = {"profile.block_third_party_cookies": False}
     opts.add_experimental_option("prefs", prefs)
     driver = webdriver.Chrome(chrome_options=opts)


### PR DESCRIPTION
Fixes #1353.

Flask test server logic:
```python
from flask import Flask, request, Response

app = Flask(__name__)

COOKIE = 'foo=bar; Path=/;'

@app.route('/.well-known/dnt-policy.txt')
def route_dnt_policy_cookie_status():
    response = Response(response="cookies={}".format(len(request.cookies)))
    response.status = '200'
    response.headers['Set-Cookie'] = COOKIE
    return response

app.run('127.0.0.1', debug=True, port=443, ssl_context='adhoc')
```