### PR TITLE
Allow Firefox ESR jobs to fail in Travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os: linux
 dist: trusty
 python: 3.4
 matrix:
+  fast_finish: true
   include:
     - env: INFO="lint"
       node_js: node
@@ -22,6 +23,10 @@ matrix:
     - addons:
         firefox: latest-beta
       env: INFO="firefox beta" BROWSER=firefox
+  allow_failures:
+    - addons:
+        firefox: latest-esr
+      env: INFO="firefox esr" BROWSER=firefox
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
To work around our testing setup no longer working with Firefox ESR as of around somewhere [this build](https://travis-ci.org/EFForg/privacybadger/builds/252526255).

Comparing with a [previous, mostly-working build](https://travis-ci.org/EFForg/privacybadger/builds/252201857) shows geckodriver 0.18.0 getting upgraded from 0.17.0, which seems relevant.