### PR TITLE
Fix some UI issues with DNT in the popup

### DIFF
--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -50,7 +50,9 @@ var htmlUtils = exports.htmlUtils = {
    * @returns {String} 'checked' if both actions match otherwise empty string.
    */
   isChecked: function(inputAction, originAction) {
-    if(originAction == constants.NO_TRACKING) { originAction = constants.ALLOW; }
+    if((originAction == constants.NO_TRACKING) || (originAction == constants.DNT)) {
+      originAction = constants.ALLOW;
+    }
     return (inputAction === originAction) ? 'checked' : '';
   },
 

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -154,7 +154,9 @@ var htmlUtils = exports.htmlUtils = {
       whitelistedText = '' +
         '<div id="dnt-compliant">' +
         '<a target=_blank href="https://www.eff.org/privacybadger#faq--I-am-an-online-advertising-/-tracking-company.--How-do-I-stop-Privacy-Badger-from-blocking-me?">' +
-        '<img src="/icons/dnt-16.png"></a></div>';
+        '<img src="' +
+        chrome.extension.getURL('/icons/dnt-16.png') +
+        '"></a></div>';
     }
 
     // If there are multiple subdomains set text showing count.

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -292,7 +292,7 @@ function refreshPopup(tabId) {
   var printable = [];
   var nonTracking = [];
   origins.sort(htmlUtils.compareReversedDomains);
-  var originCount = 0;
+  var trackerCount = 0;
   var compressedOrigins = {};
 
   for (let i=0; i < origins.length; i++) {
@@ -322,7 +322,9 @@ function refreshPopup(tabId) {
       }
     }
 
-    originCount++;
+    if (action != constants.DNT) {
+      trackerCount++;
+    }
     printable.push(
       htmlUtils.getOriginHtml(origin, action, action == constants.DNT)
     );
@@ -353,7 +355,7 @@ function refreshPopup(tabId) {
     }
   }
 
-  $('#number_trackers').text(originCount);
+  $('#number_trackers').text(trackerCount);
 
   function renderDomains() {
     const CHUNK = 1;


### PR DESCRIPTION
What this does:
* mainly the position of the sliders' when they have DNT. In `isChecked` we weren't accounting for DNT so the slider defaulted to the left.
* don't count origins with DNT in popup message "Privacy Badger detected X potential trackers"
* replace a hardcoded image path with `extension.getURL`

To test this visit https://troisiemebaobab.com/

With this PR you should see:
![pb-popup-fix-after](https://user-images.githubusercontent.com/598099/27656860-7a1ffebe-5bff-11e7-8171-c55c793258ef.png)

Before this PR you would see:
![pb-popup-fix-before](https://user-images.githubusercontent.com/598099/27656871-83434c94-5bff-11e7-8abc-a1cb0bcf6de6.png)


