### PR TITLE
Fix popup for bigger fonts/longer translations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
+[*.css]
+indent_style = space
+indent_size = 4
+
 [*.html]
 indent_style = space
 indent_size = 4

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -111,17 +111,12 @@ var htmlUtils = exports.htmlUtils = {
     if (tabId === undefined) {
       tabId = "000";
     }
-    var trackerHtml = '' +
+
+    var trackerHtml = '<div class="body-content-inner-wrapper">' +
       '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
-      '<div class="keyContainer">' +
-      '<div class="key">' +
-      '<img class="tooltip" src="/icons/UI-icons-red.svg" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
-      '<img class="tooltip" src="/icons/UI-icons-yellow.svg" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
-      '<img class="tooltip" src="/icons/UI-icons-green.svg" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
-      '<div class="tooltipContainer"></div>' +
-      '</div></div>' +
-      '<div class="spacer"></div>' +
-      '<div id="blockedResourcesInner" class="clickerContainer"></div>';
+      '<div id="blockedResourcesInner" class="body-content clickerContainer"></div>' +
+      '</div>';
+
     return trackerHtml;
   },
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -57,11 +57,16 @@ function loadOptions() {
 
   // Add event listeners for origins container.
   $(function () {
-    $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
-    $('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
-    $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
-    $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
-    $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
+    $('#blockedResourcesContainer')
+      .on('mouseenter', '.tooltip', displayTooltip)
+      .on('mouseleave', '.tooltip', hideTooltip)
+      .on('change', 'input:radio', updateOrigin)
+      .on('click', '.userset .honeybadgerPowered', revertDomainControl)
+      .on('click', '.removeOrigin', removeOrigin);
+
+    $('.keyContainer')
+      .on('mouseenter', '.tooltip', displayTooltip)
+      .on('mouseleave', '.tooltip', hideTooltip);
   });
 
   // Display jQuery UI elements
@@ -360,6 +365,7 @@ function refreshFilterPage() {
   $("#count").text(allTrackingDomains.length);
 
   // Display tracker tooltips.
+  $(".keyContainer").removeClass("hidden");
   $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
 
   // Display tracking domains.

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -90,10 +90,15 @@ function init() {
     closeOverlay();
   });
   $(document).ready(function () {
-    $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
-    $('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
-    $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
-    $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
+    $('#blockedResourcesContainer')
+      .on('mouseenter', '.tooltip', displayTooltip)
+      .on('mouseleave', '.tooltip', hideTooltip)
+      .on('change', 'input:radio', updateOrigin)
+      .on('click', '.userset .honeybadgerPowered', revertDomainControl);
+
+    $('.keyContainer')
+      .on('mouseenter', '.tooltip', displayTooltip)
+      .on('mouseleave', '.tooltip', hideTooltip);
   });
 
   //toggle activation buttons if privacy badger is not enabled for current url
@@ -288,6 +293,7 @@ function refreshPopup(tabId) {
   }
 
   // Display tracker tooltips.
+  $(".keyContainer").removeClass("hidden");
   $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml(tabId);
 
   var printable = [];

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -287,7 +287,7 @@ function refreshPopup(tabId) {
   //TODO this is calling get action and then being used to call get Action
   var origins = badger.getAllOriginsForTab(tabId);
   if (!origins || origins.length === 0) {
-    $("#blockedResources").html(i18n.getMessage("popup_blocked"));
+    $("#blockedResources").html('<h2 id="nothing-found">' + i18n.getMessage("popup_blocked") + '</h2>');
     $('#number_trackers').text('0');
     return;
   }

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -20,11 +20,10 @@ var i18n = chrome.i18n;
 // Loads and inserts i18n strings into matching elements. Any inner HTML already in the
 // element is parsed as JSON and used as parameters to substitute into placeholders in the
 // i18n message.
-function loadI18nStrings()
-{
-  var nodes = document.querySelectorAll("[class^='i18n_']");
-  for(var i = 0; i < nodes.length; i++)
-  {
+function loadI18nStrings() {
+  // replace span contents by their class names
+  let nodes = document.querySelectorAll("[class^='i18n_']");
+  for (let i = 0; i < nodes.length; i++) {
     var arguments = JSON.parse("[" + nodes[i].textContent + "]");
     var className = nodes[i].className;
     if (className instanceof SVGAnimatedString)
@@ -35,6 +34,13 @@ function loadI18nStrings()
       nodes[i][prop] = i18n.getMessage(stringName, arguments);
     else
       nodes[i][prop] = i18n.getMessage(stringName);
+  }
+
+  // also replace tooltip attributes
+  nodes = document.querySelectorAll("[tooltip^='i18n_']");
+  for (let i = 0; i < nodes.length; i++) {
+    let tooltip = nodes[i].getAttribute('tooltip');
+    nodes[i].setAttribute('tooltip', i18n.getMessage(tooltip.slice(5)));
   }
 }
 

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -29,8 +29,9 @@ button
   bottom: 27px;
 }
 
-#pbInstructions{
-  width:450px;
+#pbInstructions {
+    margin: 5px 0 15px;
+    width: 450px;
 }
 
 #rawFilters {
@@ -78,7 +79,7 @@ button
   width: 0;
 }
 
-#blockedResourcesContainer{
+#blockedResourcesContainer, #trackingDomainSearch {
   width: 390px;
 }
 
@@ -93,4 +94,10 @@ button
 a, a:hover, a:active, a:visited{
   color: #00aaaa;
   text-decoration: underline;
+}
+
+.clickerContainer {
+    background-color: #e8e9ea;
+    max-height: 290px;
+    overflow-y: auto;
 }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -1,0 +1,96 @@
+body
+{
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  padding: 20px;
+}
+
+td
+{
+  font-size: 13px;
+  vertical-align: top;
+  text-align: left;
+}
+
+p
+{
+  margin-top: 0.5em;
+}
+
+button
+{
+  white-space: pre;
+}
+#tabs {
+  min-width: 750px;
+}
+
+.tooltipArrow {
+  bottom: 27px;
+}
+
+#pbInstructions{
+  width:450px;
+}
+
+#rawFilters {
+  display: none;
+}
+
+.okMsg {
+    display: none;
+    color: #ffffff;
+    background: #30e030;
+    font-weight: bold;
+    padding: 3px;
+}
+
+.errMsg {
+    display: none;
+    color: #ffffff;
+    background: #e03030;
+    font-weight:bold;
+    padding:3px;
+}
+
+#tab-import-export {
+  width: 750px;
+  overflow: auto;
+}
+#import {
+  width: 350px;
+  float: left;
+}
+#export {
+  width: 350px;
+  float: left;
+}
+
+/* Filter list entry status message */
+.flMsg {
+    display: none;
+    color: #b0b0b0;
+}
+
+.importInput{
+  visibility: hidden;
+  height: 0;
+  width: 0;
+}
+
+#blockedResourcesContainer{
+  width: 390px;
+}
+
+#settingsSuffix{
+  color: #555;
+  font-size: 12px;
+  width: 500px;
+  position: relative;
+  left: 50px;
+}
+
+a, a:hover, a:active, a:visited{
+  color: #00aaaa;
+  text-decoration: underline;
+}

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -25,111 +25,13 @@
 <link type="text/css" href="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.structure.min.css" rel="stylesheet" />
 <link type="text/css" href="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.theme.min.css" rel="stylesheet" />
 <link type="text/css" media="screen" href="/skin/popup.css" rel="stylesheet" />
