### PR TITLE
WIP: Add new heuristic for fingerprinting detection.

### DIFF
--- a/src/js/contentscripts/fingerprinting.js
+++ b/src/js/contentscripts/fingerprinting.js
@@ -1,3 +1,4 @@
+(function() {
 /*
  * This file is part of Privacy Badger <https://www.eff.org/privacybadger>
  * Copyright (C) 2015 Electronic Frontier Foundation
@@ -294,3 +295,4 @@ document.addEventListener(event_id, function (e) {
 insertFpScript(getFpPageScript(), {
   event_id: event_id
 });
+})();

--- a/src/js/contentscripts/injector.js
+++ b/src/js/contentscripts/injector.js
@@ -1,6 +1,14 @@
-var s = document.createElement('script');
+let event_id = Math.random();
+
+// listen for messages from the script we are about to insert
+document.addEventListener(event_id, function (e) {
+  chrome.runtime.sendMessage(e.detail);
+});
+
+let s = document.createElement('script');
+s.setAttribute('data', event_id);
 s.src = chrome.extension.getURL('js/injected/fingercounting.js');
 s.onload = function() {
-    this.remove();
+  this.remove();
 };
 (document.head || document.documentElement).appendChild(s);

--- a/src/js/contentscripts/injector.js
+++ b/src/js/contentscripts/injector.js
@@ -1,0 +1,6 @@
+var s = document.createElement('script');
+s.src = chrome.extension.getURL('js/injected/fingercounting.js');
+s.onload = function() {
+    this.remove();
+};
+(document.head || document.documentElement).appendChild(s);

--- a/src/js/injected/fingercounting.js
+++ b/src/js/injected/fingercounting.js
@@ -1,7 +1,7 @@
 (function() {
 /**
  * This sets up a counter on methods that are commonly used for fingerprinting.
- * 
+ *
  * # thoughts for a metric over the counts:
  * We can think about each finger printing method a dimension in N dimensional
  * space. Then we can think about this as a metric on an N dimensional vector.
@@ -14,10 +14,12 @@
  * consider the number of times each function is called.
  *
  * Hopefully this will work okay, it kinda assumes the dimensions are linearly
- * independent. Once we have more data, we can empirically determine a
- * transformation function that would account for non-independence.
+ * independent. This certainly isn't true. Once we have more data, we can
+ * empirically determine a transformation function that would account for
+ * non-independence.
  *
- * test sites:
+ * test sites found with: https://publicwww.com/websites/%22fingerprint2.min.js%22/
+ *
  * ryanair.com  # interesting 0.8 result
  * biggo.com.tw
  * https://www.sitejabber.com/
@@ -25,7 +27,7 @@
  * https://adsbackend.com/  # is this broken? lol
  *
  * it seems like 0.8 is the minimum for sites using fpjs2,
- * 0.45 is the max I've seen (from github). So I set the threshold 
+ * 0.45 is the max I've seen (from github). So I set the threshold
  * at 0.75 for now.
  *
  * this site is loading from augur.io (I think?) and scoring 0.85.
@@ -36,7 +38,7 @@ let threshold = 0.75;
 
 /**
  * fingerprintjs2 defines the following "keys"
- * 
+ *
  * then some jsFontsKeys and flashFontsKeys
  *
  * I'll try to catch each of these
@@ -91,7 +93,7 @@ let objects = [
   //    keys = this.hasLiedOsKey(keys);
   //    keys = this.hasLiedBrowserKey(keys);
   //    keys = this.customEntropyFunction(keys);
-]; 
+];
 
 // todo: what is a better data structure here?
 let _objectsHelper = (dottedString) => {

--- a/src/js/injected/fingercounting.js
+++ b/src/js/injected/fingercounting.js
@@ -1,3 +1,4 @@
+(function() {
 /**
  * This sets up a counter on methods that are commonly used for fingerprinting.
  * 
@@ -152,3 +153,4 @@ for (let obj of objects) {
 console.log('injected');
 setInterval(()=>{console.log(counter.score());}, 2000);
 setInterval(()=>{console.log(counter.isFingerprinting());}, 2000);
+})();

--- a/src/js/injected/fingercounting.js
+++ b/src/js/injected/fingercounting.js
@@ -183,12 +183,15 @@ Counter.prototype = {
   },
 };
 
-let counter = new Counter();
-for (let obj of objects) {
-  counter.countProp(obj);
+function send(origin) {
+  console.log(origin);
+  document.dispatchEvent(new CustomEvent(event_id, {
+    detail: {countedFingers: true, origin: origin},
+  }));
 }
 
-console.log('injected');
-setInterval(()=>{console.log(counter.score());}, 2000);
-setInterval(()=>{console.log(counter.isFingerprinting());}, 2000);
+// get this asap before the script tag is removed
+let event_id = document.currentScript.getAttribute('data');
+/* start 'em up */
+let counter = new Counter(objects, send); // eslint-disable-line
 })();

