### PR TITLE
Add migration to forget mistakenly flagged domains

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -427,6 +427,7 @@ Badger.prototype = {
       Migrations.migrateDntRecheckTimes,
       // Need to run this migration again for everyone to #1181
       Migrations.migrateDntRecheckTimes2,
+      Migrations.forgetMistakenlyBlockedDomains,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -76,7 +76,6 @@ exports.Migrations= {
     let MISTAKES = [
       'akamaized.net',
       'bootcss.com',
-      'cloudinary.com',
       'edgesuite.net',
       'ehowcdn.com',
       'ewscloud.com',
@@ -89,7 +88,6 @@ exports.Migrations= {
       'kinja-img.com',
       'kxcdn.com',
       'ldwgroup.com',
-      'meme.am',
       'metapix.net',
       'optnmstr.com',
       'parastorage.com',
@@ -101,6 +99,7 @@ exports.Migrations= {
       'slidesharecdn.com',
       'staticworld.net',
       'taleo.net',
+      'techhive.com',
       'unpkg.com',
       'uvcdn.com',
       'washingtonpost.com',

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -84,7 +84,6 @@ exports.Migrations= {
       'hsforms.net',
       'hubspot.com',
       'jsdelivr.net',
-      'jwplatform.com',
       'kinja-img.com',
       'kxcdn.com',
       'ldwgroup.com',

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -73,6 +73,8 @@ exports.Migrations= {
   },
 
   forgetMistakenlyBlockedDomains: function (badger) {
+    console.log("Running migration to forget mistakenly flagged domains ...");
+
     let MISTAKES = [
       'akamaized.net',
       'bootcss.com',

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -72,6 +72,73 @@ exports.Migrations= {
     }
   },
 
+  forgetMistakenlyBlockedDomains: function (badger) {
+    let MISTAKES = [
+      'akamaized.net',
+      'bootcss.com',
+      'cloudinary.com',
+      'edgesuite.net',
+      'ehowcdn.com',
+      'ewscloud.com',
+      'fncstatic.com',
+      'hgmsites.net',
+      'hsforms.net',
+      'hubspot.com',
+      'jsdelivr.net',
+      'jwplatform.com',
+      'kinja-img.com',
+      'kxcdn.com',
+      'ldwgroup.com',
+      'meme.am',
+      'metapix.net',
+      'optnmstr.com',
+      'parastorage.com',
+      'polyfill.io',
+      'qbox.me',
+      'rfdcontent.com',
+      'scene7.com',
+      'sinaimg.cn',
+      'slidesharecdn.com',
+      'staticworld.net',
+      'taleo.net',
+      'unpkg.com',
+      'uvcdn.com',
+      'washingtonpost.com',
+      'wixstatic.com',
+      'ykimg.com',
+    ];
+
+    let action_map = badger.storage.getBadgerStorageObject("action_map"),
+      snitch_map = badger.storage.getBadgerStorageObject("snitch_map");
+
+    // remove from action map
+    let actions = action_map.getItemClones();
+    for (let domain in actions) {
+      for (let i = 0; i < MISTAKES.length; i++) {
+        if (domain.endsWith(MISTAKES[i])) {
+          // remove only if domain was seen tracking
+          // and user did not set an override
+          if (actions[domain].userAction == "" && (
+            actions[domain].heuristicAction == constants.ALLOW ||
+            actions[domain].heuristicAction == constants.BLOCK ||
+            actions[domain].heuristicAction == constants.COOKIEBLOCK
+          )) {
+            action_map.deleteItem(domain);
+          }
+        }
+      }
+    }
+
+    // remove from snitch map
+    for (let domain in snitch_map.getItemClones()) {
+      for (let i = 0; i < MISTAKES.length; i++) {
+        if (domain.endsWith(MISTAKES[i])) {
+          snitch_map.deleteItem(domain);
+        }
+      }
+    }
+  },
+
 };
 
 


### PR DESCRIPTION
Following up on #1403.

I compiled the domain list from support emails and [broken site issues](https://github.com/EFForg/privacybadger/issues?q=is%3Aissue+is%3Aopen+label%3A%22broken+site%22). I looked for reports where we can't reproduce tracking by the domain but writing to localStorage by other resources on the same page as the domain is reproducible or at least seems likely. Domains that seem to be CDNs are particularly excellent candidates for forgetting.

If we are wrong about any of these domains, the good news is that Privacy Badgers will relearn to treat them as trackers soon enough.