+<link type="text/css" media="screen" href="/skin/options-layout.css" rel="stylesheet" />
 <link type="text/css" media="screen" href="/skin/toggle-switch.css" rel="stylesheet" />
 <script type="text/javascript" src="/lib/vendor/jquery-2.2.4.min.js"></script>
 <script type="text/javascript" src="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.min.js"></script>
 <script type="text/javascript" src="/lib/i18n.js" charset="utf-8"></script>
 <script type="text/javascript" src="/js/options.js" charset="utf-8"></script>
 <title class="i18n_options_title"></title>
-<style type="text/css" media="screen">
-body
-{
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 13px;
-  padding: 20px;
-}
-
-td
-{
-  font-size: 13px;
-  vertical-align: top;
-  text-align: left;
-}
-
-p
-{
-  margin-top: 0.5em;
-}
-
-button
-{
-  white-space: pre;
-}
-#tabs {
-  min-width: 750px;
-}
-
-.tooltipArrow {
-  bottom: 27px;
-}
-
-#pbInstructions{
-  width:450px;
-}
-
-#rawFilters {
-  display: none;
-}
-
-.okMsg {
-    display: none;
-    color: #ffffff;
-    background: #30e030;
-    font-weight: bold;
-    padding: 3px;
-}
-
-.errMsg {
-    display: none;
-    color: #ffffff;
-    background: #e03030;
-    font-weight:bold;
-    padding:3px;
-}
-
-#tab-import-export {
-  width: 750px;
-  overflow: auto;
-}
-#import {
-  width: 350px;
-  float: left;
-}
-#export {
-  width: 350px;
-  float: left;
-}
-
-/* Filter list entry status message */
-.flMsg {
-    display: none;
-    color: #b0b0b0;
-}
-
-.importInput{
-  visibility: hidden;
-  height: 0;
-  width: 0;
-}
-
-#blockedResourcesContainer{
-  width: 390px;
-}
-
-#settingsSuffix{
-  color: #555;
-  font-size: 12px;
-  width: 500px;
-  position: relative;
-  left: 50px;
-}
-
-a, a:hover, a:active, a:visited{
-  color: #00aaaa;
-  text-decoration: underline;
-}
-
-</style>
 </head>
 <body class="options">
 <table>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -54,19 +54,30 @@
   </ul>
 
   <div id="tab-pb-status">
