### PR TITLE
Restore canvas fingerprinting detection on Firefox

### DIFF
--- a/release-utils/make-signed-xpi.sh
+++ b/release-utils/make-signed-xpi.sh
@@ -27,10 +27,6 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-# TODO restore: https://github.com/EFForg/privacybadger/issues/1158
-echo "remove fingerprinting"
-sed -i '/        "js\/contentscripts\/fingerprinting.js",/d' ../checkout/src/manifest.json
-
 echo "change author value"
 sed -i 's/"author": { "email": "eff.software.projects@gmail.com" },/"author": "privacybadger-owner@eff.org",/' ../checkout/src/manifest.json
 


### PR DESCRIPTION
I also changed this so it would be injected with a script tag. Otherwise it was violating some sites CSP on Firefox.

Test it out on http://www.gettvstreamnow.com/

If that goes down try other sites from https://publicwww.com/websites/%22fingerprint2.min.js%22/

Closes #1158.