### PR TITLE
Refactoring how badge count is calculated and updated

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -519,7 +519,6 @@ Badger.prototype = {
 
     let thisTab = this.tabData[tabId];
     let numBlocked = thisTab ? thisTab.blockedCount : 0;
-    console.log("numBlocked: " + numBlocked);
 
     if(numBlocked === 0){
       chrome.browserAction.setBadgeBackgroundColor({tabId: tabId, color: "#00cc00"});

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -548,28 +548,27 @@ Badger.prototype = {
 
   /**
    * Checks conditions for updating page action badge and call updateBadge
-   * @param {Object} details details object from onBeforeRequest event
+   * @param {Object} tab_id ID of the tab we want to update the badge on
    */
-  updateCount: function(details) {
-    if(!this.isPrivacyBadgerEnabled(webrequest.getHostForTab(details.tabId))){
+  updateCount: function(tab_id) {
+    if(!this.isPrivacyBadgerEnabled(webrequest.getHostForTab(tab_id))){
       return;
     }
 
-    var tabId = details.tabId;
-    if (!this.tabData[tabId]) {
+    if (!this.tabData[tab_id]) {
       return;
     }
-    if(this.tabData[tabId].bgTab === true){
+    if(this.tabData[tab_id].bgTab === true){
       // prerendered tab, Chrome will throw error for setBadge functions, don't call
       return;
     } else {
       var badger = this;
-      chrome.tabs.get(tabId, function(/*tab*/){
+      chrome.tabs.get(tab_id, function(/*tab*/){
         if (chrome.runtime.lastError){
-          badger.tabData[tabId].bgTab = true;
+          badger.tabData[tab_id].bgTab = true;
         } else {
-          badger.tabData[tabId].bgTab = false;
-          badger.updateBadge(tabId);
+          badger.tabData[tab_id].bgTab = false;
+          badger.updateBadge(tab_id);
         }
       });
     }
@@ -771,12 +770,6 @@ Badger.prototype = {
 /**************************** Listeners ****************************/
 
 function startBackgroundListeners() {
-  chrome.webRequest.onBeforeRequest.addListener(function(details) {
-    if (details.tabId != -1){
-      badger.updateCount(details);
-    }
-  }, {urls: ["http://*/*", "https://*/*"]}, []);
-
   // Update icon if a tab changes location
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -504,34 +504,6 @@ Badger.prototype = {
   },
 
   /**
-   * count of blocked origins for a given tab
-   * @param {Integer} tabId chrome tab id
-   * @return {Integer} count of blocked origins
-   */
-  blockedOriginCount: function(tabId) {
-    return this.getAllOriginsForTab(tabId).length;
-  },
-
-  /**
-   * Counts total blocked trackers and blocked cookies trackers
-   * TODO: ugly code, refactor
-   *
-   * @param tabId Tab ID to count for
-   * @returns {Integer} The sum of blocked trackers and cookie blocked trackers
-   */
-  blockedTrackerCount: function(tabId){
-    var self = this;
-    return self.getAllOriginsForTab(tabId)
-      .reduce(function(memo,origin){
-        var action = self.storage.getBestAction(origin);
-        if(action && constants.BLOCKED_ACTIONS.hasOwnProperty(action)){
-          memo+=1;
-        }
-        return memo;
-      }, 0);
-  },
-
-  /**
    * Update page action badge with current count
    * @param {Integer} tabId chrome tab id
    */

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -501,13 +501,13 @@ Badger.prototype = {
    * Update page action badge with current count
    * @param {Integer} tabId chrome tab id
    */
-  updateBadge: function(tabId){
+  updateBadge: function(tabId, disabled) {
     if(FirefoxAndroid.isUsed){
       return;
     }
 
     let thisTab = this.tabData[tabId];
-    if (!this.showCounter() || !thisTab) {
+    if (!this.showCounter() || !thisTab || disabled) {
       chrome.browserAction.setBadgeText({tabId: tabId, text: ""});
       return;
     }
@@ -743,7 +743,11 @@ function startBackgroundListeners() {
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {
       badger.refreshIconAndContextMenu(tab);
-      badger.updateBadge(tabId);
+      if (badger.isPrivacyBadgerDisabled(webrequest.getHostForTab(tabId))) {
+        badger.updateBadge(tabId, true);
+      } else {
+        badger.updateBadge(tabId);
+      }
     }
   });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -488,7 +488,7 @@ Badger.prototype = {
 
 
 /**
-   * Helper function returns a list of all blocked origins for a tab
+   * Helper function returns a list of all third party origins for a tab
    * @param {Integer} tabId requested tab id as provided by chrome
    * @returns {*} A dictionary of third party origins and their actions
    */

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -719,7 +719,7 @@ Badger.prototype = {
   logThirdPartyOriginOnTab: function(tabId, fqdn, action) {
     if(!this.tabData[tabId].origins.hasOwnProperty(fqdn)) {
       this.tabData[tabId].origins[fqdn] = action;
-      if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
+      if (constants.BLOCKED_ACTIONS.has(action)) {
         this.tabData[tabId].blockedCount += 1;
         return true;
       }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -506,14 +506,13 @@ Badger.prototype = {
       return;
     }
 
-    if (!this.showCounter()){
+    let thisTab = this.tabData[tabId];
+    if (!this.showCounter() || !thisTab) {
       chrome.browserAction.setBadgeText({tabId: tabId, text: ""});
       return;
     }
 
-    let thisTab = this.tabData[tabId];
     let numBlocked = thisTab ? thisTab.blockedCount : 0;
-
     if(numBlocked === 0){
       chrome.browserAction.setBadgeBackgroundColor({tabId: tabId, color: "#00cc00"});
     } else {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -739,11 +739,13 @@ Badger.prototype = {
 /**************************** Listeners ****************************/
 
 function startBackgroundListeners() {
-  // Update icon if a tab changes location
+  // Update icon if a tab changes location. If new location is a background
+  // tab or Privacy Badger is disabled on the new origin, hide the badge
+  // counter. Else refresh the badge counter to '0'.
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {
       badger.refreshIconAndContextMenu(tab);
-      if (badger.isPrivacyBadgerDisabled(webrequest.getHostForTab(tabId))) {
+      if (changeInfo.url.indexOf("http") !== 0 || badger.isPrivacyBadgerDisabled(webrequest.getHostForTab(tabId))) {
         badger.updateBadge(tabId, true);
       } else {
         badger.updateBadge(tabId);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -730,14 +730,10 @@ Badger.prototype = {
 /**************************** Listeners ****************************/
 
 function startBackgroundListeners() {
-  // Update icon if a tab changes location. If new location is a background
-  // tab or Privacy Badger is disabled on the new origin, hide the badge
-  // counter. Else refresh the badge counter to '0'.
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-    if(changeInfo.status == "loading") {
+    if(changeInfo.status == "loading" && tab.url) {
       badger.refreshIconAndContextMenu(tab);
-      if ((changeInfo.url && changeInfo.url.indexOf("http") !== 0)
-        || badger.isPrivacyBadgerDisabled(webrequest.getHostForTab(tabId))) {
+      if (badger.isPrivacyBadgerDisabled(window.extractHostFromURL(tab.url))) {
         badger.updateBadge(tabId, true);
       } else {
         badger.updateBadge(tabId);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -122,7 +122,7 @@ Badger.prototype = {
             },
             ...
           },
-          trackers: {
+          origins: {
             domain.tld: bool
             ...
           }
@@ -180,7 +180,7 @@ Badger.prototype = {
               url: tab.url
             }
           },
-          trackers: {},
+          origins: {},
           blocked: {
             [constants.BLOCK]: {},
             [constants.USER_BLOCK]: {},
@@ -500,7 +500,7 @@ Badger.prototype = {
    * @returns {*} A dictionary of third party origins and their actions
    */
   getAllOriginsForTab: function(tabId) {
-    return Object.keys(this.tabData[tabId].trackers);
+    return Object.keys(this.tabData[tabId].origins);
   },
 
   /**
@@ -713,17 +713,17 @@ Badger.prototype = {
   },
 
   /**
-   * Add the tracker and action to the tabData[tabId] object
+   * Add the third party origin and action to the tabData[tabId] object
    * so it can be used for the popup and the badge count.
    *
    * @param tabId the tab we are on
-   * @param fqdn the tracker to add
+   * @param fqdn the third party origin to add
    * @param action the action we are taking
    *
    * @returns {boolean} true if badge count should be incremented
    **/
-  logTrackerOnTab: function(tabId, fqdn, action) {
-    this.tabData[tabId].trackers[fqdn] = action;
+  logThirdPartyOriginOnTab: function(tabId, fqdn, action) {
+    this.tabData[tabId].origins[fqdn] = action;
 
     if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
       if (!this.tabData[tabId].blocked[action].hasOwnProperty(fqdn)) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -745,7 +745,8 @@ function startBackgroundListeners() {
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {
       badger.refreshIconAndContextMenu(tab);
-      if (changeInfo.url.indexOf("http") !== 0 || badger.isPrivacyBadgerDisabled(webrequest.getHostForTab(tabId))) {
+      if ((changeInfo.url && changeInfo.url.indexOf("http") !== 0)
+        || badger.isPrivacyBadgerDisabled(webrequest.getHostForTab(tabId))) {
         badger.updateBadge(tabId, true);
       } else {
         badger.updateBadge(tabId);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -519,6 +519,7 @@ Badger.prototype = {
 
     let thisTab = this.tabData[tabId];
     let numBlocked = thisTab ? thisTab.blockedCount : 0;
+    console.log("numBlocked: " + numBlocked);
 
     if(numBlocked === 0){
       chrome.browserAction.setBadgeBackgroundColor({tabId: tabId, color: "#00cc00"});
@@ -718,6 +719,8 @@ Badger.prototype = {
    * @param tabId the tab we are on
    * @param fqdn the tracker to add
    * @param action the action we are taking
+   *
+   * @returns {boolean} true if badge count should be incremented
    **/
   logTrackerOnTab: function(tabId, fqdn, action) {
     this.tabData[tabId].trackers[fqdn] = action;
@@ -726,8 +729,10 @@ Badger.prototype = {
       if (!this.tabData[tabId].blocked[action].hasOwnProperty(fqdn)) {
         this.tabData[tabId].blocked[action][fqdn] = true;
         this.tabData[tabId].blockedCount += 1;
+        return true;
       }
     }
+    return false;
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -181,12 +181,6 @@ Badger.prototype = {
             }
           },
           origins: {},
-          blocked: {
-            [constants.BLOCK]: {},
-            [constants.USER_BLOCK]: {},
-            [constants.COOKIEBLOCK]: {},
-            [constants.USER_COOKIE_BLOCK]: {}
-          },
           blockedCount: 0
         };
       }
@@ -712,21 +706,20 @@ Badger.prototype = {
   },
 
   /**
-   * Add the third party origin and action to the tabData[tabId] object
-   * so it can be used for the popup and the badge count.
+   * Add only new third party origins to the tabData[tabId] object for
+   * use in the popup and return 'true' if the badge needs to be refreshed
+   * to display an updated number.
    *
    * @param tabId the tab we are on
    * @param fqdn the third party origin to add
    * @param action the action we are taking
    *
-   * @returns {boolean} true if badge count should be incremented
+   * @returns {boolean} true if badge needs to be updated
    **/
   logThirdPartyOriginOnTab: function(tabId, fqdn, action) {
-    this.tabData[tabId].origins[fqdn] = action;
-
-    if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
-      if (!this.tabData[tabId].blocked[action].hasOwnProperty(fqdn)) {
-        this.tabData[tabId].blocked[action][fqdn] = true;
+    if(!this.tabData[tabId].origins.hasOwnProperty(fqdn)) {
+      this.tabData[tabId].origins[fqdn] = action;
+      if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
         this.tabData[tabId].blockedCount += 1;
         return true;
       }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -517,9 +517,7 @@ Badger.prototype = {
     return self.getAllOriginsForTab(tabId)
       .reduce(function(memo,origin){
         var action = self.storage.getBestAction(origin);
-        if(action && (action == constants.USER_BLOCK || action ==
-                    constants.BLOCK || action == constants.COOKIEBLOCK ||
-                    action == constants.USER_COOKIE_BLOCK)){
+        if(action && constants.BLOCKED_ACTIONS.hasOwnProperty(action)){
           memo+=1;
         }
         return memo;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -774,6 +774,7 @@ function startBackgroundListeners() {
   chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     if(changeInfo.status == "loading") {
       badger.refreshIconAndContextMenu(tab);
+      badger.updateBadge(tabId);
     }
   });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -180,7 +180,14 @@ Badger.prototype = {
               url: tab.url
             }
           },
-          trackers: {}
+          trackers: {},
+          blocked: {
+            [constants.BLOCK]: {},
+            [constants.USER_BLOCK]: {},
+            [constants.COOKIEBLOCK]: {},
+            [constants.USER_COOKIE_BLOCK]: {}
+          },
+          blockedCount: 0
         };
       }
     });

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -40,5 +40,12 @@ var exports = {
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
 };
 
+exports.BLOCKED_ACTIONS = {
+  [exports.BLOCK]: true,
+  [exports.USER_BLOCK]: true,
+  [exports.COOKIEBLOCK]: true,
+  [exports.USER_COOKIE_BLOCK]: true
+};
+
 return exports;
 })();

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -40,12 +40,12 @@ var exports = {
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
 };
 
-exports.BLOCKED_ACTIONS = {
-  [exports.BLOCK]: true,
-  [exports.USER_BLOCK]: true,
-  [exports.COOKIEBLOCK]: true,
-  [exports.USER_COOKIE_BLOCK]: true
-};
+exports.BLOCKED_ACTIONS = new Set([
+  exports.BLOCK,
+  exports.USER_BLOCK,
+  exports.COOKIEBLOCK,
+  exports.USER_COOKIE_BLOCK,
+]);
 
 return exports;
 })();

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -325,7 +325,14 @@ function recordFrame(tabId, frameId, parentFrameId, frameUrl) {
   if (!badger.tabData.hasOwnProperty(tabId)){
     badger.tabData[tabId] = {
       frames: {},
-      trackers: {}
+      trackers: {},
+      blocked: {
+        [constants.BLOCK]: {},
+        [constants.USER_BLOCK]: {},
+        [constants.COOKIEBLOCK]: {},
+        [constants.USER_COOKIE_BLOCK]: {}
+      },
+      blockedCount: 0
     };
   }
   // check if this is a prerendered (bg) tab or not

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -535,8 +535,8 @@ function checkAction(tabId, url, quiet, frameId){
   var action = badger.storage.getBestAction(requestHost);
 
   if (action && ! quiet) {
-    badger.logTrackerOnTab(tabId, requestHost, action);
-    if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
+    let update = badger.logTrackerOnTab(tabId, requestHost, action);
+    if (update) {
       setTimeout(function() {
         badger.updateCount(tabId);
       }, 0);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -529,6 +529,11 @@ function checkAction(tabId, url, quiet, frameId){
 
   if (action && ! quiet) {
     badger.logTrackerOnTab(tabId, requestHost, action);
+    if (constants.BLOCKED_ACTIONS.hasOwnProperty(action)) {
+      setTimeout(function() {
+        badger.updateCount(tabId);
+      }, 0);
+    }
   }
   return action;
 }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -325,7 +325,7 @@ function recordFrame(tabId, frameId, parentFrameId, frameUrl) {
   if (!badger.tabData.hasOwnProperty(tabId)){
     badger.tabData[tabId] = {
       frames: {},
-      trackers: {},
+      origins: {},
       blocked: {
         [constants.BLOCK]: {},
         [constants.USER_BLOCK]: {},
@@ -535,7 +535,7 @@ function checkAction(tabId, url, quiet, frameId){
   var action = badger.storage.getBestAction(requestHost);
 
   if (action && ! quiet) {
-    let update = badger.logTrackerOnTab(tabId, requestHost, action);
+    let update = badger.logThirdPartyOriginOnTab(tabId, requestHost, action);
     if (update) {
       setTimeout(function() {
         badger.updateCount(tabId);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -326,12 +326,6 @@ function recordFrame(tabId, frameId, parentFrameId, frameUrl) {
     badger.tabData[tabId] = {
       frames: {},
       origins: {},
-      blocked: {
-        [constants.BLOCK]: {},
-        [constants.USER_BLOCK]: {},
-        [constants.COOKIEBLOCK]: {},
-        [constants.USER_COOKIE_BLOCK]: {}
-      },
       blockedCount: 0
     };
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -147,7 +147,7 @@ function onBeforeSendHeaders(details) {
   if (badger.isPrivacyBadgerEnabled(tabDomain) && 
       isThirdPartyDomain(requestDomain, tabDomain)) {
     var requestAction = checkAction(tab_id, url, false, frame_id);
-    // If this might be the third stike against the potential tracker which
+    // If this might be the third strike against the potential tracker which
     // would cause it to be blocked we should check immediately if it will be blocked.
     if (requestAction == constants.ALLOW && 
         badger.storage.getTrackingCount(requestDomain) == constants.TRACKING_THRESHOLD - 1){

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -329,15 +329,6 @@ function recordFrame(tabId, frameId, parentFrameId, frameUrl) {
       blockedCount: 0
     };
   }
-  // check if this is a prerendered (bg) tab or not
-  chrome.tabs.get(tabId, function(/*tab*/){
-    if (chrome.runtime.lastError){
-      // chrome will throw error for the prerendered tabs
-      badger.tabData[tabId].bgTab = true;
-    }else{
-      badger.tabData[tabId].bgTab = false;
-    }
-  });
 
   badger.tabData[tabId].frames[frameId] = {
     url: frameUrl,
@@ -569,7 +560,7 @@ function _isTabAnExtension(tabId) {
   return (
     _frameUrlStartsWith(tabId, "chrome-extension://") ||
     _frameUrlStartsWith(tabId, "moz-extension://")
-   );
+  );
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -529,12 +529,7 @@ function checkAction(tabId, url, quiet, frameId){
   var action = badger.storage.getBestAction(requestHost);
 
   if (action && ! quiet) {
-    let update = badger.logThirdPartyOriginOnTab(tabId, requestHost, action);
-    if (update) {
-      setTimeout(function() {
-        badger.updateCount(tabId);
-      }, 0);
-    }
+    badger.logThirdPartyOriginOnTab(tabId, requestHost, action);
   }
   return action;
 }

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -13,6 +13,8 @@
     xhrSpy,
     dnt_policy_txt;
 
+  let beforeChromeTabsGet = chrome.tabs.get;
+
   QUnit.module("Background", {
     before: (assert) => {
       let done = assert.async();
@@ -46,6 +48,7 @@
     afterEach: (/*assert*/) => {
       // reset call counts, etc. after each test
       utils.xhrRequest.restore();
+      chrome.tabs.get = beforeChromeTabsGet;
     },
 
     after: (/*assert*/) => {
@@ -141,6 +144,10 @@
   });
 
   QUnit.test("Blocked domain only counted once in badge", (assert) => {
+    chrome.tabs.get = (tabId, callback) => {
+      callback();
+    };
+
     badger.tabData[-1] = {
       frames: {},
       origins: {},

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -139,4 +139,26 @@
 
     badger.isCheckingDNTPolicyEnabled = old_dnt_check_func;
   });
+
+  QUnit.test("Blocked domain only counted once in badge", (assert) => {
+    badger.tabData[-1] = {
+      frames: {},
+      origins: {},
+      blocked: {
+        [constants.BLOCK]: {},
+        [constants.USER_BLOCK]: {},
+        [constants.COOKIEBLOCK]: {},
+        [constants.USER_COOKIE_BLOCK]: {}
+      },
+      blockedCount: 0
+    };
+
+    badger.logThirdPartyOriginOnTab(-1, "test.com", constants.BLOCK);
+    assert.equal(badger.tabData[-1].blockedCount, 1);
+
+    // Verify that a second occurrence of 'test.com' doesn't result in
+    // the blockedCount (used for the badge) incrementing again.
+    badger.logThirdPartyOriginOnTab(-1, "test.com", constants.BLOCK);
+    assert.equal(badger.tabData[-1].blockedCount, 1);
+  });
 }());

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -160,5 +160,9 @@
     // the blockedCount (used for the badge) incrementing again.
     badger.logThirdPartyOriginOnTab(-1, "test.com", constants.BLOCK);
     assert.equal(badger.tabData[-1].blockedCount, 1);
+
+    // Verify that non-blocked domains don't increment badge count.
+    badger.logThirdPartyOriginOnTab(-1, "test2.com", constants.ALLOW);
+    assert.equal(badger.tabData[-1].blockedCount, 1);
   });
 }());

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -1,47 +1,45 @@
 /* globals badger:false */
-
-function noop () {
-  Array.from(arguments).forEach(arg => {
-    if (typeof arg == 'function') {
-      arg();
-    }
-  });
-}
-
-function getter(name) {
-  let parts = name.split('.'),
-    out = window;
-  parts.forEach(part => {
-    out = out[part];
-  });
-  return out;
-}
-
-function setter(name, value) {
-  let parts = name.split('.'),
-    last = parts.pop(),
-    part = window;
-  parts.forEach(partName => {
-    part = part[partName];
-  });
-  part[last] = value;
-}
-
-function beforeMock(names) {
-  let mocked = {};
-  names.forEach(name => {
-    mocked[name] = getter(name);
-  });
-  return mocked;
-}
-
-function unmock(mocked) {
-  Object.keys(mocked).forEach(name => {
-    setter(name, mocked[name]);
-  });
-}
-
 (function() {
+  function noop () {
+    Array.from(arguments).forEach(arg => {
+      if (typeof arg == 'function') {
+        arg();
+      }
+    });
+  }
+
+  function getter(name) {
+    let parts = name.split('.'),
+      out = window;
+    parts.forEach(part => {
+      out = out[part];
+    });
+    return out;
+  }
+
+  function setter(name, value) {
+    let parts = name.split('.'),
+      last = parts.pop(),
+      part = window;
+    parts.forEach(partName => {
+      part = part[partName];
+    });
+    part[last] = value;
+  }
+
+  function beforeMock(names) {
+    let mocked = {};
+    names.forEach(name => {
+      mocked[name] = getter(name);
+    });
+    return mocked;
+  }
+
+  function unmock(mocked) {
+    Object.keys(mocked).forEach(name => {
+      setter(name, mocked[name]);
+    });
+  }
 
   const DNT_COMPLIANT_DOMAIN = 'eff.org',
     POLICY_URL = chrome.extension.getURL('data/dnt-policy.txt');

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -227,15 +227,17 @@ function unmock(mocked) {
       },
     });
     QUnit.test("disabled", function(assert) {
-      let called1 = false,
-        called2 = false;
+      let done = assert.async(),
+        called = false;
       chrome.tabs.get = noop;
-      chrome.browserAction.setBadgeText = () => {called1 = true;};
-      chrome.browserAction.setBadgeBackgroundColor = () => {called2 = true;};
+      chrome.browserAction.setBadgeText = (obj) => {
+        assert.deepEqual(obj, {tabId: this.tabId, text: ''});
+        done();
+      };
+      chrome.browserAction.setBadgeBackgroundColor = () => {called = true;};
 
       badger.updateBadge(this.tabId, true);
-      assert.ok(called1);
-      assert.notOk(called2);
+      assert.notOk(called);
     });
 
     QUnit.test("numblocked zero", function(assert) {

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -225,7 +225,7 @@
       },
     });
     QUnit.test("disabled", function(assert) {
-      let done = assert.async(),
+      let done = assert.async(2),
         called = false;
       chrome.tabs.get = noop;
       chrome.browserAction.setBadgeText = (obj) => {
@@ -236,6 +236,7 @@
 
       badger.updateBadge(this.tabId, true);
       assert.notOk(called);
+      done();
     });
 
     QUnit.test("numblocked zero", function(assert) {


### PR DESCRIPTION
This PR includes two primary change sets:
1) tabData includes a new map structure that allows blocked third party origins to be tallied up.
2) Refactoring of when `updateCount()` function is called such that we only call it when the number on the badge increases. This should hopefully save some overhead, since we won't be querying any internal Chrome APIs to update the badge over and over with the same number.

I want to finish up with a test that verifies that blocked third party origins aren't double counted and the badge number reflects the actual number of blocked third party origins. The current code works, though a test will ensure this doesn't break in the future. Will get this done before the upcoming meeting on Monday.