### PR TITLE
Yellowlist cdn.lib.newsvine.com

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -366,6 +366,7 @@ networksolutions.com
 newsinc.com
 newslook.com
 newstogram.com
+cdn.lib.newsvine.com
 nextopiasoftware.com
 nfl.com
 nflcdn.com

--- a/doc/sample_cookieblocklist_legacy.txt
+++ b/doc/sample_cookieblocklist_legacy.txt
@@ -366,6 +366,7 @@
 @@||newsinc.com^$third-party
 @@||newslook.com^$third-party
 @@||newstogram.com^$third-party
+@@||cdn.lib.newsvine.com^$third-party
 @@||nextopiasoftware.com^$third-party
 @@||nfl.com^$third-party
 @@||nflcdn.com^$third-party


### PR DESCRIPTION
Fixes #1293 by yellowlisting the cdn, as suggested.

Debug data from Privacy Badger:

```
**** ACTION_MAP for newsvine.com
VM378:5 cdn.lib.newsvine.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 1502978092047
}
VM378:5 www.newsvine.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "allow",
  "nextUpdateTime": 1502915615392
}
VM378:5 www.polls.newsvine.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 1503070943545
}
VM378:5 newsvine.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "allow",
  "nextUpdateTime": 0
}
VM378:7 **** SNITCH_MAP for newsvine.com
VM378:9 newsvine.com [
  "msnbc.com"
]
```

Cookie set by newsvine.com lasts for twenty years; obvious tracker.
```
Name: vid
Content: cba03db2435fb858ede5ee68277dcd9d
Domain: .newsvine.com
Path: /
Send for: Any kind of connection
Accessible to script: Yes
Created: Sunday, August 13, 2017 at 7:56:21 PM
Expires: Saturday, August 8, 2037 at 7:56:17 PM
```