### PR TITLE
Add Twitter DNT meta tag.

### DIFF
--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -49,10 +49,10 @@
  */
 let trackerInfo;
 let styleSheetAdded = false;
+let metaTagInserted = false;
 
 let REPLACEMENT_BUTTONS_FOLDER_PATH = chrome.extension.getURL("skin/socialwidgets/");
 let STYLESHEET_URL = chrome.extension.getURL("skin/socialwidgets/socialwidgets.css");
-
 
 /**
  * Initializes the content script.
@@ -64,6 +64,9 @@ function initialize() {
     trackerInfo = trackers;
     replaceInitialTrackerButtonsHelper(trackerButtonsToReplace);
   });
+
+  // add twitter dnt meta tag if needed
+  maybeAddTwitterDNTMetaTag();
 
   // Set up listener for blocks that happen after initial check
   chrome.runtime.onMessage.addListener( function(request/*, sender, sendResponse*/) {
@@ -346,6 +349,26 @@ function unblockTracker(buttonUrls, callback) {
     "buttonUrls": buttonUrls
   };
   chrome.runtime.sendMessage(request, callback);
+}
+
+/*
+ * Add the twitter dnt meta tag:
+ * <meta name="twitter:dnt" content="on">
+ * to pages that load the platform.twitter.com/wigets.js
+ * This makes twitter apply their old DNT policy.
+ */
+function maybeAddTwitterDNTMetaTag() {
+  if (metaTagInserted) {
+    return;
+  }
+  let maybe = document.querySelector('script[src*="//platform.twitter.com/widgets.js"]');
+  if (maybe) {
+    let m = document.createElement('meta');
+    m.name = 'twitter:dnt';
+    m.content = 'on';
+    (document.head || document.documentElement).appendChild(m);
+    metaTagInserted = true;
+  }
 }
 
 chrome.runtime.sendMessage({

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -566,9 +566,9 @@ function _isTabChromeInternal(tabId) {
  */
 function _isTabAnExtension(tabId) {
   return (
-    _frameUrlStartsWith(tabId, "chrome-extension://") ||
-    _frameUrlStartsWith(tabId, "moz-extension://")
-   );
+   _frameUrlStartsWith(tabId, "chrome-extension://") ||
+   _frameUrlStartsWith(tabId, "moz-extension://")
+  );
 }
 
 /**


### PR DESCRIPTION
Twitter recently withdrew support for allowing their users to opt out of tracking with DNT. But they still quietly support this privacy policy in the case where website publisher's choose to use it when they embed Twitter content. They no longer call this privacy policy "DNT", but they have confirmed that the policy has not changed.

This PR embeds a meta tag on websites that load content from twitter. Twitter has no* way of distinguishing meta tags embedded by the website publisher, or by an extension in the user's browser. So they should continue to apply their DNT policy on visited with PB.

Twitter's documentation about this privacy policy is here: https://dev.twitter.com/web/overview/privacy#what-privacy-options-do-website-publishers-have

(*) no practical method to my knowledge