### PR TITLE
Add option to re-enable alternateErrorPagesEnabled

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -107,6 +107,9 @@
     "options_webrtc_warning": {
         "message": "* WebRTC can leak your local IP address. Privacy Badger's default setting helps protect you, but for added protection you may enable this option. Note that doing so may degrade performance on some tools like Google Hangouts."
     },
+    "options_alternate_error_pages_setting": {
+      "message": "Allow data about mistyped URLs to be shared with Google"
+    },
     "pb_detected": {
         "message": "Privacy Badger detected"
     },

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -93,7 +93,8 @@ function loadOptions() {
     details => {
       $("#checkbox_alternate_error_pages").click(privacySettings.toggleAlternateErrorPages);
       $("#checkbox_alternate_error_pages").prop("checked", details.value);
-    }, details => {
+    },
+    () => {
       $("#alternate_error_pages").css({"visibility": "hidden", "height": 0});
     }
   );

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -32,6 +32,7 @@ var log = backgroundPage.log;
 var constants = backgroundPage.constants;
 var htmlUtils = require("htmlutils").htmlUtils;
 var i18n = chrome.i18n;
+var privacySettings = require("privacySettings");
 var originCache = null;
 var settings = badger.storage.getBadgerStorageObject("settings_map");
 
@@ -87,6 +88,15 @@ function loadOptions() {
     $("#webRTCToggle").css({"visibility": "hidden", "height": 0});
     $("#settingsSuffix").css({"visibility": "hidden", "height": 0});
   }
+
+  privacySettings.isAlternateErrorPagesAvailable().then(
+    details => {
+      $("#checkbox_alternate_error_pages").click(privacySettings.toggleAlternateErrorPages);
+      $("#checkbox_alternate_error_pages").prop("checked", details.value);
+    }, details => {
+      $("#alternate_error_pages").css({"visibility": "hidden", "height": 0});
+    }
+  );
 
   // Show user's filters
   reloadWhitelist();

--- a/src/js/privacy_settings.js
+++ b/src/js/privacy_settings.js
@@ -1,0 +1,45 @@
+require.scopes.privacySettings = (function() {
+
+const canControl = new Set([
+  'controllable_by_this_extension',
+  'controlled_by_this_extension'
+]);
+
+const alternateErrorPages = chrome.privacy.services.alternateErrorPagesEnabled;
+
+function set(setting, obj) {
+  return new Promise((resolve, reject) => {
+    setting.set(obj, () => {
+      if (chrome.runtime.lastError === undefined) {
+        resolve();
+      } else {
+        reject(chrome.runtime.lastError);
+      }
+    });
+  });
+}
+
+function get(setting) {
+  return new Promise((resolve, reject) => {
+    setting.get({}, function(details) {
+      if (canControl.has(details.levelOfControl)) {
+        resolve(details);
+      } else {
+        reject(details);
+      }
+    });
+  });
+}
+
+function isAlternateErrorPagesAvailable() {
+  return get(alternateErrorPages);
+}
+
+function toggleAlternateErrorPages() {
+  return isAlternateErrorPagesAvailable().then(
+    details => set(alternateErrorPages, {value: !details.value})
+  );
+}
+
+return {isAlternateErrorPagesAvailable, toggleAlternateErrorPages};
+})();

--- a/src/js/privacy_settings.js
+++ b/src/js/privacy_settings.js
@@ -5,10 +5,18 @@ const canControl = new Set([
   'controlled_by_this_extension'
 ]);
 
-const alternateErrorPages = chrome.privacy.services.alternateErrorPagesEnabled;
+let alternateErrorPages;
+try {
+  alternateErrorPages = chrome.privacy.services.alternateErrorPagesEnabled;
+} catch (e) {
+  alternateErrorPages = false;
+}
 
 function set(setting, obj) {
   return new Promise((resolve, reject) => {
+    if (!setting) {
+      return reject();
+    }
     setting.set(obj, () => {
       if (chrome.runtime.lastError === undefined) {
         resolve();
@@ -21,6 +29,9 @@ function set(setting, obj) {
 
 function get(setting) {
   return new Promise((resolve, reject) => {
+    if (!setting) {
+      return reject();
+    }
     setting.get({}, function(details) {
       if (canControl.has(details.levelOfControl)) {
         resolve(details);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,7 @@
       "lib/basedomain.js",
       "lib/underscore-min.js",
       "data/surrogates.js",
+      "js/privacy_settings.js",
       "js/surrogates.js",
       "js/multiDomainFirstParties.js",
       "js/incognito.js",

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -221,6 +221,12 @@ a, a:hover, a:active, a:visited{
           <span class="i18n_options_webrtc_setting"></span>
         </label>
       </div>
+      <div class="checkbox" id="alternate_error_pages">
+        <label>
+          <input type="checkbox" id="checkbox_alternate_error_pages">
+          <span class="i18n_options_alternate_error_pages_setting"></span>
+        </label>
+      </div>
       <div id="settingsSuffix">
         <br>
         <span class="i18n_options_webrtc_warning"></span>


### PR DESCRIPTION
This needs unittests, and I'm unsure about the language used in the options page.