### PR TITLE
WIP Quick changes to Flat UI (#1461)

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -76,7 +76,7 @@ a:hover { color: #ec9329 }
 .clicker{
   border-top: 1px solid #aaaaaa;
   padding: 5px;
-  height: 40px;
+  height: 43px;
   overflow: hidden;
 }
 .clicker.greyed { background: #aaa; }
@@ -120,7 +120,7 @@ font-size: 12px;
 background-color: #555;
 height: 12px;
 border-radius: 7px;
-padding: 3px;
+padding: 1px 3px 3px 3px;
 position: relative;
 bottom: 30px;
 left: 0;

--- a/src/skin/toggle-switch.css
+++ b/src/skin/toggle-switch.css
@@ -315,7 +315,7 @@
 }
 
 .noaction .switch-candy a {
-  background-color: #339900;
+  background-color: #4CAF50;
 }
 
 .switch-candy {


### PR DESCRIPTION
Quick fixes for #1461 
* [x] Same greens for toggles in lists.
* [x] Size of hints when going into options so they don't run into rows
* [ ] Vertical alignment of toolbox (where shadow was removed).

Last one actually is aligned but looks weird so I changed the padding on the top from 1 to 3px. It looks like this:

![comppb_padding](https://user-images.githubusercontent.com/1775039/28096050-df915454-665a-11e7-9e30-a989ce866ef8.png)
