### PR TITLE
Change twitter share message to correctly point to the EFF account

### DIFF
--- a/src/skin/firstRun.html
+++ b/src/skin/firstRun.html
@@ -65,7 +65,7 @@
 
     <div id="social-links">
       <h3 class="i18n_intro_social_share"></h3>
-        <a target=_blank href="https://twitter.com/home?status=I%20just%20installed%20Privacy%20Badger%2C%20a%20new%20tool%20from%20@EFF%20to%20stop%20companies%20from%20spying%20on%20your%20browsing%20habits%20https%3A%2F%2Feff.org%2Fprivacybadger" title="Share on Twitter"><img src="/icons/t.png" alt="Share on Twitter" title="Share on Twitter"></a>
+        <a target=_blank href="https://twitter.com/home?status=I%20just%20installed%20Privacy%20Badger%2C%20a%20new%20tool%20from%20@EFF%20to%20stop%20companies%20from%20spying%20on%20your%20browsing%20habits%20https%3A%2F%2Feff.org%2Fprivacybadger&related=eff" title="Share on Twitter"><img src="/icons/t.png" alt="Share on Twitter" title="Share on Twitter"></a>
         <a href="https://www.facebook.com/share.php?u=https%3A%2F%2Feff.org%2Fprivacybadger" target="_blank">
           <img src="/icons/f.png" alt="Share on Facebook" title="Share on Facebook">
         </a>

--- a/src/skin/firstRun.html
+++ b/src/skin/firstRun.html
@@ -65,7 +65,7 @@
 
     <div id="social-links">
       <h3 class="i18n_intro_social_share"></h3>
-        <a target=_blank href="https://twitter.com/home?status=I%20just%20installed%20Privacy%20Badger%2C%20a%20new%20tool%20from%20EFF%20to%20stop%20companies%20from%20spying%20on%20your%20browsing%20habits%20-%20https%3A%2F%2Feff.org%2Fprivacybadger" title="Share on Twitter"><img src="/icons/t.png" alt="Share on Twitter" title="Share on Twitter"></a>
+        <a target=_blank href="https://twitter.com/home?status=I%20just%20installed%20Privacy%20Badger%2C%20a%20new%20tool%20from%20@EFF%20to%20stop%20companies%20from%20spying%20on%20your%20browsing%20habits%20https%3A%2F%2Feff.org%2Fprivacybadger" title="Share on Twitter"><img src="/icons/t.png" alt="Share on Twitter" title="Share on Twitter"></a>
         <a href="https://www.facebook.com/share.php?u=https%3A%2F%2Feff.org%2Fprivacybadger" target="_blank">
           <img src="/icons/f.png" alt="Share on Facebook" title="Share on Facebook">
         </a>


### PR DESCRIPTION
Resolves #1620.

From a ticket to change:
"I just installed Privacy Badger, a new tool from EFF to stop companies
from spying on your browsing habits - https://eff.org/privacybadger"
to
"I just installed Privacy Badger, a new tool from @EFF to stop companies
from spying on your browsing habits https://eff.org/privacybadger"

Therefor adding "@" and removing "-"