### PR TITLE
Unwrap t.co links on tweetdeck

### DIFF
--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -1,6 +1,15 @@
-let query_param = 'data-expanded-url';
-let tcos_with_destination = "a[" + query_param + "][href^='https://t.co/'], a[" + query_param + "][href^='http://t.co/']";
-let fixes = {};
+let query_param,
+  tcos_with_destination,
+  fixes = {};
+
+function setQuery() {
+  if (/https?:\/\/tweetdeck.twitter.com\//.test(window.location.href)) {
+    query_param = 'data-full-url';     // tweetdeck
+  } else {
+    query_param = 'data-expanded-url'; // twitter and tests
+  }
+  tcos_with_destination = "a[" + query_param + "][href^='https://t.co/'], a[" + query_param + "][href^='http://t.co/']";
+}
 
 function maybeAddNoreferrer(link) {
   let rel = link.rel ? link.rel : "";
@@ -51,5 +60,6 @@ function unwrapTwitterURLs() {
   });
 }
 
+setQuery();
 unwrapTwitterURLs();
 setInterval(unwrapTwitterURLs, 2000);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,8 +48,8 @@
         "js/firstparties/twitter.js"
       ],
       "matches": [
-        "https://twitter.com/*",
-        "http://twitter.com/*"
+        "*://twitter.com/*",
+        "*://tweetdeck.twitter.com/*"
       ],
       "run_at": "document_idle"
     },


### PR DESCRIPTION
closes #1651 

This gets most links except for image links, they can be done in a seperate PR. Those links look like:
```javascript
<a class="js-media-image-link block med-link media-item media-size-medium   is-zoomable" href="https://t.co/JFf6tr0uAx" rel="mediaPreview" target="_blank" style="background-image:url(https://pbs.twimg.com/media/DJEQ01jVAAAQsqQ.jpg)" data-media-entity-id="905523499992678400">      </a>
```
