### PR TITLE
Don't check for supercookies until document_idle

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -56,8 +56,7 @@
       "js": [
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",
-        "js/contentscripts/fingerprinting.js",
-        "js/contentscripts/supercookie.js"
+        "js/contentscripts/fingerprinting.js"
       ],
       "matches": [
         "<all_urls>"
@@ -67,7 +66,8 @@
     },
     {
       "js": [
-	"js/contentscripts/socialwidgets.js"
+        "js/contentscripts/socialwidgets.js",
+        "js/contentscripts/supercookie.js"
       ],
       "matches": [
         "<all_urls>"


### PR DESCRIPTION
This should close #1483 

My theory is that there is a race condition. The supercookie detection content script is injected at "`document_start`" which means it might check for the localstorage data before the other script can write it.