### PR TITLE
Fix failing firefox esr tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ matrix:
     - addons:
         firefox: latest-beta
       env: INFO="firefox beta" BROWSER=firefox
-  allow_failures:
-    - addons:
-        firefox: latest-esr
-      env: INFO="firefox esr" BROWSER=firefox
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -11,7 +11,7 @@ function setup_chrome {
 }
 
 function setup_firefox {
-    version=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
+    version="v0.17.0"
     url="https://github.com/mozilla/geckodriver/releases/download/${version}/geckodriver-${version}-linux64.tar.gz"
     wget -O /tmp/geckodriver.tar.gz ${url}
     sudo tar -xvf /tmp/geckodriver.tar.gz -C /usr/local/bin/


### PR DESCRIPTION
Geckodriver upgraded to v0.18.0, but this fails with ff esr. So we fallback to v0.17.0