### PR TITLE
Add filepicker.io domains to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -156,8 +156,7 @@ fastly.net
 fbcdn.net
 attachment.fbsbx.com
 feedburner.com
-api.filepicker.io
-dialog.filepicker.io
+filepicker.io
 financialcontent.com
 findnsave.com
 firstlook.org


### PR DESCRIPTION
Following up on https://github.com/EFForg/privacybadger/pull/923#discussion_r135643624. Seems like we should just add all of `filepicker.io` to the yellowlist:
```
+-------+-----------------------+
| count | blocked_fqdn          |
+-------+-----------------------+
|   113 | www.filepicker.io     |
|    28 | api.filepicker.io     |
|    24 | dialog.filepicker.io  |
|     8 | assets.filepicker.io  |
|     4 | cdn.filepicker.io     |
|     2 | process.filepicker.io |
+-------+-----------------------+
```