### PR TITLE
Fix DNT checking for blocked domains

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -477,7 +477,7 @@ Badger.prototype = {
       Migrations.migrateDntRecheckTimes2,
       Migrations.forgetMistakenlyBlockedDomains,
       Migrations.unblockIncorrectlyBlockedDomains,
-      Migrations.unblockEff,
+      Migrations.unblockEFF,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -477,7 +477,7 @@ Badger.prototype = {
       Migrations.migrateDntRecheckTimes2,
       Migrations.forgetMistakenlyBlockedDomains,
       Migrations.unblockIncorrectlyBlockedDomains,
-      Migrations.unblockEFF,
+      Migrations.forgetBlockedDNTDomains,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -477,6 +477,7 @@ Badger.prototype = {
       Migrations.migrateDntRecheckTimes2,
       Migrations.forgetMistakenlyBlockedDomains,
       Migrations.unblockIncorrectlyBlockedDomains,
+      Migrations.unblockEff,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -181,14 +181,18 @@ exports.Migrations= {
     }
   },
 
-  unblockEFF: function(badger) {
+  forgetBlockedDNTDomains: function(badger) {
+    console.log('unblocking mistakenly blocked DNT domains');
     let action_map = badger.storage.getBadgerStorageObject("action_map"),
-      snitch_map = badger.storage.getBadgerStorageObject("snitch_map");
+      snitch_map = badger.storage.getBadgerStorageObject("snitch_map"),
+      domainsToFix = new Set(['eff.org', 'medium.com']);
 
     for (let domain in action_map.getItemClones()) {
-      if (window.getBaseDomain(domain) == 'eff.org') {
+      let base = window.getBaseDomain(domain);
+      if (domainsToFix.has(base)) {
         action_map.deleteItem(domain);
         snitch_map.deleteItem(domain);
+        snitch_map.deleteItem(base);
       }
     }
   },

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -181,7 +181,7 @@ exports.Migrations= {
     }
   },
 
-  unblockEff: function(badger) {
+  unblockEFF: function(badger) {
     let action_map = badger.storage.getBadgerStorageObject("action_map"),
       snitch_map = badger.storage.getBadgerStorageObject("snitch_map");
 

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -181,6 +181,17 @@ exports.Migrations= {
     }
   },
 
+  unblockEff: function(badger) {
+    let action_map = badger.storage.getBadgerStorageObject("action_map"),
+      snitch_map = badger.storage.getBadgerStorageObject("snitch_map");
+
+    for (let domain in action_map.getItemClones()) {
+      if (window.getBaseDomain(domain) == 'eff.org') {
+        action_map.deleteItem(domain);
+        snitch_map.deleteItem(domain);
+      }
+    }
+  },
 };
 
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -103,7 +103,9 @@ function onBeforeRequest(details){
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
-      badger.checkForDNTPolicy(requestDomain, badger.storage.getNextUpdateForDomain(requestDomain));
+      setTimeout(() => {
+        badger.checkForDNTPolicy(requestDomain, badger.storage.getNextUpdateForDomain(requestDomain));
+      });
       return {cancel: true};
     }
   }
@@ -173,7 +175,9 @@ function onBeforeSendHeaders(details) {
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
-      badger.checkForDNTPolicy(requestDomain, badger.storage.getNextUpdateForDomain(requestDomain));
+      setTimeout(() => {
+        badger.checkForDNTPolicy(requestDomain, badger.storage.getNextUpdateForDomain(requestDomain));
+      });
       return {cancel: true};
     }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -103,6 +103,7 @@ function onBeforeRequest(details){
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
+      badger.checkForDNTPolicy(requestDomain, badger.storage.getNextUpdateForDomain(requestDomain));
       return {cancel: true};
     }
   }
@@ -172,6 +173,7 @@ function onBeforeSendHeaders(details) {
       };
       chrome.tabs.sendMessage(tab_id, msg);
 
+      badger.checkForDNTPolicy(requestDomain, badger.storage.getNextUpdateForDomain(requestDomain));
       return {cancel: true};
     }
 


### PR DESCRIPTION
closes #1398 and closes #1397

The fix is 4819c06 I add a call to `checkForDNTPolicy` in places where we cancel requests.

Migration to unblock eff.org and its subdomains is fafbd5d.

Removed extra `nextUpdate` argument from `checkForDNTPolicy` in  ef51841 I update the tests and usage in the code to reflect this API change.

Moved the getter/setter functions from the tests into utils.js, and documented them. I use these in other currently pending pull requests, so I'd like to have them included here bb23c55