### PR TITLE
WIP: refactoring tracking tabs

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -31,6 +31,7 @@ window.SocialWidgetList = SocialWidgetLoader.loadSocialWidgetsFromFile("data/soc
 
 var Migrations = require("migrations").Migrations;
 var incognito = require("incognito");
+var tabs = require("tabs");
 
 /**
 * privacy badger initializer
@@ -499,7 +500,7 @@ Badger.prototype = {
    * @param {Object} details details object from onBeforeRequest event
    */
   updateCount: function(details) {
-    if(!this.isPrivacyBadgerEnabled(webrequest.getHostForTab(details.tabId))){
+    if(!this.isPrivacyBadgerEnabled(tabs.getTabHost(details))){
       return;
     }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -779,3 +779,4 @@ startBackgroundListeners();
 
 console.log('Privacy badger is ready to rock!');
 console.log('Set DEBUG=1 to view console messages.');
+var DEBUG=1;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -500,7 +500,7 @@ Badger.prototype = {
    * @param {Object} details details object from onBeforeRequest event
    */
   updateCount: function(details) {
-    if(!this.isPrivacyBadgerEnabled(tabs.getTabHost(details.tabId))){
+    if(!this.isPrivacyBadgerEnabled(tabs.getTabHostname(details.tabId))){
       return;
     }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -500,7 +500,7 @@ Badger.prototype = {
    * @param {Object} details details object from onBeforeRequest event
    */
   updateCount: function(details) {
-    if(!this.isPrivacyBadgerEnabled(tabs.getTabHost(details))){
+    if(!this.isPrivacyBadgerEnabled(tabs.getTabHost(details.tabId))){
       return;
     }
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -47,32 +47,23 @@ function requestAccountant(details) {
   }
 }
 
-function getFrameHost(tabId, frameId) {
-  let frames = tabs[tabId];
-  if (!frames) {
-    log('ERROR: missing tab data for tabId: ' + tabId);
-    return '';
-  }
-  let url = frames[frameId];
-  if (!url) {
-    log('ERROR: missing subframe url for: ' + url);
-  }
-  return window.extractHostFromURL(frames[frameId]);
+function getFrameHostname(tabId, frameId) {
+  return window.extractHostFromURL(tabs[tabId][frameId].frameURL);
 }
-
 
 /**
  * Gets the host name for a given tab id
  * @param {Integer} tabId chrome tab id
  * @return {String} the host name for the tab
  */
-function getTabHost(tabId) {
-  return getFrameHost(tabId, 0);
+function getTabHostname(tabId) {
+  return getFrameHostname(tabId, 0);
 }
 
 
 let exports = {};
 exports.requestAccountant = requestAccountant;
-exports.getTabHost = getTabHost;
+exports.getTabHostname = getTabHostname;
+exports.getFrameHostname = getFrameHostname;
 return exports;
 })();

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -27,19 +27,18 @@ function requestAccountant(details) {
     log('New tab url: ' + details.url);
     tabs[details.tabId] = details.url;
   }
-  console.log(details);
 }
 
 
 /**
  * Gets the host name for a given tab id
- * @param {Integer} tabId chrome tab id
+ * @param {details} the details object passed into the callback of onBeforeRequest
  * @return {String} the host name for the tab
  */
 function getTabHost(details) {
   let url = tabs[details.tabId];
   if (!url) {
-    log('ERROR: missing url');
+    log('ERROR: missing url for tabId: ' + details.tabId);
     return '';
   }
   return window.extractHostFromURL(url);

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -61,6 +61,13 @@ function isMainPage(details) {
   return false;
 }
 
+function storeMainPage(details) {
+  if (!tabs[details.tabId]) {
+    tabs[details.tabId] = {0: newFrameData(details.url, details.url)}
+  } else {
+    tabs[details.tabId][0] = newFrameData(details.url, details.url)}
+}
+
 function isSubFrame(details) {
   if (details.frameId > 0 &&
       (details.type == 'main_frame' || details.type == 'sub_frame')) {
@@ -69,21 +76,28 @@ function isSubFrame(details) {
   return false;
 }
 
+function storeSubFrame(details) {
+  let frames = tabs[details.tabId];
+  if (!frames) {
+    throw('ERROR unitialized tab for :' + details.tabId);
+  }
+  let tabURL = frames[0].tabURL;
+  frames[details.frameId] = newFrameData(tabURL, details.url);
+}
 
 /**
  * Receives the details object that is passed from webRequest.onBeforeRequest
  */
 function requestAccountant(details) {
-  console.log(details);
+  if (!ready) {
+    console.log('ERROR: tabs not ready yet');
+    //requestAccountant(details); // dirty hack to force synchronicity
+    return;
+  }
   if (isMainPage(details)) {
-    log('New tab url: ' + details.url);
-    tabs[details.tabId] = {0: details.url};
+    storeMainPage(details);
   } else if (isSubFrame(details)) {
-    let frames = tabs[details.tabId];
-    if (!frames) {
-      log('ERROR unitialized tab for :' + details.tabId);
-    }
-    frames[details.frameId] = details.url;
+    storeSubFrame(details);
   }
 }
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -21,27 +21,53 @@ function isMainPage(details) {
   return false;
 }
 
-// receives the details object that is passed from webRequest.onBeforeRequest 
+function isSubFrame(details) {
+  if (details.frameId > 0 &&
+      (details.type == 'main_frame' || details.type == 'sub_frame')) {
+    return true;
+  }
+  return false;
+}
+
+
+/**
+ * Receives the details object that is passed from webRequest.onBeforeRequest
+ */
 function requestAccountant(details) {
+  console.log(details);
   if (isMainPage(details)) {
     log('New tab url: ' + details.url);
-    tabs[details.tabId] = details.url;
+    tabs[details.tabId] = {0: details.url};
+  } else if (isSubFrame(details)) {
+    let frames = tabs[details.tabId];
+    if (!frames) {
+      log('ERROR unitialized tab for :' + details.tabId);
+    }
+    frames[details.frameId] = details.url;
   }
+}
+
+function getFrameHost(tabId, frameId) {
+  let frames = tabs[tabId];
+  if (!frames) {
+    log('ERROR: missing tab data for tabId: ' + tabId);
+    return '';
+  }
+  let url = frames[frameId];
+  if (!url) {
+    log('ERROR: missing subframe url for: ' + url);
+  }
+  return window.extractHostFromURL(frames[frameId]);
 }
 
 
 /**
  * Gets the host name for a given tab id
- * @param {details} the details object passed into the callback of onBeforeRequest
+ * @param {Integer} tabId chrome tab id
  * @return {String} the host name for the tab
  */
-function getTabHost(details) {
-  let url = tabs[details.tabId];
-  if (!url) {
-    log('ERROR: missing url for tabId: ' + details.tabId);
-    return '';
-  }
-  return window.extractHostFromURL(url);
+function getTabHost(tabId) {
+  return getFrameHost(tabId, 0);
 }
 
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -10,6 +10,20 @@
  * since it is used there.
  */
 /* globals log:false */
+/*
+ * tabs = {
+ *          tabId: {
+ *                   frameId: {
+ *                              'frameURL' : '...',
+ *                              'tabURL'   : '...'
+ *                 }
+ *        }
+ *
+ * maybe this should be refactored around "frame" objects since the would
+ * inherently have info about their state when they are created, like
+ * "isthirdparty" or whatever.
+ */
+
 require.scopes.tabs = (function() {
 
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -1,0 +1,53 @@
+/* we need to know the host associated with a give tabid in a synchronous way,
+ * so lets start with host bookeeping.
+ *
+ * maybe we could also do this by just tracking responses from webrequests.
+ * this doesn't catch window.onpopstate like in this SO question. this is what
+ * https://stackoverflow.com/questions/824349/modify-the-url-without-reloading-the-page
+ * this is what twitter does
+ *
+ */
+/* globals log:false */
+require.scopes.tabs = (function() {
+
+let tabs = {};
+
+function isMainPage(details) {
+  if (details.frameId == 0 &&
+      details.method == 'GET' &&
+      details.type == 'main_frame') {
+    return true;
+  }
+  return false;
+}
+
+// receives the details object that is passed from webRequest.onBeforeRequest 
+function requestAccountant(details) {
+  if (isMainPage(details)) {
+    log('New tab url: ' + details.url);
+    tabs[details.tabId] = details.url;
+  }
+  console.log(details);
+}
+
+
+/**
+ * Gets the host name for a given tab id
+ * @param {Integer} tabId chrome tab id
+ * @return {String} the host name for the tab
+ */
+function getTabHost(details) {
+  let url = tabs[details.tabId];
+  if (!url) {
+    log('ERROR: missing url');
+    return '';
+  }
+  return window.extractHostFromURL(url);
+}
+
+
+let exports = {};
+exports.requestAccountant = requestAccountant;
+exports.getTabHost = getTabHost;
+return exports;
+})();

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -293,29 +293,6 @@ function isThirdPartyDomain(domain1, domain2) {
 }
 
 /**
- * Gets the host name for a given tab id
- * @param {Integer} tabId chrome tab id
- * @return {String} the host name for the tab
- */
-function getHostForTab(tabId){
-  var mainFrameIdx = 0;
-  if (!badger.tabData[tabId]) {
-    return '';
-  }
-  // TODO what does this actually do?
-  // meant to address https://github.com/EFForg/privacybadger/issues/136
-  if (_isTabAnExtension(tabId)) {
-    // If the tab is an extension get the url of the first frame for its implied URL
-    // since the url of frame 0 will be the hash of the extension key
-    mainFrameIdx = Object.keys(badger.tabData[tabId].frames)[1] || 0;
-  }
-  if (!badger.tabData[tabId].frames[mainFrameIdx]) {
-    return '';
-  }
-  return window.extractHostFromURL(badger.tabData[tabId].frames[mainFrameIdx].url);
-}
-
-/**
  * Generate representation in internal data structure for frame
  *
  * @param tabId ID of the tab

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -509,7 +509,7 @@ function checkAction(tabId, url, quiet, frameId){
  * @private
  */
 function _frameUrlStartsWith(tabId, str) {
-  var tabDomain = tabs.getTabHostname(tab_id);
+  var tabDomain = tabs.getTabHostname(tabId);
   return tabDomain && tabDomain.indexOf(str) === 0;
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -441,18 +441,6 @@ function getFrameData(tab_id, frame_id) {
 }
 
 /**
- * Based on tab/frame ids, get the URL
- *
- * @param {Integer} tabId The tab id to look up
- * @param {Integer} frameId The frame id to look up
- * @returns {String} The url
- */
-function getFrameUrl(tabId, frameId) {
-  var frameData = getFrameData(tabId, frameId);
-  return (frameData ? frameData.url : null);
-}
-
-/**
  * Delete tab data, de-register tab
  *
  * @param {Integer} tabId The id of the tab

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -77,7 +77,7 @@ function onBeforeRequest(details){
     return {};
   }
 
-  var tabDomain = tabs.getTabHost(tab_id);
+  var tabDomain = tabs.getTabHostname(tab_id);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -143,7 +143,7 @@ function onBeforeSendHeaders(details) {
     return {};
   }
 
-  var tabDomain = tabs.getTabHost(tab_id);
+  var tabDomain = tabs.getTabHostname(tab_id);
   var requestDomain = window.extractHostFromURL(url);
 
   if (badger.isPrivacyBadgerEnabled(tabDomain) && 
@@ -228,7 +228,7 @@ function onHeadersReceived(details) {
     return {};
   }
 
-  var tabDomain = tabs.getTabHost(tab_id);
+  var tabDomain = tabs.getTabHostname(tab_id);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -336,7 +336,7 @@ function recordSuperCookie(sender, msg) {
 
   // docUrl: url of the frame with supercookie
   let frameHost = window.extractHostFromURL(msg.docUrl);
-  let pageHost = tabs.getTabHost(sender.tab.id);
+  let pageHost = tabs.getTabHostname(sender.tab.id);
 
   if (!isThirdPartyDomain(frameHost, pageHost)) {
     // Only happens on the start page for google.com
@@ -365,7 +365,7 @@ function recordFingerprinting(tabId, msg) {
 
   // Ignore first-party scripts
   var script_host = window.extractHostFromURL(msg.scriptUrl),
-    document_host = tabs.getFrameHost(tabId);
+    document_host = tabs.getTabHostname(tabId);
   if (!isThirdPartyDomain(script_host, document_host)) {
     return;
   }
@@ -472,7 +472,7 @@ function checkAction(tabId, url, quiet, frameId){
   }
 
   // Ignore requests that don't have a document URL for some reason.
-  var documentUrl = tabs.getTabHost(tabId);
+  var documentUrl = tabs.getTabHostname(tabId);
   if (! documentUrl) {
     return false;
   }
@@ -509,8 +509,8 @@ function checkAction(tabId, url, quiet, frameId){
  * @private
  */
 function _frameUrlStartsWith(tabId, str) {
-  let frameData = getFrameData(tabId, 0);
-  return frameData && frameData.url.indexOf(str) === 0;
+  var tabDomain = tabs.getTabHostname(tab_id);
+  return tabDomain && tabDomain.indexOf(str) === 0;
 }
 
 /**
@@ -579,7 +579,7 @@ function isSocialWidgetTemporaryUnblock(tabId, url, frameId) {
   var requestHost = window.extractHostFromURL(url);
   var requestExcept = (exceptions.indexOf(requestHost) != -1);
 
-  var frameHost = tabs.getFrameHost(tabId, frameId);
+  var frameHost = tabs.getFrameHostname(tabId, frameId);
   var frameExcept = (exceptions.indexOf(frameHost) != -1);
 
   return (requestExcept || frameExcept);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -77,7 +77,7 @@ function onBeforeRequest(details){
     return {};
   }
 
-  var tabDomain = tabs.getTabHost(details);
+  var tabDomain = tabs.getTabHost(tab_id);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -143,7 +143,7 @@ function onBeforeSendHeaders(details) {
     return {};
   }
 
-  var tabDomain = tabs.getTabHost(details);
+  var tabDomain = tabs.getTabHost(tab_id);
   var requestDomain = window.extractHostFromURL(url);
 
   if (badger.isPrivacyBadgerEnabled(tabDomain) && 
@@ -228,7 +228,7 @@ function onHeadersReceived(details) {
     return {};
   }
 
-  var tabDomain = tabs.getTabHost(details);
+  var tabDomain = tabs.getTabHost(tab_id);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -28,6 +28,7 @@ var constants = require('constants');
 var getSurrogateURI = require('surrogates').getSurrogateURI;
 var mdfp = require('multiDomainFP');
 var incognito = require("incognito");
+var tabs = require('tabs');
 
 require.scopes.webrequest = (function() {
 
@@ -46,6 +47,7 @@ var temporarySocialWidgetUnblock = {};
  * @returns {*} Can cancel requests
  */
 function onBeforeRequest(details){
+  tabs.requestAccountant(details);
   var frame_id = details.frameId,
     tab_id = details.tabId,
     type = details.type,
@@ -75,7 +77,7 @@ function onBeforeRequest(details){
     return {};
   }
 
-  var tabDomain = getHostForTab(tab_id);
+  var tabDomain = tabs.getTabHost(details);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -141,7 +143,7 @@ function onBeforeSendHeaders(details) {
     return {};
   }
 
-  var tabDomain = getHostForTab(tab_id);
+  var tabDomain = tabs.getTabHost(details);
   var requestDomain = window.extractHostFromURL(url);
 
   if (badger.isPrivacyBadgerEnabled(tabDomain) && 
@@ -226,7 +228,7 @@ function onHeadersReceived(details) {
     return {};
   }
 
-  var tabDomain = getHostForTab(tab_id);
+  var tabDomain = tabs.getTabHost(details);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -568,7 +570,7 @@ function _isTabAnExtension(tabId) {
   return (
     _frameUrlStartsWith(tabId, "chrome-extension://") ||
     _frameUrlStartsWith(tabId, "moz-extension://")
-   );
+  );
 }
 
 /**
@@ -700,7 +702,6 @@ function startListeners() {
 
 /************************************** exports */
 var exports = {};
-exports.getHostForTab = getHostForTab;
 exports.startListeners = startListeners;
 return exports;
 /************************************** exports */

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -335,8 +335,8 @@ function recordSuperCookie(sender, msg) {
   }
 
   // docUrl: url of the frame with supercookie
-  var frameHost = window.extractHostFromURL(msg.docUrl);
-  var pageHost = window.extractHostFromURL(getFrameUrl(sender.tab.id, 0));
+  let frameHost = window.extractHostFromURL(msg.docUrl);
+  let pageHost = tabs.getTabHost(sender.tab.id);
 
   if (!isThirdPartyDomain(frameHost, pageHost)) {
     // Only happens on the start page for google.com
@@ -365,7 +365,7 @@ function recordFingerprinting(tabId, msg) {
 
   // Ignore first-party scripts
   var script_host = window.extractHostFromURL(msg.scriptUrl),
-    document_host = window.extractHostFromURL(getFrameUrl(tabId, 0));
+    document_host = tabs.getFrameHost(tabId);
   if (!isThirdPartyDomain(script_host, document_host)) {
     return;
   }
@@ -484,7 +484,7 @@ function checkAction(tabId, url, quiet, frameId){
   }
 
   // Ignore requests that don't have a document URL for some reason.
-  var documentUrl = getFrameUrl(tabId, 0);
+  var documentUrl = tabs.getTabHost(tabId);
   if (! documentUrl) {
     return false;
   }
@@ -591,7 +591,7 @@ function isSocialWidgetTemporaryUnblock(tabId, url, frameId) {
   var requestHost = window.extractHostFromURL(url);
   var requestExcept = (exceptions.indexOf(requestHost) != -1);
 
-  var frameHost = window.extractHostFromURL(getFrameUrl(tabId, frameId));
+  var frameHost = tabs.getFrameHost(tabId, frameId);
   var frameExcept = (exceptions.indexOf(frameHost) != -1);
 
   return (requestExcept || frameExcept);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -60,6 +60,7 @@ function onBeforeRequest(details){
   if (type == "main_frame" || type == "sub_frame"){
     // Firefox workaround: https://bugzilla.mozilla.org/show_bug.cgi?id=1329299
     // TODO remove after Firefox 51 is no longer in use
+    // fix this with onTabCreated
     if (type == "main_frame" && frame_id != 0) {
       frame_id = 0;
     }
@@ -297,7 +298,7 @@ function isThirdPartyDomain(domain1, domain2) {
  *
  * @param tabId ID of the tab
  * @param frameId ID of the frame
- * @param parentFrameId ID of the parent frame
+ * @param parentFrameId ID of the parent frame // blake: unused
  * @param frameUrl The url of the frame
  */
 function recordFrame(tabId, frameId, parentFrameId, frameUrl) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,7 @@
       "lib/basedomain.js",
       "lib/underscore-min.js",
       "data/surrogates.js",
+      "js/tabs.js",
       "js/surrogates.js",
       "js/multiDomainFirstParties.js",
       "js/incognito.js",


### PR DESCRIPTION
The chrome webrequest api looks like:
```javascript
chrome.webRequest.onBeforeRequest.addListener(function callback)
```
Where the `callback` has to *return* some value to modify the request. Because we need to *synchronously* return something we can't directly use info from *asynchronous* apis like `tabs` or `storage`.  But we often need to associate requests with the url of the tab they are called from, or get info from storage. So we keep track of data from tabs and data from storage in memory so that we can access them synchronously. This pull request addresses problems with how we account for tabs in the `tabData` datastructure.