--- a/src/js/injected/fingercounting.js
+++ b/src/js/injected/fingercounting.js
@@ -1,0 +1,154 @@
+/**
+ * This sets up a counter on methods that are commonly used for fingerprinting.
+ * 
+ * # thoughts for a metric over the counts:
+ * We can think about each finger printing method a dimension in N dimensional
+ * space. Then we can think about this as a metric on an N dimensional vector.
+ * where each fingerprinting method maps to an element of this vector.
+ *
+ * A first naive metric can be the count of all elements of the vector that are
+ * non-zero. The higher the metric, the more likely the fingerprinting.
+ *
+ * Later to improve the metric, we can add weights to each dimension, and
+ * consider the number of times each function is called.
+ *
+ * Hopefully this will work okay, it kinda assumes the dimensions are linearly
+ * independent. Once we have more data, we can empirically determine a
+ * transformation function that would account for non-independence.
+ *
+ * test sites:
+ * ryanair.com  # interesting 0.8 result
+ * biggo.com.tw
+ * https://www.sitejabber.com/
+ * http://www.gettvstreamnow.com/ 0.95
+ * https://adsbackend.com/  # is this broken? lol
+ *
+ * it seems like 0.8 is the minimum for sites using fpjs2,
+ * 0.45 is the max I've seen (from github). So I set the threshold 
+ * at 0.75 for now.
+ *
+ * this site is loading from augur.io (I think?) and scoring 0.85.
+ * http://www.dixipay.com/
+ */
+
+let threshold = 0.75;
+
+/**
+ * fingerprintjs2 defines the following "keys"
+ * 
+ * then some jsFontsKeys and flashFontsKeys
+ *
+ * I'll try to catch each of these
+ */
+let objects = [
+  //    keys = this.userAgentKey(keys);
+  'navigator.userAgent',
+  //    keys = this.languageKey(keys);
+  'navigator.language',
+  //    keys = this.pixelRatioKey(keys);
+  'window.devicePixelRatio',
+  //    keys = this.hasLiedLanguagesKey(keys);
+  'navigator.languages',
+  //    keys = this.colorDepthKey(keys);
+  'screen.colorDepth',
+  //    keys = this.hardwareConcurrencyKey(keys);
+  'navigator.hardwareConcurrency',
+  //    keys = this.cpuClassKey(keys);
+  'navigator.cpuClass',
+  //    keys = this.platformKey(keys);
+  'navigator.platform',
+  //    keys = this.doNotTrackKey(keys);
+  'navigator.doNotTrack',
+  //    keys = this.touchSupportKey(keys);
+  'navigator.maxTouchPoints',
+
+  //    keys = this.screenResolutionKey(keys);
+  'screen.width',
+  //    keys = this.availableScreenResolutionKey(keys);
+  'screen.availWidth',
+  // these also are counted with:
+  //    keys = this.hasLiedResolutionKey(keys);
+
+  //    keys = this.timezoneOffsetKey(keys);
+  'Date.prototype.getTimezoneOffset',
+  //    keys = this.sessionStorageKey(keys);
+  'window.sessionStorage',
+  //    keys = this.localStorageKey(keys);
+  'window.localStorage',
+  //    keys = this.indexedDbKey(keys);
+  'window.indexedDB',
+  //    keys = this.openDatabaseKey(keys);
+  'window.openDatabase',
+  //    keys = this.pluginsKey(keys);
+  'navigator.plugins',
+  //    keys = this.canvasKey(keys);
+  'window.CanvasRenderingContext2D.prototype.rect',
+  //    keys = this.webglKey(keys);
+  'window.WebGLRenderingContext.prototype.createBuffer',
+  //    keys = this.adBlockKey(keys);
+  //    keys = this.addBehaviorKey(keys);
+  //    keys = this.hasLiedOsKey(keys);
+  //    keys = this.hasLiedBrowserKey(keys);
+  //    keys = this.customEntropyFunction(keys);
+]; 
+
+// todo: what is a better data structure here?
+let _objectsHelper = (dottedString) => {
+  let arr = dottedString.split('.'),
+    last = arr.pop(),
+    base = window[arr.shift()];
+  if (arr) {
+    base = arr.reduce((o, i) => o[i], base);
+  }
+  return {
+    'name': dottedString,
+    'baseObj': base,
+    'propName': last
+  }
+};
+
+function Counter() {
+}
+
+Counter.prototype = {
+  counts: {},
+  countProp: function(dottedPropName) {
+    let self = this,
+      propInfo = _objectsHelper(dottedPropName),
+      name = propInfo.name,
+      baseObj = propInfo.baseObj,
+      propName = propInfo.propName,
+      before = baseObj[propName];
+
+    self.counts[name] = 0;
+    Object.defineProperty(baseObj, propName, {
+      get: function() {
+        self.counts[name] += 1;
+        return before;
+      }
+    });
+  },
+  score: function() {
+    let out = 0,
+      vals = Object.values(this.counts);
+    for (let val of vals) {
+      if (val > 0) {
+        out += 1;
+      }
+    }
+    return out/vals.length;
+  },
+
+  isFingerprinting: function() {
+    return this.score > threshold;
+  }
+};
+
+let counter = new Counter();
+for (let obj of objects) {
+  counter.countProp(obj);
+}
+
+console.log('injected');
+setInterval(()=>{console.log(counter.score());}, 2000);
+setInterval(()=>{console.log(counter.isFingerprinting());}, 2000);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -636,6 +636,17 @@ function unblockSocialWidgetOnTab(tabId, socialWidgetUrls) {
   }
 }
 
