### PR TITLE
Refactoring of listeners

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -744,6 +744,7 @@ function startBackgroundListeners() {
     if(changeInfo.status == "loading") {
       badger.refreshIconAndContextMenu(tab);
     }
+    incognito.onUpdated(tabId, changeInfo, tab);
   });
 
   // Update icon if a tab is replaced or loaded from cache

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -787,7 +787,6 @@ var badger = window.badger = new Badger();
 */
 incognito.startListeners();
 webrequest.startListeners();
-HeuristicBlocking.startListeners();
 startBackgroundListeners();
 
 console.log('Privacy badger is ready to rock!');

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -747,13 +747,6 @@ function startBackgroundListeners() {
     incognito.onUpdated(tab);
   });
 
-  // Update icon if a tab is replaced or loaded from cache
-  chrome.tabs.onReplaced.addListener(function(addedTabId/*, removedTabId*/){
-    chrome.tabs.get(addedTabId, function(tab){
-      badger.refreshIconAndContextMenu(tab);
-    });
-  });
-
   // Listening for Avira Autopilot remote control UI
   // The Scout browser needs a "emergency off" switch in case Privacy Badger breaks a page.
   // The Privacy Badger UI will removed from the URL bar into the menu to achieve a cleaner UI in the future.

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -744,7 +744,7 @@ function startBackgroundListeners() {
     if(changeInfo.status == "loading") {
       badger.refreshIconAndContextMenu(tab);
     }
-    incognito.onUpdated(tabId, changeInfo, tab);
+    incognito.onUpdated(tab);
   });
 
   // Update icon if a tab is replaced or loaded from cache

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -786,7 +786,6 @@ var badger = window.badger = new Badger();
 /**
 * Start all the listeners
 */
-incognito.startListeners();
 webrequest.startListeners();
 startBackgroundListeners();
 

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -510,27 +510,6 @@ function startListeners() {
       return {};
     }
   }, {urls: ["<all_urls>"]}, ["requestHeaders"]);
-
-  /**
-   * Adds onResponseStarted listener. Monitor for cookies
-   */
-  chrome.webRequest.onResponseStarted.addListener(function(details) {
-    var hasSetCookie = false;
-    for(var i = 0; i < details.responseHeaders.length; i++) {
-      if(details.responseHeaders[i].name.toLowerCase() == "set-cookie") {
-        hasSetCookie = true;
-        break;
-      }
-    }
-    if(hasSetCookie) {
-      if (badger) {
-        return badger.heuristicBlocking.heuristicBlockingAccounting(details);
-      } else {
-        return {};
-      }
-    }
-  },
-  {urls: ["<all_urls>"]}, ["responseHeaders"]);
 }
 
 /************************************** exports */

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -499,23 +499,9 @@ function hasCookieTracking(details, origin) {
   return false;
 }
 
-function startListeners() {
-  /**
-   * Adds heuristicBlockingAccounting as listened to onBeforeSendHeaders request
-   */
-  chrome.webRequest.onBeforeSendHeaders.addListener(function(details) {
-    if (badger) {
-      return badger.heuristicBlocking.heuristicBlockingAccounting(details);
-    } else {
-      return {};
-    }
-  }, {urls: ["<all_urls>"]}, ["requestHeaders"]);
-}
-
 /************************************** exports */
 var exports = {};
 exports.HeuristicBlocker = HeuristicBlocker;
-exports.startListeners = startListeners;
 exports.hasCookieTracking = hasCookieTracking;
 return exports;
 /************************************** exports */

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -8,12 +8,12 @@ chrome.tabs.query({}, function(results) {
   });
 });
 