-    <p class=""></p>
-    <div id="blockedResourcesContainer">
-      <p id="pbInstructions">
+
+    <p id="pbInstructions">
         <span class="i18n_options_pb_has_detected"></span>
         <span id='count'>0</span>
         <span class="i18n_options_potential"></span>
         <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?"><span class="i18n_options_tracking_domains"></span></a>
         <span class="i18n_options_so_far"></span>
-      </p>
-      <div class="spacer"></div>
-      <input id="trackingDomainSearch" type="text" value="" style="width:100%">
-      <div id="blockedResources"><span class="i18n_options_loading"></span></div>
+    </p>
+
+    <input id="trackingDomainSearch" type="text" value="">
+
+    <div class="keyContainer hidden">
+        <div class="key">
+            <img class="tooltip" src="/icons/UI-icons-red.svg" tooltip="i18n_tooltip_block"><img class="tooltip" src="/icons/UI-icons-yellow.svg" tooltip="i18n_tooltip_cookieblock"><img class="tooltip" src="/icons/UI-icons-green.svg" tooltip="i18n_tooltip_allow">
+            <div class="tooltipContainer"></div>
+        </div>
     </div>
+
+    <div id="blockedResourcesContainer">
+      <div id="blockedResources">
+          <span class="i18n_options_loading"></span>
+      </div>
+    </div>
+
   </div>
 
 

--- a/src/skin/popup-layout.css
+++ b/src/skin/popup-layout.css
@@ -1,0 +1,50 @@
+body {
+    overflow: hidden;
+    margin: 8px 8px 0;
+    padding: 0 7px;
+}
+
+.table {
+    display: table;
+}
+
+.table-row {
+    display: table-row;
+}
+
+.table-cell {
+    display: table-cell;
+}
+
+.container {
+    height: 38em;
+}
+
+.header {
+}
+
+.body {
+    height: 100%;
+}
+
+.body-content-outer-wrapper {
+    height: 100%;
+
+    vertical-align: middle;
+}
+
+.body-content-inner-wrapper {
+    height: 100%;
+    position: relative;
+    overflow: auto;
+
+    background-color: #e8e9ea;
+}
+
+.body-content {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -160,7 +160,8 @@ left: 0;
 color: #505050;
 font-size: 16px;
 }
-#privacyBadgerHeader h2{
+
+#privacyBadgerHeader h2, h2#nothing-found {
   margin: 5px;
   padding-left: 5px;
   float: left;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -59,13 +59,6 @@ a:hover { color: #ec9329 }
     padding: .6em 1em;
 }
 
-.spacer {
-  height: 7px;
-  width: 5px;
-  display: block;
-  clear: both;
-}
-
 .click-nav ul {position:relative;font-weight:900;list-style-type:none;}
 .click-nav ul li {position:relative;list-style:none;cursor:pointer;}
 .click-nav ul li ul {position:relative;}
@@ -218,31 +211,23 @@ font-size: 16px;
   background-color: #EC9329;
   color: #333;
 }
-.clickerContainer {
-  max-height: 290px;
-  overflow-y: auto;
-  background-color: #E8E9EA;
-  position: relative;
-}
+
 .key {
-  position: absolute;
-  height: 25px;
-  left: 0;
-  right: 0;
-  z-index: 30;
-  background: #fefefe;
-  padding-top: 4px;
-  padding-left: 215px;
+    position: relative;
+    padding: 4px 0 5px 215px;
 }