+/*
+ *
+ * checkEnabled
+ * checkLocation
+ * checkReplaceButton
+ * unblockSocialWidget
+ * fpReport
+ * superCookieReport
+ * checkEnabledAndThirdParty
+ * checkSocialWidgetReplacementEnabled
+ */
 function dispatcher(request, sender, sendResponse) {
   var tabHost;
   if (sender.tab && sender.tab.url) {
@@ -655,6 +666,9 @@ function dispatcher(request, sender, sendResponse) {
       sendResponse(cookieBlock);
     }
 
+  } else if (request.countedFingers) {
+    console.log('saw fingerprinting');
+    sendResponse();
   } else if (request.checkReplaceButton) {
     if (badger.isPrivacyBadgerEnabled(tabHost) && badger.isSocialWidgetReplacementEnabled()) {
       var socialWidgetBlockList = getSocialWidgetBlockList();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -54,6 +54,7 @@
     },
     {
       "js": [
+        "js/contentscripts/injector.js",
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",
         "js/contentscripts/fingerprinting.js",
@@ -102,6 +103,7 @@
   },
   "options_page": "/skin/options.html",
   "web_accessible_resources": [
+    "js/injected/fingercounting.js",
     "skin/socialwidgets/*"
   ]
 }


### PR DESCRIPTION
We have list of methods commonly used by browser fingerprinting tools. We wrap each of these in a counter to track their usage. When an origin uses more than some threshold percentage (currently %75) of the methods, we say it is fingerprinting. 

I set the %75 value empirically from testing. The highest percentage I saw on a non-fingerprinting site was 45% (github), the lowest I saw on a fingerprinting site was 80% (this site has since gone down).

There are currently some architectural issue with privacy badger which should be fixed before merging this. Mainly: This kind of tracking should *not* be associated with an **origin**, instead it should be associated with a URL (or some notion of it). It makes sense for cookies to  be associated with an origin, because that is how cookies are scoped. But this tracking is normally loaded from a standalone library that could be anywhere, like a third party CDN service or the first party.

If we block origins associated with fingerprinting, we'll end up blocking CDN's, which breaks other sites, which means we'll manually have to add the sites to the cookieblock list, which will just allow the fingerprinting to continue. I'll expand more on this in a separate issue.