### PR TITLE
added option to disable DNT policy checking

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -90,7 +90,7 @@
         "message": "Privacy Badger Options"
     },
     "options_dnt_policy_setting": {
-        "message": "Check if sites have a DNT policy and unblock them"
+        "message": "Check if sites comply with EFF's Do Not Track policy"
     },
     "options_dnt_policy_learn_more": {
         "message": "Learn more"

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -89,12 +89,12 @@
     "options_title": {
         "message": "Privacy Badger Options"
     },
-	"options_dnt_policy_setting": {
-		"message": "Check if sites have a DNT policy and unblock them"
-	},
-	"options_dnt_policy_learn_more": {
-		"message": "Learn more"
-	},
+    "options_dnt_policy_setting": {
+        "message": "Check if sites have a DNT policy and unblock them"
+    },
+    "options_dnt_policy_learn_more": {
+        "message": "Learn more"
+    },
     "options_webrtc_setting": {
         "message": "Prevent WebRTC from leaking local IP address *"
     },

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -89,6 +89,12 @@
     "options_title": {
         "message": "Privacy Badger Options"
     },
+	"options_dnt_policy_setting": {
+		"message": "Check if sites have a DNT policy and unblock them"
+	},
+	"options_dnt_policy_learn_more": {
+		"message": "Learn more"
+	},
     "options_webrtc_setting": {
         "message": "Prevent WebRTC from leaking local IP address *"
     },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -298,6 +298,11 @@ Badger.prototype = {
   * Fetch acceptable DNT policy hashes from the EFF server
   */
   updateDNTPolicyHashes: function(){
+    if (! badger.isCheckingDNTPolicyEnabled()) {
+      // user has disabled this, we can check when they re-enable
+      return ;
+    }
+
     var self = this;
     utils.xhrRequest(constants.DNT_POLICIES_URL, function(err,response){
       if(err){
@@ -322,9 +327,14 @@ Badger.prototype = {
       return;
     }
 
-    log('Checking', domain, 'for DNT policy.');
-
     var badger = this;
+
+    if (! badger.isCheckingDNTPolicyEnabled()) {
+      // user has disabled this check
+      return ;
+    }
+
+    log('Checking', domain, 'for DNT policy.');
 
     // update timestamp first;
     // avoids queuing the same domain multiple times
@@ -382,6 +392,7 @@ Badger.prototype = {
    */
   defaultSettings: {
     socialWidgetReplacementEnabled: true,
+    checkForDNTPolicy: false,
     showCounter: true,
     disabledSites: [],
     isFirstRun: true,
@@ -563,6 +574,10 @@ Badger.prototype = {
    */
   isSocialWidgetReplacementEnabled: function() {
     return this.getSettings().getItem("socialWidgetReplacementEnabled");
+  },
+
+  isCheckingDNTPolicyEnabled: function() {
+    return this.getSettings().getItem("checkForDNTPolicy");
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -392,7 +392,7 @@ Badger.prototype = {
    */
   defaultSettings: {
     socialWidgetReplacementEnabled: true,
-    checkForDNTPolicy: false,
+    checkForDNTPolicy: true,
     showCounter: true,
     disabledSites: [],
     isFirstRun: true,

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -76,6 +76,8 @@ function loadOptions() {
   $("#show_counter_checkbox").prop("checked", badger.showCounter());
   $("#replace_social_widgets_checkbox").click(updateSocialWidgetReplacement);
   $("#replace_social_widgets_checkbox").prop("checked", badger.isSocialWidgetReplacementEnabled());
+  $("#check_dnt_policy_checkbox").click(updateCheckingDNTPolicy);
+  $("#check_dnt_policy_checkbox").prop("checked", badger.isCheckingDNTPolicyEnabled());
   if(chrome.privacy && badger.webRTCAvailable){
     $("#toggle_webrtc_mode").click(toggleWebRTCIPProtection);
     $("#toggle_webrtc_mode").prop("checked", badger.isWebRTCIPProtectionEnabled());
@@ -208,6 +210,12 @@ function updateShowCounter() {
 function updateSocialWidgetReplacement() {
   var replaceSocialWidgets = $("#replace_social_widgets_checkbox").prop("checked");
   settings.setItem("socialWidgetReplacementEnabled", replaceSocialWidgets);
+}
+
+function updateCheckingDNTPolicy() {
+  var newDNTSetting = $("#check_dnt_policy_checkbox").prop("checked");
+  settings.setItem("checkForDNTPolicy", newDNTSetting);
+  refreshFilterPage(); // This setting means sites need to be re-evaluated
 }
 
 function reloadWhitelist() {

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -99,13 +99,15 @@ BadgerPen.prototype = {
    * @returns {String} the presumed action for this FQDN
    **/
   getAction: function (domain, ignoreDNT) {
-    let checking_dnt = badger.isCheckingDNTPolicyEnabled();
+    if(! badger.isCheckingDNTPolicyEnabled()){
+      ignoreDNT = true;
+    }
 
     if (_.isString(domain)) {
       domain = this.getBadgerStorageObject('action_map').getItem(domain) || {};
     }
     if (domain.userAction) { return domain.userAction; }
-    if (domain.dnt && !ignoreDNT && checking_dnt) { return constants.DNT; }
+    if (domain.dnt && !ignoreDNT) { return constants.DNT; }
     if (domain.heuristicAction) { return domain.heuristicAction; }
     return constants.NO_TRACKING;
   },

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -99,11 +99,13 @@ BadgerPen.prototype = {
    * @returns {String} the presumed action for this FQDN
    **/
   getAction: function (domain, ignoreDNT) {
+    let checking_dnt = badger.isCheckingDNTPolicyEnabled();
+
     if (_.isString(domain)) {
       domain = this.getBadgerStorageObject('action_map').getItem(domain) || {};
     }
     if (domain.userAction) { return domain.userAction; }
-    if (domain.dnt && !ignoreDNT) { return constants.DNT; }
+    if (domain.dnt && !ignoreDNT && checking_dnt) { return constants.DNT; }
     if (domain.heuristicAction) { return domain.heuristicAction; }
     return constants.NO_TRACKING;
   },

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -212,7 +212,7 @@ a, a:hover, a:active, a:visited{
           <input type="checkbox" id="check_dnt_policy_checkbox">
           <span class="i18n_options_dnt_policy_setting"></span>
         </label>
-        <a target="_blank" href="https://www.eff.org/dnt-policy"/><span class="i18n_options_dnt_policy_learn_more"></span></a>
+        <a target="_blank" href="https://www.eff.org/dnt-policy"><span class="i18n_options_dnt_policy_learn_more"></span></a>
       </div>
       <div class="checkbox" id="webRTCToggle">
         <label>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -207,6 +207,13 @@ a, a:hover, a:active, a:visited{
           <span class="i18n_options_social_widgets_checkbox"></span>
         </label>
       </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" id="check_dnt_policy_checkbox">
+          <span class="i18n_options_dnt_policy_setting"></span>
+        </label>
+        <a target="_blank" href="https://www.eff.org/dnt-policy"/><span class="i18n_options_dnt_policy_learn_more"></span></a>
+      </div>
       <div class="checkbox" id="webRTCToggle">
         <label>
           <input type="checkbox" id="toggle_webrtc_mode">

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -11,8 +11,7 @@
   let clock,
     server,
     xhrSpy,
-    dnt_policy_txt,
-    old_dnt_check_func;
+    dnt_policy_txt;
 
   QUnit.module("Background", {
     before: (assert) => {
@@ -35,9 +34,6 @@
         // set up fake timers to simulate window.setTimeout and co.
         clock = sinon.useFakeTimers(+new Date());
 
-        old_dnt_check_func = badger.isCheckingDNTPolicyEnabled;
-        badger.isCheckingDNTPolicyEnabled = () => true;
-        
         done();
       });
     },
@@ -55,7 +51,6 @@
     after: (/*assert*/) => {
       clock.restore();
       server.restore();
-      badger.isCheckingDNTPolicyEnabled = old_dnt_check_func;
     }
   });
 
@@ -128,9 +123,10 @@
     const NUM_TESTS = 5;
 
     let done = assert.async(NUM_TESTS);
+    // TODO: unit tests may be effected by user settings, and should be isolated somehow
+    let old_dnt_check_func = badger.isCheckingDNTPolicyEnabled;
 
     assert.expect(NUM_TESTS);
-
     badger.isCheckingDNTPolicyEnabled = () => false;
 
     for (let i = 0; i < NUM_TESTS; i++) {
@@ -141,5 +137,7 @@
       assert.equal(xhrSpy.callCount, 0);
       done();
     }
+
+    badger.isCheckingDNTPolicyEnabled = old_dnt_check_func;
   });
 }());

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -164,6 +164,8 @@
   });
 
   QUnit.test("DNT does not cascade", (assert) => {
+    let settings_map = storage.getBadgerStorageObject('settings_map');
+    settings_map.setItem("checkForDNTPolicy", true);
     storage.setupDNT(DOMAIN);
 
     // check domain itself
@@ -191,7 +193,26 @@
     );
   });
 
+  QUnit.test("DNT does not return as an action if user has chosen not to", (assert) => {
+    let settings_map = storage.getBadgerStorageObject('settings_map');
+    settings_map.setItem("checkForDNTPolicy", false);
+    storage.setupDNT(DOMAIN);
+
+    assert.equal(
+      storage.getAction(DOMAIN),
+      constants.NO_TRACKING,
+      "domain is marked as DNT directly"
+    );
+    assert.equal(
+      storage.getBestAction(DOMAIN),
+      constants.NO_TRACKING,
+      "domain is marked as DNT"
+    );
+  });
+
   QUnit.test("blocking still cascades after domain declares DNT", (assert) => {
+    let settings_map = storage.getBadgerStorageObject('settings_map');
+    settings_map.setItem("checkForDNTPolicy", true);
     storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
     storage.setupDNT(DOMAIN);
 
@@ -312,6 +333,8 @@
   });
 
   QUnit.test("user actions overrule everything else", (assert) => {
+    let settings_map = storage.getBadgerStorageObject('settings_map');
+    settings_map.setItem("checkForDNTPolicy", true);
     storage.setupUserAction(DOMAIN, constants.USER_BLOCK);
     storage.setupHeuristicAction(SUBDOMAIN, constants.COOKIEBLOCK);
     storage.setupDNT(SUBSUBDOMAIN);

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -201,12 +201,12 @@
     assert.equal(
       storage.getAction(DOMAIN),
       constants.NO_TRACKING,
-      "domain is marked as DNT directly"
+      "domain is marked as DNT directly, but returns as NO_TRACKING because user has disabled DNT"
     );
     assert.equal(
       storage.getBestAction(DOMAIN),
       constants.NO_TRACKING,
-      "domain is marked as DNT"
+      "domain is marked as DNT directly, but returns as NO_TRACKING because user has disabled DNT"
     );
   });
 

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -164,8 +164,6 @@
   });
 
   QUnit.test("DNT does not cascade", (assert) => {
-    let settings_map = storage.getBadgerStorageObject('settings_map');
-    settings_map.setItem("checkForDNTPolicy", true);
     storage.setupDNT(DOMAIN);
 
     // check domain itself
@@ -211,8 +209,6 @@
   });
 
   QUnit.test("blocking still cascades after domain declares DNT", (assert) => {
-    let settings_map = storage.getBadgerStorageObject('settings_map');
-    settings_map.setItem("checkForDNTPolicy", true);
     storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
     storage.setupDNT(DOMAIN);
 
@@ -333,8 +329,6 @@
   });
 
   QUnit.test("user actions overrule everything else", (assert) => {
-    let settings_map = storage.getBadgerStorageObject('settings_map');
-    settings_map.setItem("checkForDNTPolicy", true);
     storage.setupUserAction(DOMAIN, constants.USER_BLOCK);
     storage.setupHeuristicAction(SUBDOMAIN, constants.COOKIEBLOCK);
     storage.setupDNT(SUBSUBDOMAIN);

--- a/tests/selenium/localstorage_test.py
+++ b/tests/selenium/localstorage_test.py
@@ -53,6 +53,10 @@ class LocalStorageTest(pbtest.PBSeleniumTest):
 
         self.assertFalse(len(disabled_sites),
                          "Shouldn't have any disabledSites after installation")
+        
+        self.assertTrue(js("return (badger.storage.getBadgerStorageObject("\
+            "'settings_map').getItem('checkForDNTPolicy'))"),
+            "Should start with DNT policy enabled")
         # TODO: do we expect currentVersion to be present after the first run?
 
 


### PR DESCRIPTION
Fixes #1389.

http://imgur.com/a/N8DqL

adds an option to disable DNT policy checks. When this option is disabled, domains fall back to heuristics and privacy badger stops asking the EFF for updated policy hashes.

I couldn't think of a better way to test these settings, and I couldn't find any of the other settings being tested, so I didn't have anything to emulate.

Let me know what needs changed here!