### PR TITLE
Add weatherzone.com.au to yellowlist

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -551,6 +551,7 @@ weather.com
 weather.gov
 weatherbug.com
 weathernationtv.com
+weatherzone.com.au
 webtype.com
 where.com
 widgetserver.com

--- a/doc/sample_cookieblocklist_legacy.txt
+++ b/doc/sample_cookieblocklist_legacy.txt
@@ -551,6 +551,7 @@
 @@||weather.gov^$third-party
 @@||weatherbug.com^$third-party
 @@||weathernationtv.com^$third-party
+@@||weatherzone.com.au^$third-party
 @@||webtype.com^$third-party
 @@||where.com^$third-party
 @@||widgetserver.com^$third-party


### PR DESCRIPTION
To unbreak weather-related images on the following websites:

* https://www.bluemts.com.au/weather-forecast/
* https://www.hawkesburyaustralia.com.au/weather-forecast/
* https://www.experiencesydneyaustralia.com/visitor-information/weather/

```
**** ACTION_MAP for weatherzone

www.weatherzone.com.au {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 1501904291446
}

weatherzone.com.au {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
}

**** SNITCH_MAP for weatherzone

weatherzone.com.au [
  "bluemts.com.au",
  "hawkesburyaustralia.com.au",
  "experiencesydneyaustralia.com"
]
```
The tracking that Privacy Badger sees comes from AWS "sticky sessions" load balancer cookies:
```
Name: AWSELB
Content: B91D09251A9AEDA4A6E0B5D8E22294B3...7CAD2DC5BB63CA01BE7F37EA
Domain: www.weatherzone.com.au
Path: /
Send for: Any kind of connection
Accessible to script: Yes
Created: Tuesday, August 1, 2017 at 11:36:22 AM
Expires: Tuesday, August 1, 2017 at 12:36:22 PM
```

These cookies have a short expiration date (one hour). Should we treat them differently? This is related to session cookies, which came up in #1539.