### PR TITLE
Fix tracking misattribution bug

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -523,14 +523,9 @@ Badger.prototype = {
     }
   },
 
-  /**
-   * Get Supercookie data from storage
-   * @returns {*|{}} Dict with Supercookie domains
-   */
-  getSupercookieDomains: function() {
-    return this.storage.getBadgerStorageObject('supercookie_domains');
+  getSettings: function() {
+    return this.storage.getBadgerStorageObject('settings_map');
   },
-  getSettings: function(){ return this.storage.getBadgerStorageObject('settings_map'); },
 
   /**
    * Check if privacy badger is enabled, take an origin and
@@ -717,10 +712,6 @@ Badger.prototype = {
     chrome.browserAction.setIcon({tabId: tab.id, path: iconFilename});
     chrome.browserAction.setTitle({tabId: tab.id, title: "Privacy Badger"});
   },
-
-  getFrameData: function(tabId, frameId){
-    return webrequest.getFrameData(tabId, frameId);
-  }
 
 };
 

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -86,38 +86,6 @@ HeuristicBlocker.prototype = {
   },
 
   /**
-   * Check if SuperCookie tracking is done
-   *
-   * @param details onBeforeSendHeaders details
-   * @param origin The URL
-   * @returns {*} null or the supercookie data structure
-   */
-  hasSupercookieTracking: function(details, origin) {
-    /* This function is called before we hear from the localstorage check in supercookie.js.
-     * So, we're missing the scripts which may have supercookies.
-     * Alternatively, we could record the prevalence when we find hi-entropy localstorage items
-     * and check that record to see if the frame hasSupercookieTracking.
-     */
-    var frameData = badger.getFrameData(details.tabId, details.frameId);
-    if (frameData){
-      return frameData.superCookie;
-    } else { // Check localStorage if we can't find the frame in frameData
-      return badger.getSupercookieDomains().hasItem(origin);
-    }
-  },
-
-  /**
-   * Decides if a origin has tracking
-   *
-   * @param details onBeforeSendHeaders details
-   * @param origin The URL
-   * @returns {bool} true if it has tracking
-   */
-  hasTracking: function(details, origin) {
-    return (hasCookieTracking(details, origin) || this.hasSupercookieTracking(details, origin));
-  },
-
-  /**
    * Wraps _recordPrevalence for use from webRequest listeners.
    * Also saves tab (page) origins. TODO Should be handled by tabData instead.
    * Also sets a timeout for checking DNT policy for third-party FQDNs.
@@ -163,8 +131,8 @@ HeuristicBlocker.prototype = {
       return {};
     }
 
-    // if there are no tracking cookies or similar things, ignore
-    if (!this.hasTracking(details, origin)) {
+    // ignore if there are no tracking cookies
+    if (!hasCookieTracking(details, origin)) {
       return {};
     }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -510,7 +510,6 @@ function removeOrigin(event) {
   var origin = $element.data('origin');
   badger.storage.getBadgerStorageObject("snitch_map").deleteItem(origin);
   badger.storage.getBadgerStorageObject("action_map").deleteItem(origin);
-  badger.storage.getBadgerStorageObject("supercookie_domains").deleteItem(origin);
   backgroundPage.log('Removed', origin, 'from Privacy Badger');
 
   refreshFilterPage();

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -59,7 +59,6 @@ function BadgerPen(callback) {
     "snitch_map",
     "action_map",
     "cookieblock_list",
-    "supercookie_domains",
     "dnt_hashes",
     "settings_map",
   ];

--- a/src/js/supercookie.js
+++ b/src/js/supercookie.js
@@ -104,7 +104,6 @@ function getScPageScript() {
         });
     }
 
-  // save locally to keep from getting overwritten by site code
   } + "());";
 
   // code above is not a content script: no chrome.* APIs /////////////////////

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -465,16 +465,15 @@ function recordFingerprinting(tabId, msg) {
 /**
  * Read the frame data from memory
  *
- * @param tabId TabId to check for
- * @param frameId FrameID to check for
+ * @param tab_id Tab ID to check for
+ * @param frame_id Frame ID to check for
  * @returns {*} Frame data object or null
  */
-function getFrameData(tabId, frameId) {
-  if (tabId in badger.tabData && frameId in badger.tabData[tabId].frames){
-    return badger.tabData[tabId].frames[frameId];
-  } else if (frameId > 0 && tabId in badger.tabData && 0 in badger.tabData[tabId].frames) {
-    // We don't know anything about javascript: or data: frames, use top frame
-    return badger.tabData[tabId].frames[0];
+function getFrameData(tab_id, frame_id) {
+  if (badger.tabData.hasOwnProperty(tab_id)) {
+    if (badger.tabData[tab_id].frames.hasOwnProperty(frame_id)) {
+      return badger.tabData[tab_id].frames[frame_id];
+    }
   }
   return null;
 }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -700,12 +700,8 @@ function startListeners() {
 
 /************************************** exports */
 var exports = {};
-exports.getFrameData = getFrameData;
 exports.getHostForTab = getHostForTab;
-exports.getFrameUrl = getFrameUrl;
 exports.startListeners = startListeners;
-exports.isSocialWidgetTemporaryUnblock = isSocialWidgetTemporaryUnblock;
-
 return exports;
 /************************************** exports */
 })();

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -139,7 +139,7 @@ https://github.com/EFForg/privacybadger/pull/1347#issuecomment-297573773""")
         print("this is checking for a dnt file at a site without https, so we'll just have to wait for the connection to timeout before we proceed")
         self.load_url(SITE1_URL)
         window_utils.close_windows_with_url(self.driver, SITE3_URL)
-        for i in range(60):
+        for i in range(5):
             self.load_pb_ui(SITE1_URL)
             self.get_tracker_state()
 

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -33,12 +33,13 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         return origin in supercookieDomains
 
     # test for https://github.com/EFForg/privacybadger/pull/1403
-    def test_async_navigation_tracker_misattribution(self):
-        self.load_url("https://cdn.rawgit.com/ghostwords/d3685dc39f7e67dddf1edf2614beb6fc/raw/a78cfd6c86d51a8d8ab1e214e4e49e2c025d4715/privacy_badger_async_bug_test_fixture.html")
+    def test_async_tracking_misattribution_bug(self):
+        for _ in range(2 if os.environ.get('BROWSER') == 'firefox' else 1):
+            self.load_url("https://cdn.rawgit.com/ghostwords/d3685dc39f7e67dddf1edf2614beb6fc/raw/a78cfd6c86d51a8d8ab1e214e4e49e2c025d4715/privacy_badger_async_bug_test_fixture.html")
 
-        # the above HTML page reloads itself furiously to trigger our bug
-        # we need to wait for it to finish reloading
-        self.wait_for_script("return window.DONE_RELOADING === true")
+            # the above HTML page reloads itself furiously to trigger our bug
+            # we need to wait for it to finish reloading
+            self.wait_for_script("return window.DONE_RELOADING === true")
 
         # the HTML page contains:
 
@@ -49,6 +50,10 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         # and an image from raw.githubusercontent.com that doesn't do any tracking
         self.assertFalse(self.detected_tracking_by("raw.githubusercontent.com"),
             msg="Image is not a tracker but was flagged as one.")
+    if os.environ.get('BROWSER') == 'firefox':
+        test_async_tracking_misattribution_bug = (
+            pbtest.repeat_if_failed(5)(test_async_tracking_misattribution_bug)
+        )
 
     @pbtest.repeat_if_failed(5)
     def test_should_detect_ls_of_third_party_frame(self):

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -57,9 +57,6 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         """
         self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html",  # noqa
                       wait_on_site=5)
-        #self.driver.switch_to_frame(self.driver.
-        #                            find_element_by_tag_name("iframe"))
-        #print(self.js("return localStorage['frameId']"))
         self.assertTrue(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -24,22 +24,13 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
 
         return self.js(CHECK_SNITCH_MAP_JS)
 
-    def has_supercookies(self, origin):
-        """Check if the given origin has supercookies in PB's localStorage."""
-        self.load_url(self.bg_url, wait_on_site=1)
-        get_sc_domains_js = "return JSON.stringify(badger.storage."\
-            "getBadgerStorageObject('supercookie_domains').getItemClones())"
-        supercookieDomains = json.loads(self.js(get_sc_domains_js))
-        return origin in supercookieDomains
-
     # test for https://github.com/EFForg/privacybadger/pull/1403
     def test_async_tracking_misattribution_bug(self):
-        for _ in range(2 if os.environ.get('BROWSER') == 'firefox' else 1):
-            self.load_url("https://cdn.rawgit.com/ghostwords/d3685dc39f7e67dddf1edf2614beb6fc/raw/a78cfd6c86d51a8d8ab1e214e4e49e2c025d4715/privacy_badger_async_bug_test_fixture.html")
+        self.load_url("https://cdn.rawgit.com/ghostwords/d3685dc39f7e67dddf1edf2614beb6fc/raw/a78cfd6c86d51a8d8ab1e214e4e49e2c025d4715/privacy_badger_async_bug_test_fixture.html")
 
-            # the above HTML page reloads itself furiously to trigger our bug
-            # we need to wait for it to finish reloading
-            self.wait_for_script("return window.DONE_RELOADING === true")
+        # the above HTML page reloads itself furiously to trigger our bug
+        # we need to wait for it to finish reloading
+        self.wait_for_script("return window.DONE_RELOADING === true")
 
         # the HTML page contains:
 
@@ -66,27 +57,27 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         """
         self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html",  # noqa
                       wait_on_site=5)
-        self.driver.switch_to_frame(self.driver.
-                                    find_element_by_tag_name("iframe"))
-        print(self.js("return localStorage['frameId']"))
-        self.assertTrue(self.has_supercookies("githack.com"))
+        #self.driver.switch_to_frame(self.driver.
+        #                            find_element_by_tag_name("iframe"))
+        #print(self.js("return localStorage['frameId']"))
+        self.assertTrue(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):
         self.load_url("https://gistcdn.githack.com/gunesacar/6f0c39fb728a218ccd91215bfefbd4e0/raw/f438eb4e5ce10dc8623a8834b1298fd4a846c6fa/low_entropy_localstorage_from_third_party_script.html",  #noqa
                       wait_on_site=5)
 
-        self.assertFalse(self.has_supercookies("githack.com"))
+        self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_first_party_ls(self):
         self.load_url("https://gistcdn.githack.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html",  # noqa
                       wait_on_site=5)
-        self.assertFalse(self.has_supercookies("githack.com"))
+        self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_ls_of_third_party_script(self):
         # a third-party script included by the top page (not a 3rd party frame)
         self.load_url("https://rawgit.com/gunesacar/b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11/localstorage_from_third_party_script.html",  # noqa
                       wait_on_site=5)
-        self.assertFalse(self.has_supercookies("githack.com"))
+        self.assertFalse(self.detected_tracking_by("githack.com"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reloading a tab that contains localStorage tracking, such as from an embedded YouTube video, while the tab is still loading runs into a Badger bookkeeping bug which causes localStorage tracking to be attributed to all frame 0 resources (instead of the actual frame localStorage was in).

- [x] Refactor [supercookie detection](https://github.com/EFForg/privacybadger/commit/8935682cb31be75f0c9b5d04d8ddd57297d950a1)
- [x] Remove fallback to frame 0 data when we don't have data for frame XX
- [x] Add test that catches misattribution bug
- [ ] Since this will only resolve the problem going forward, to fix overblocking for existing users, we should "yellowlist" affected domains (like `kxcdn.com`) or, more to the point, make Badger do a one-time cleanup for a set of false positives