-.key img{
-  margin-left: 19px;
+
+.key img {
+    margin-left: 19px;
 }
-.key .tooltipContainer{
-  position: absolute;
-  left: 3px;
-  top:-1;
-  box-shadow: 0px 5px 5px #000;
+
+.key .tooltipContainer {
+    position: absolute;
+    left: 3px;
+    top: -1px;
+    box-shadow: 0px 5px 5px #000;
 }
+
 #instruction-outer {
   display: none;
   position: fixed;
@@ -284,9 +269,6 @@ font-size: 16px;
   float: right;
   padding-right: 5px;
   padding-top: 7px;
-}
-.clickerContainer{
-  margin-top: 25px;
 }
 #pbInstructions{
   color: #505050;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -26,6 +26,7 @@
 <link type="text/css" href="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.structure.min.css" rel="stylesheet" />
 <link type="text/css" href="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.theme.min.css" rel="stylesheet" />
 <link type="text/css" media="screen" href="/skin/popup.css" rel="stylesheet" />
+<link type="text/css" media="screen" href="/skin/popup-layout.css" rel="stylesheet" />
 <link type="text/css" media="screen" href="/skin/toggle-switch.css" rel="stylesheet" />
 <script type="text/javascript" src="/lib/vendor/jquery-2.2.4.min.js"></script>
 <script type="text/javascript" src="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.min.js"></script>
@@ -62,25 +63,45 @@
   </div>
 <div id="mustReloadMsg" style="display:none"><span class="i18n_new_filters_added"></span></div>
 
-<div id='privacyBadgerHeader'>
-  <a id="options" title="options" href='/skin/options.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/options.svg'></a>
-  <a id="help" title="help" href='/skin/firstRun.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/help.svg'></a>
-  <div id='title'><img src='/icons/badger-48.png'> <h2><span class="i18n_privacy_badger"></span></h2></div>
-  <div class='clear'></div>
-  <div id="subtitle"><span id="version" class="i18n_version"></span></div>
-</div>
-<div id="blockedResourcesContainer">
-  <p id="pbInstructions"> <span class="i18n_pb_detected"></span> <span id='number_trackers'></span> <span class="i18n_popup_instructions"></span></p>
-  <div class="spacer"></div>
-  <div id="blockedResources"><span class="options_loading"></span></div>
+<!-- flexible div layout from https://stackoverflow.com/a/28634506 -->
+<div class="table container">
+    <div class="table-row header">
+
+        <div id='privacyBadgerHeader'>
+            <a id="options" title="options" href='/skin/options.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/options.svg'></a>
+            <a id="help" title="help" href='/skin/firstRun.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/help.svg'></a>
+            <div id="title">
+                <img src="/icons/badger-48.png">
+                <h2><span class="i18n_privacy_badger"></span></h2>
+            </div>
+            <div class='clear'></div>
+            <div id="subtitle"><span id="version" class="i18n_version"></span></div>
+        </div>
+
+        <p id="pbInstructions"> <span class="i18n_pb_detected"></span> <span id='number_trackers'></span> <span class="i18n_popup_instructions"></span></p>
+
+        <div class="keyContainer hidden">
+            <div class="key">
+                <img class="tooltip" src="/icons/UI-icons-red.svg" tooltip="i18n_tooltip_block"><img class="tooltip" src="/icons/UI-icons-yellow.svg" tooltip="i18n_tooltip_cookieblock"><img class="tooltip" src="/icons/UI-icons-green.svg" tooltip="i18n_tooltip_allow">
+                <div class="tooltipContainer"></div>
+            </div>
+        </div>
+
+    </div>
+
+    <div id="blockedResourcesContainer" class="table-row body">
+        <div id="blockedResources" class="table-cell body-content-outer-wrapper">
+            <span class="options_loading"></span>
+        </div>
+    </div>
+
+    <div id="siteControls" class="table-row">
+        <center><button id="deactivate_site_btn" class="pbButton" style="display:block"><span class="i18n_popup_disable_for_site"></span></button></center>
+        <center><button id="activate_site_btn" class="pbButton" style="display:none"> <span class="i18n_popup_enable_for_site"></span></button></center>
+        <center><button id="error" class="pbButton" style="display:block" target="blank"><span class="i18n_report_broken_site"></span></button></center>
+        <center><button id="donate" class="pbButton" style="display:block" target="blank"><span class="i18n_donate_to_eff"></span></button></center>
+    </div>
 </div>
 
-<div id="siteControls">
-    <center><button id="deactivate_site_btn" class="pbButton" style="display:block"><span class="i18n_popup_disable_for_site"></span></button></center>
-  <center><button id="activate_site_btn" class="pbButton" style="display:none"> <span class="i18n_popup_enable_for_site"></span></button></center>
-  <center><button id="error" class="pbButton" style="display:block" target="blank"><span class="i18n_report_broken_site"></span></button></center>
-  <center><button id="donate" class="pbButton" style="display:block" target="blank"><span class="i18n_donate_to_eff"></span></button></center>
-</div>
-<div class='clear'></div>
 </body>
 </html>


### PR DESCRIPTION
Fixes #1113, fixes #1077.

The goal is to at least support 110% and 125% page zoom settings in Chrome (and equivalent (up to 1.25?) `layout.css.devPixelsPerPx` `about:config` values in Firefox)