### PR TITLE
Fix chrome.privacy.services exceptions in Firefox

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -72,20 +72,29 @@ function Badger() {
   * WebRTC availability check
   */
   function checkWebRTCBrowserSupport(){
+    if (!(chrome.privacy && chrome.privacy.network &&
+      chrome.privacy.network.webRTCIPHandlingPolicy)) {
+      return false;
+    }
+
     var available = true;
     var connection = null;
-    try{
-      var RTCPeerConnection = window.RTCPeerConnection || window.webkitRTCPeerConnection;
-      if(RTCPeerConnection){
+
+    try {
+      var RTCPeerConnection = (
+        window.RTCPeerConnection || window.webkitRTCPeerConnection
+      );
+      if (RTCPeerConnection) {
         connection = new RTCPeerConnection(null);
       }
-    } catch (ex){
+    } catch (ex) {
       available = false;
     }
 
-    if(connection !== null && connection.close){
+    if (connection !== null && connection.close) {
       connection.close();
     }
+
     return available;
   }
 }
@@ -198,7 +207,9 @@ Badger.prototype = {
    **/
   enableWebRTCProtection: function(){
     // Return early with non-supporting browsers
-    if (!chrome.privacy || !badger.webRTCAvailable) { return; }
+    if (!badger.webRTCAvailable) {
+      return;
+    }
 
     var cpn = chrome.privacy.network;
     var settings = this.storage.getBadgerStorageObject("settings_map");
@@ -585,7 +596,9 @@ Badger.prototype = {
     var self = this;
 
     // Return early with non-supporting browsers
-    if (!chrome.privacy || !badger.webRTCAvailable) { return; }
+    if (!badger.webRTCAvailable) {
+      return;
+    }
 
     chrome.privacy.network.webRTCIPHandlingPolicy.get({}, function(result) {
       self.getSettings().setItem("webRTCIPProtection",

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -25,8 +25,12 @@ exports.Migrations= {
   changePrivacySettings: function() {
     if (!chrome.extension.inIncognitoContext && chrome.privacy ) {
       console.log('changing privacy settings');
-      chrome.privacy.services.alternateErrorPagesEnabled.set({'value': false, 'scope': 'regular'});
-      chrome.privacy.websites.hyperlinkAuditingEnabled.set({'value': false, 'scope': 'regular'});
+      if (chrome.privacy.services && chrome.privacy.services.alternateErrorPagesEnabled) {
+        chrome.privacy.services.alternateErrorPagesEnabled.set({'value': false, 'scope': 'regular'});
+      }
+      if (chrome.privacy.websites && chrome.privacy.websites.hyperlinkAuditingEnabled) {
+        chrome.privacy.websites.hyperlinkAuditingEnabled.set({'value': false, 'scope': 'regular'});
+      }
     }
   },
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -78,13 +78,12 @@ function loadOptions() {
   $("#replace_social_widgets_checkbox").prop("checked", badger.isSocialWidgetReplacementEnabled());
   $("#check_dnt_policy_checkbox").click(updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", badger.isCheckingDNTPolicyEnabled());
-  if(chrome.privacy && badger.webRTCAvailable){
+
+  if (badger.webRTCAvailable) {
     $("#toggle_webrtc_mode").click(toggleWebRTCIPProtection);
     $("#toggle_webrtc_mode").prop("checked", badger.isWebRTCIPProtectionEnabled());
-  }
-
-  // Hide WebRTC-related settings for non-supporting browsers
-  if (!chrome.privacy || !badger.webRTCAvailable) {
+  } else {
+    // Hide WebRTC-related settings for non-supporting browsers
     $("#webRTCToggle").css({"visibility": "hidden", "height": 0});
     $("#settingsSuffix").css({"visibility": "hidden", "height": 0});
   }
@@ -463,7 +462,9 @@ function showTrackingDomains(domains) {
  */
 function toggleWebRTCIPProtection() {
   // Return early with non-supporting browsers
-  if (!chrome.privacy || !badger.webRTCAvailable) { return; }
+  if (!badger.webRTCAvailable) {
+    return;
+  }
   var cpn = chrome.privacy.network;
 
   cpn.webRTCIPHandlingPolicy.get({}, function(result) {


### PR DESCRIPTION
Firefox 54 (which just got promoted to stable) includes `chrome.privacy` but not `chrome.privacy.services`.