-// Create tab event listeners
-function onUpdatedListener(tabId, changeInfo, tab) {
+// Tab event handlers
+function onUpdatedHandler(tab) {
   tabs[tab.id] = tab.incognito;
 }
 
-function onRemovedListener(tabId) {
+function onRemovedHandler(tabId) {
   delete tabs[tabId];
 }
 
@@ -23,8 +23,8 @@ function tabIsIncognito(tabId) {
 
 /************************************** exports */
 var exports = {};
-exports.onRemoved = onRemovedListener;
-exports.onUpdated = onUpdatedListener;
+exports.onRemoved = onRemovedHandler;
+exports.onUpdated = onUpdatedHandler;
 exports.tabIsIncognito = tabIsIncognito;
 
 return exports;

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -17,19 +17,12 @@ function onRemovedListener(tabId) {
   delete tabs[tabId];
 }
 
-// Subscribe to tab events
-function startListeners() {
-  chrome.tabs.onUpdated.addListener(onUpdatedListener);
-  chrome.tabs.onRemoved.addListener(onRemovedListener);
-}
-
 function tabIsIncognito(tabId) {
   return tabs[tabId] || false;
 }
 
 /************************************** exports */
 var exports = {};
-exports.startListeners = startListeners;
 exports.onRemoved = onRemovedListener;
 exports.onUpdated = onUpdatedListener;
 exports.tabIsIncognito = tabIsIncognito;

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -9,11 +9,11 @@ chrome.tabs.query({}, function(results) {
 });
 
 // Tab event handlers
-function onUpdatedHandler(tab) {
+function onUpdated(tab) {
   tabs[tab.id] = tab.incognito;
 }
 
-function onRemovedHandler(tabId) {
+function onRemoved(tabId) {
   delete tabs[tabId];
 }
 
@@ -23,8 +23,8 @@ function tabIsIncognito(tabId) {
 
 /************************************** exports */
 var exports = {};
-exports.onRemoved = onRemovedHandler;
-exports.onUpdated = onUpdatedHandler;
+exports.onRemoved = onRemoved;
+exports.onUpdated = onUpdated;
 exports.tabIsIncognito = tabIsIncognito;
 
 return exports;

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -30,6 +30,8 @@ function tabIsIncognito(tabId) {
 /************************************** exports */
 var exports = {};
 exports.startListeners = startListeners;
+exports.onRemoved = onRemovedListener;
+exports.onUpdated = onUpdatedListener;
 exports.tabIsIncognito = tabIsIncognito;
 
 return exports;

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -263,6 +263,7 @@ function onHeadersReceived(details) {
  */
 function onTabRemoved(tabId){
   forgetTab(tabId);
+  incognito.tabRemoved(tabId);
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -117,6 +117,12 @@ function onBeforeRequest(details){
  * @returns {*} modified headers
  */
 function onBeforeSendHeaders(details) {
+  if(badger) {
+    setTimeout(function() {
+      badger.heuristicBlocking.heuristicBlockingAccounting(details);
+    }, 0);
+  }
+
   let frame_id = details.frameId,
     headers = details.requestHeaders,
     tab_id = details.tabId,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -274,6 +274,12 @@ function onTabRemoved(tabId){
  */
 function onTabReplaced(addedTabId, removedTabId){
   forgetTab(removedTabId);
+
+  // Update icon if a tab is replaced or loaded from cache
+  chrome.tabs.get(addedTabId, function(tab){
+    badger.refreshIconAndContextMenu(tab);
+  });
+  
   // Update the badge of the added tab, which was probably used for prerendering.
   badger.updateBadge(addedTabId);
 }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -263,7 +263,7 @@ function onHeadersReceived(details) {
  */
 function onTabRemoved(tabId){
   forgetTab(tabId);
-  incognito.tabRemoved(tabId);
+  incognito.onRemoved(tabId);
 }
 
 /**


### PR DESCRIPTION
This contains the listener refactoring present in #1455 sans anything relating to the badge.

- Remove `onResponseStarted` listener
- Merge `onBeforeRequest`, `onUpdated`, `onReplaced` and `onRemoved` listeners (the latter 3 being for `chrome.tabs`).

Please check as to whether my refactoring of the listeners present in `incognito.js` makes sense.