### PR TITLE
Disable google translate on settings page

### DIFF
--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -19,6 +19,7 @@
 
 <html>
 <head>
+<meta name="google" content="notranslate">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <link type="text/css" href="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.structure.min.css" rel="stylesheet" />
 <link type="text/css" href="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.theme.min.css" rel="stylesheet" />


### PR DESCRIPTION
Fixes #1273 

Added a meta tag to disable the translation suggestion from appearing in chrome on the settings page. Not sure if a regression test can be written for this bug since it does not look like tests would be able to determine if the translate popup appears. Additionally, it seems like the translate option is being enabled by a particular set of domains in the "User Filter Settings" tab, so in order to replicate the issue, I needed to manually add Portuguese text to the settings page. However the fix can be tested manually with the following steps:

1. In a version of privacybadger without this fix, add a Portuguese text to options.html in order to trigger the chrome translate option (I used the contents of [this page](http://www.laits.utexas.edu/orkelm/port/reading/pracpara.html))

2. Start chrome and navigate to the settings page. Verify that the translate option appears.

3. Add the meta tag to the options.html page. Reload chrome and navigate to the settings page, verify that the translate option does not appear.