### PR TITLE
Reorder tabs on the options page

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -168,7 +168,7 @@
         "description": ""
     },
     "whitelisted_domains": {
-        "message": "Whitelisted domains",
+        "message": "Whitelisted Domains",
         "description": "This is a tab heading."
     },
     "popup_enable_for_site": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -53,7 +53,7 @@
     },
     "data_settings": {
         "message": "Manage Data",
-        "description": ""
+        "description": "This is an options page tab heading."
     },
     "slideshow_13": {
         "message": " If I am breaking a page, please let my developers know so that they can fix the problem! You can do so by clicking this button.",
@@ -169,7 +169,7 @@
     },
     "whitelisted_domains": {
         "message": "Whitelisted Domains",
-        "description": "This is a tab heading."
+        "description": "This is an options page tab heading."
     },
     "popup_enable_for_site": {
         "message": "Enable Privacy Badger for This Site",
@@ -193,7 +193,7 @@
     },
     "options_general_settings": {
         "message": "General Settings",
-        "description": ""
+        "description": "This is an options page tab heading."
     },
     "slideshow_7": {
         "message": " If the slider is green that means that I can't tell if this domain is tracking you yet. It might not be, but I will still keep an eye on it.",
@@ -267,9 +267,9 @@
         "message": " The first time you click my icon you might see that all the trackers are green—don't worry! I'm different from other tracker blocking software—instead of knowing a list of things to block right away, I learn what to block as you browse. If I'm not blocking anything yet, try browsing around to 4 or 5 different websites. I should start blocking common trackers after that.",
         "description": ""
     },
-    "options_filter_settings": {
-        "message": "User Filter Settings",
-        "description": ""
+    "options_domain_list_tab": {
+        "message": "Domain List",
+        "description": "This is an options page tab heading."
     },
     "ded_logging_into": {
         "message": "Logging into ",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -168,7 +168,7 @@
         "description": ""
     },
     "whitelisted_domains": {
-        "message": "Whitelisted domains",
+        "message": "Whitelisted Domains",
         "description": "This is a tab heading."
     },
     "popup_enable_for_site": {

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -147,7 +147,7 @@ a, a:hover, a:active, a:visited{
   <ul>
     <li><a href="#tab-general-settings"><span class="i18n_options_general_settings"></span></a></li>
     <li><a href="#tab-whitelisted"><span class="i18n_whitelisted_domains"></span></a></li>
-    <li><a href="#tab-pb-status"><span class="i18n_options_filter_settings"></span></a></li>
+    <li><a href="#tab-pb-status"><span class="i18n_options_domain_list_tab"></span></a></li>
     <li><a href="#tab-import-export"><span class="i18n_data_settings"></span></a></li>
   </ul>
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -145,9 +145,9 @@ a, a:hover, a:active, a:visited{
 
 <div id="tabs">
   <ul>
-    <li><a href="#tab-pb-status"><span class="i18n_options_filter_settings"></span></a></li>
-    <li><a href="#tab-whitelisted"><span class="i18n_whitelisted_domains"></span></a></li>
     <li><a href="#tab-general-settings"><span class="i18n_options_general_settings"></span></a></li>
+    <li><a href="#tab-whitelisted"><span class="i18n_whitelisted_domains"></span></a></li>
+    <li><a href="#tab-pb-status"><span class="i18n_options_filter_settings"></span></a></li>
     <li><a href="#tab-import-export"><span class="i18n_data_settings"></span></a></li>
   </ul>
 


### PR DESCRIPTION
Fixes #1603 (for now, may revisit as needed).

Reordered page tabs, renamed the tab with the domain list. Screenshot of the new page:

![screenshot from 2017-09-14 10 43 19](https://user-images.githubusercontent.com/794578/30436226-9a60b098-9939-11e7-8289-6a65fec11240.png)