### PR TITLE
Performance improvements/optimizations (#1371)

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -479,9 +479,7 @@ Badger.prototype = {
     return self.getAllOriginsForTab(tabId)
       .reduce(function(memo,origin){
         var action = self.storage.getBestAction(origin);
-        if(action && (action == constants.USER_BLOCK || action ==
-                    constants.BLOCK || action == constants.COOKIEBLOCK ||
-                    action == constants.USER_COOKIE_BLOCK)){
+        if(action && _.contains(constants.BLOCKED_ACTIONS, action)){
           memo+=1;
         }
         return memo;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -731,14 +731,6 @@ Badger.prototype = {
 /**************************** Listeners ****************************/
 
 function startBackgroundListeners() {
-  // TODO Remove this.
-  // chrome.webRequest.onBeforeRequest.addListener(function(details) {
-  //   if (details.tabId != -1){
-  //     badger.updateCount(details);
-  //   }
-  // }, {urls: ["http://*/*", "https://*/*"]}, []);
-
-
   // Update icon if a tab changes location
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -732,11 +732,12 @@ Badger.prototype = {
 /**************************** Listeners ****************************/
 
 function startBackgroundListeners() {
-  chrome.webRequest.onBeforeRequest.addListener(function(details) {
-    if (details.tabId != -1){
-      badger.updateCount(details);
-    }
-  }, {urls: ["http://*/*", "https://*/*"]}, []);
+  // TODO Remove this.
+  // chrome.webRequest.onBeforeRequest.addListener(function(details) {
+  //   if (details.tabId != -1){
+  //     badger.updateCount(details);
+  //   }
+  // }, {urls: ["http://*/*", "https://*/*"]}, []);
 
 
   // Update icon if a tab changes location

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -788,7 +788,6 @@ var badger = window.badger = new Badger();
 */
 incognito.startListeners();
 webrequest.startListeners();
-HeuristicBlocking.startListeners();
 startBackgroundListeners();
 
 console.log('Privacy badger is ready to rock!');

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -479,7 +479,7 @@ Badger.prototype = {
     return self.getAllOriginsForTab(tabId)
       .reduce(function(memo,origin){
         var action = self.storage.getBestAction(origin);
-        if(action && _.contains(constants.BLOCKED_ACTIONS, action)){
+        if(action && constants.BLOCKED_ACTIONS.hasOwnProperty(action)){
           memo+=1;
         }
         return memo;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -508,14 +508,13 @@ Badger.prototype = {
 
   /**
    * Checks conditions for updating page action badge and call updateBadge
-   * @param {Object} details details object from onBeforeRequest event
+   * @param {Object} tabId The tab ID whose badge we want to update.
    */
-  updateCount: function(details) {
-    if(!this.isPrivacyBadgerEnabled(webrequest.getHostForTab(details.tabId))){
+  updateCount: function(tabId) {
+    if(!this.isPrivacyBadgerEnabled(webrequest.getHostForTab(tabId))){
       return;
     }
 
-    var tabId = details.tabId;
     if (!this.tabData[tabId]) {
       return;
     }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -29,13 +29,6 @@ var exports = {
   USER_BLOCK: "user_block",
   USER_COOKIE_BLOCK: "user_cookieblock",
 
-  BLOCKED_ACTIONS: {
-    "block": true,
-    "cookieblock": true,
-    "user_block": true,
-    "user_cookieblock": true
-  },
-
   // URLS
   DNT_POLICIES_URL: "https://www.eff.org/files/dnt-policies.json",
   COOKIE_BLOCK_LIST_URL: "https://www.eff.org/files/cookieblocklist_new.txt",
@@ -45,6 +38,13 @@ var exports = {
   MAX_COOKIE_ENTROPY: 12,
 
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
+};
+
+exports.BLOCKED_ACTIONS = {
+  [exports.BLOCK]: true,
+  [exports.USER_BLOCK]: true,
+  [exports.COOKIEBLOCK]: true,
+  [exports.USER_COOKIE_BLOCK]: true
 };
 
 return exports;

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -29,6 +29,13 @@ var exports = {
   USER_BLOCK: "user_block",
   USER_COOKIE_BLOCK: "user_cookieblock",
 
+  BLOCKED_ACTIONS: [
+    "block",
+    "cookieblock",
+    "user_block",
+    "user_cookieblock"
+  ],
+
   // URLS
   DNT_POLICIES_URL: "https://www.eff.org/files/dnt-policies.json",
   COOKIE_BLOCK_LIST_URL: "https://www.eff.org/files/cookieblocklist_new.txt",

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -29,12 +29,12 @@ var exports = {
   USER_BLOCK: "user_block",
   USER_COOKIE_BLOCK: "user_cookieblock",
 
-  BLOCKED_ACTIONS: [
-    "block",
-    "cookieblock",
-    "user_block",
-    "user_cookieblock"
-  ],
+  BLOCKED_ACTIONS: {
+    "block": true,
+    "cookieblock": true,
+    "user_block": true,
+    "user_cookieblock": true
+  },
 
   // URLS
   DNT_POLICIES_URL: "https://www.eff.org/files/dnt-policies.json",

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -510,27 +510,6 @@ function startListeners() {
       return {};
     }
   }, {urls: ["<all_urls>"]}, ["requestHeaders"]);
-
-  /**
-   * Adds onResponseStarted listener. Monitor for cookies
-   */
-  chrome.webRequest.onResponseStarted.addListener(function(details) {
-    var hasSetCookie = false;
-    for(var i = 0; i < details.responseHeaders.length; i++) {
-      if(details.responseHeaders[i].name.toLowerCase() == "set-cookie") {
-        hasSetCookie = true;
-        break;
-      }
-    }
-    if(hasSetCookie) {
-      if (badger) {
-        return badger.heuristicBlocking.heuristicBlockingAccounting(details);
-      } else {
-        return {};
-      }
-    }
-  },
-  {urls: ["<all_urls>"]}, ["responseHeaders"]);
 }
 
 /************************************** exports */

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -499,23 +499,9 @@ function hasCookieTracking(details, origin) {
   return false;
 }
 
-function startListeners() {
-  /**
-   * Adds heuristicBlockingAccounting as listened to onBeforeSendHeaders request
-   */
-  chrome.webRequest.onBeforeSendHeaders.addListener(function(details) {
-    if (badger) {
-      return badger.heuristicBlocking.heuristicBlockingAccounting(details);
-    } else {
-      return {};
-    }
-  }, {urls: ["<all_urls>"]}, ["requestHeaders"]);
-}
-
 /************************************** exports */
 var exports = {};
 exports.HeuristicBlocker = HeuristicBlocker;
-exports.startListeners = startListeners;
 exports.hasCookieTracking = hasCookieTracking;
 return exports;
 /************************************** exports */

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -119,7 +119,7 @@ function onBeforeRequest(details){
 function onBeforeSendHeaders(details) {
   if (badger) {
     setTimeout(function() {
-      return badger.heuristicBlocking.heuristicBlockingAccounting(details);
+      badger.heuristicBlocking.heuristicBlockingAccounting(details);
     }, 0);
   }
 
@@ -536,7 +536,9 @@ function checkAction(tabId, url, quiet, frameId){
   if (action && ! quiet) {
     badger.logTrackerOnTab(tabId, requestHost, action);
     if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
-      setTimeout(badger.updateCount(tabId), 0);
+      setTimeout(function() {
+        badger.updateCount(tabId)
+      }, 0);
     }
   }
   return action;

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -118,6 +118,12 @@ function onBeforeRequest(details){
  * @returns {*} modified headers
  */
 function onBeforeSendHeaders(details) {
+  if (badger) {
+    setTimeout(function() {
+      return badger.heuristicBlocking.heuristicBlockingAccounting(details);
+    }, 0);
+  }
+
   let frame_id = details.frameId,
     headers = details.requestHeaders,
     tab_id = details.tabId,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -103,7 +103,7 @@ function onBeforeRequest(details){
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
-      badger.updateCount(details);
+      badger.updateCount(details.tabId);
       return {cancel: true};
     }
   }
@@ -179,7 +179,7 @@ function onBeforeSendHeaders(details) {
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
-      badger.updateCount(details);
+      badger.updateCount(details.tabId);
       return {cancel: true};
     }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -46,36 +46,36 @@ var temporarySocialWidgetUnblock = {};
  * @returns {*} Can cancel requests
  */
 function onBeforeRequest(details){
-  var frameId = details.frameId,
-    tabId = details.tabId,
+  var frame_id = details.frameId,
+    tab_id = details.tabId,
     type = details.type,
     url = details.url;
 
   if (type == "main_frame"){
-    forgetTab(tabId);
+    forgetTab(tab_id);
   }
 
   if (type == "main_frame" || type == "sub_frame"){
     // Firefox workaround: https://bugzilla.mozilla.org/show_bug.cgi?id=1329299
     // TODO remove after Firefox 51 is no longer in use
-    if (type == "main_frame" && frameId != 0) {
-      frameId = 0;
+    if (type == "main_frame" && frame_id != 0) {
+      frame_id = 0;
     }
-    recordFrame(tabId, frameId, details.parentFrameId, url);
+    recordFrame(tab_id, frame_id, details.parentFrameId, url);
   }
 
   // Block ping requests sent by navigator.sendBeacon (see, #587)
   // tabId for pings are always -1 due to Chrome bugs #522124 and #522129
   // Once these bugs are fixed, PB will treat pings as any other request
-  if (type == "ping" && tabId < 0 ){
+  if (type == "ping" && tab_id < 0 ){
     return {cancel: true};
   }
 
-  if ( _isTabChromeInternal(tabId)){
+  if ( _isTabChromeInternal(tab_id)){
     return {};
   }
 
-  var tabDomain = getHostForTab(tabId);
+  var tabDomain = getHostForTab(tab_id);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -86,7 +86,7 @@ function onBeforeRequest(details){
     return {};
   }
 
-  var requestAction = checkAction(tabId, url, false, frameId);
+  var requestAction = checkAction(tab_id, url, false, frame_id);
   if (requestAction) {
     if (requestAction == constants.BLOCK || requestAction == constants.USER_BLOCK) {
       if (type == 'script') {
@@ -101,7 +101,7 @@ function onBeforeRequest(details){
         replaceSocialWidget: true,
         trackerDomain: requestDomain
       };
-      chrome.tabs.sendMessage(tabId, msg);
+      chrome.tabs.sendMessage(tab_id, msg);
 
       return {cancel: true};
     }
@@ -123,13 +123,13 @@ function onBeforeSendHeaders(details) {
     }, 0);
   }
 
-  let frameId = details.frameId,
+  let frame_id = details.frameId,
     headers = details.requestHeaders,
-    tabId = details.tabId,
+    tab_id = details.tabId,
     type = details.type,
     url = details.url;
 
-  if (_isTabChromeInternal(tabId)) {
+  if (_isTabChromeInternal(tab_id)) {
     // DNT policy requests: strip cookies
     if (type == "xmlhttprequest" && url.endsWith("/.well-known/dnt-policy.txt")) {
       // remove Cookie headers
@@ -147,18 +147,18 @@ function onBeforeSendHeaders(details) {
     return {};
   }
 
-  var tabDomain = getHostForTab(tabId);
+  var tabDomain = getHostForTab(tab_id);
   var requestDomain = window.extractHostFromURL(url);
 
   if (badger.isPrivacyBadgerEnabled(tabDomain) && 
       isThirdPartyDomain(requestDomain, tabDomain)) {
-    var requestAction = checkAction(tabId, url, false, frameId);
+    var requestAction = checkAction(tab_id, url, false, frame_id);
     // If this might be the third strike against the potential tracker which
     // would cause it to be blocked we should check immediately if it will be blocked.
     if (requestAction == constants.ALLOW && 
         badger.storage.getTrackingCount(requestDomain) == constants.TRACKING_THRESHOLD - 1){
       badger.heuristicBlocking.heuristicBlockingAccounting(details);
-      requestAction = checkAction(tabId, url, false, frameId);
+      requestAction = checkAction(tab_id, url, false, frame_id);
     }
 
     // This will only happen if the above code sets the action for the request
@@ -176,7 +176,7 @@ function onBeforeSendHeaders(details) {
         replaceSocialWidget: true,
         trackerDomain: requestDomain
       };
-      chrome.tabs.sendMessage(tabId, msg);
+      chrome.tabs.sendMessage(tab_id, msg);
 
       return {cancel: true};
     }
@@ -203,10 +203,10 @@ function onBeforeSendHeaders(details) {
  * @returns {*} The new response header
  */
 function onHeadersReceived(details) {
-  var tabId = details.tabId,
+  var tab_id = details.tabId,
     url = details.url;
 
-  if (_isTabChromeInternal(tabId)) {
+  if (_isTabChromeInternal(tab_id)) {
     // DNT policy responses: strip cookies, reject redirects
     if (details.type == "xmlhttprequest" && url.endsWith("/.well-known/dnt-policy.txt")) {
       // if it's a redirect, cancel it
@@ -232,7 +232,7 @@ function onHeadersReceived(details) {
     return {};
   }
 
-  var tabDomain = getHostForTab(tabId);
+  var tabDomain = getHostForTab(tab_id);
   var requestDomain = window.extractHostFromURL(url);
    
   if (badger.isPrivacyBadgerDisabled(tabDomain)) {
@@ -243,7 +243,7 @@ function onHeadersReceived(details) {
     return {};
   }
 
-  var requestAction = checkAction(tabId, url, false, details.frameId);
+  var requestAction = checkAction(tab_id, url, false, details.frameId);
   if (requestAction) {
     if (requestAction == constants.COOKIEBLOCK || requestAction == constants.USER_COOKIE_BLOCK) {
       var newHeaders = details.responseHeaders.filter(function(header) {
@@ -454,14 +454,14 @@ function recordFingerprinting(tabId, msg) {
 /**
  * Read the frame data from memory
  *
- * @param tabId Tab ID to check for
- * @param frameId Frame ID to check for
+ * @param tab_id Tab ID to check for
+ * @param frame_id Frame ID to check for
  * @returns {*} Frame data object or null
  */
-function getFrameData(tabId, frameId) {
-  if (badger.tabData.hasOwnProperty(tabId)) {
-    if (badger.tabData[tabId].frames.hasOwnProperty(frameId)) {
-      return badger.tabData[tabId].frames[frameId];
+function getFrameData(tab_id, frame_id) {
+  if (badger.tabData.hasOwnProperty(tab_id)) {
+    if (badger.tabData[tab_id].frames.hasOwnProperty(frame_id)) {
+      return badger.tabData[tab_id].frames[frame_id];
     }
   }
   return null;

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -266,6 +266,15 @@ function onTabRemoved(tabId){
 }
 
 /**
+ * Event handler to update the badge when the tab is updated.
+ *
+ * @param {Integer} tabId Id of the tab
+ */
+function onTabUpdated(tabId){
+  badger.updateBadge(tabId);
+}
+
+/**
  * Update internal db on tabs when a tab gets replaced
  *
  * @param {Integer} addedTabId The new tab id that replaces
@@ -706,6 +715,7 @@ function startListeners() {
   chrome.webRequest.onHeadersReceived.addListener(onHeadersReceived, {urls: ["<all_urls>"]}, ["responseHeaders", "blocking"]);
   chrome.tabs.onRemoved.addListener(onTabRemoved);
   chrome.tabs.onReplaced.addListener(onTabReplaced);
+  chrome.tabs.onUpdated.addListener(onTabUpdated);
   chrome.runtime.onMessage.addListener(dispatcher);
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -103,6 +103,7 @@ function onBeforeRequest(details){
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
+      badger.updateCount(details);
       return {cancel: true};
     }
   }
@@ -147,7 +148,7 @@ function onBeforeSendHeaders(details) {
   if (badger.isPrivacyBadgerEnabled(tabDomain) && 
       isThirdPartyDomain(requestDomain, tabDomain)) {
     var requestAction = checkAction(tab_id, url, false, frame_id);
-    // If this might be the third stike against the potential tracker which
+    // If this might be the third strike against the potential tracker which
     // would cause it to be blocked we should check immediately if it will be blocked.
     if (requestAction == constants.ALLOW && 
         badger.storage.getTrackingCount(requestDomain) == constants.TRACKING_THRESHOLD - 1){
@@ -172,6 +173,7 @@ function onBeforeSendHeaders(details) {
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
+      badger.updateCount(details);
       return {cancel: true};
     }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -535,7 +535,7 @@ function checkAction(tabId, url, quiet, frameId){
 
   if (action && ! quiet) {
     badger.logTrackerOnTab(tabId, requestHost, action);
-    if (_.contains(constants.BLOCKED_ACTIONS, action)) {
+    if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
       setTimeout(badger.updateCount(tabId), 0);
     }
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -103,7 +103,6 @@ function onBeforeRequest(details){
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
-      badger.updateCount(details.tabId);
       return {cancel: true};
     }
   }
@@ -179,7 +178,6 @@ function onBeforeSendHeaders(details) {
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
-      badger.updateCount(details.tabId);
       return {cancel: true};
     }
 
@@ -537,6 +535,9 @@ function checkAction(tabId, url, quiet, frameId){
 
   if (action && ! quiet) {
     badger.logTrackerOnTab(tabId, requestHost, action);
+    if (_.contains(constants.BLOCKED_ACTIONS, action)) {
+      badger.updateCount(tabId);
+    }
   }
   return action;
 }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -536,7 +536,7 @@ function checkAction(tabId, url, quiet, frameId){
   if (action && ! quiet) {
     badger.logTrackerOnTab(tabId, requestHost, action);
     if (_.contains(constants.BLOCKED_ACTIONS, action)) {
-      badger.updateCount(tabId);
+      setTimeout(badger.updateCount(tabId), 0);
     }
   }
   return action;


### PR DESCRIPTION
Tweaks relating to #1371.
This PR includes the following:

1) Removal of `onResponseStarted` listener, as this behavior is handled in the `onBeforeSendHeaders` listener. Tested to verify that it is indeed not needed.
2) Migration of `updateCount` listener from an event listener to places in the code where we actually cancel requests. NB: This change currently prevents the green `0` badge counter from showing, as it will not be triggered if no requests take place. I can think of a couple workarounds to this (_e.g._ calling this when the "tab" is updated), though nothing is currently implemented.
3) Moving of non-blocking `onBeforeSendHeaders` listener in `heuristicblocking.js` into the same listener in `webrequest.js`.

I've done some performance benchmarking of this, but I'm finding it very challenging to find reliable results. I've been doing 5 page loads in a row for the current production version, then for this version, then comparing the results. However, when I rerun this same experiment I'm finding the results can be wildly different for both. I haven't found this version to be any slower than the production version in any cases, though I haven't been able to gather sufficiently concrete statistics as to what the speedup might be, if any. Any tips here would be greatly appreciated.

The ratio is about 3:1 / 4:1 in terms of Chrome extensions overhead to Privacy Badger application code. This means for each 100ms of CPU time consumed by Privacy Badger, it costs about 300-400ms of CPU time in internal calls.

Lastly, with the `onBeforeRequest`, `onBeforeSendHeaders` and `onHeadersReceived` listeners all being required, there is a limit to how much we can speed things up. I see room for some more modest improvements in Privacy Badger's, but it is unlikely we'll get rid of the huge plateau with the current blocking model (_i.e._ up to 3 blocking event listeners for each request).

![cpu plateau](https://user-images.githubusercontent.com/11308076/27505825-79258500-585e-11e7-80c8-460f9ff735a5.png)