### PR TITLE
Restore "why isn't anything blocked" popup message (closes #1374)

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -498,6 +498,15 @@ Badger.prototype = {
   },
 
   /**
+   * Count of blocked origins for a given tab
+   * @param {Integer} tabId chrome tab id
+   * @return {Integer} count of blocked origins
+   */
+  blockedOriginCount: function(tabId) {
+    return this.tabData[tabId].blockedCount;
+  },
+
+  /**
    * Update page action badge with current count
    * @param {Integer} tabId chrome tab id
    */

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -107,6 +107,7 @@ function init() {
 
   var version = i18n.getMessage("version") + " " +  chrome.runtime.getManifest().version;
   $("#version").text(version);
+  adjustNoInitialBlockingLink();
 }
 $(init);
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -503,6 +503,21 @@ function syncUISelections() {
   }
 }
 
+
+/**
+* Hide or show additional info depending on if there is any additional info
+*/
+function adjustNoInitialBlockingLink() {
+  getTab(tab => {
+    if (badger.blockedOriginCount(tab.id) == 0) {
+      $("#noBlockingLink").show();
+    } else {
+      $("#noBlockingLink").hide();
+    }
+  });
+}
+
+
 /**
 * We use this function where:
 * * getting the tabId from the associatedTab id won't work because

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -71,6 +71,9 @@
 </div>
 <div id="blockedResourcesContainer">
   <p id="pbInstructions"> <span class="i18n_pb_detected"></span> <span id='number_trackers'></span> <span class="i18n_popup_instructions"></span></p>
+
+  <p id="noBlockingLink"><!-- TODO: tooltip into _locales --><a href="https://www.eff.org/privacybadger#how_is_it_different" target="_blank" tabindex="-1" title="Blocking starts only if privacy badger detects an attempt to track you across multiple websites. Domains listed below did not tracked you yet. It is either because they had no chance yet (you did not browsed enough) or because they do not engage in tracking. "><span class="i18n_popup_noblocked"></span></a></p>
+
   <div class="spacer"></div>
   <div id="blockedResources"><span class="options_loading"></span></div>
 </div>


### PR DESCRIPTION
Close #1374 

This is currently manually rebased on #1480 since I need to use the `blockedCount` stuff @alexristich added. I'll rebase it on master after that PR is merged.