### PR TITLE
Fix fingerprinting detection on Firefox

### DIFF
--- a/release-utils/make-signed-xpi.sh
+++ b/release-utils/make-signed-xpi.sh
@@ -27,11 +27,6 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-# TODO restore: https://github.com/EFForg/privacybadger/issues/1158
-echo "remove fingerprinting"
-sed -i '/        "js\/contentscripts\/fingerprinting.js"/d' ../checkout/src/manifest.json
-sed -i 's/        "js\/contentscripts\/clobberlocalstorage.js",/        "js\/contentscripts\/clobberlocalstorage.js"/' ../checkout/src/manifest.json
-
 echo "change author value"
 sed -i 's/"author": { "email": "eff.software.projects@gmail.com" },/"author": "privacybadger-owner@eff.org",/' ../checkout/src/manifest.json
 

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -5,9 +5,23 @@ import unittest
 
 import pbtest
 
+from window_utils import switch_to_window_with_url
+
 
 class FingerprintingDetectionTest(pbtest.PBSeleniumTest):
     """Tests to make sure fingerprinting detection works as expected."""
+
+    def detected_fingerprinting(self, domain):
+        return self.js("""let tracker_origin = window.getBaseDomain("{}");
+return (
+  Object.keys(badger.tabData).some(tab_id => {{
+    let fpData = badger.tabData[tab_id].fpData;
+    return fpData &&
+      fpData.hasOwnProperty(tracker_origin) &&
+      fpData[tracker_origin].canvas &&
+      fpData[tracker_origin].canvas.fingerprinting === true;
+  }})
+);""".format(domain))
 
     def detected_tracking(self, domain, page_url):
         return self.js("""let tracker_origin = window.getBaseDomain("{}"),
@@ -27,17 +41,29 @@ return (
         )
         FINGERPRINTING_DOMAIN = "cdn.jsdelivr.net"
 
+        # open Badger's background page
+        self.load_url(self.bg_url, wait_on_site=1)
+
+        # need to keep Badger's background page open for tabData to persist
+        # so, open and switch to a new window
+        self.open_window()
+
         # visit the page
         self.load_url(PAGE_URL)
 
-        # open Badger's background page
-        self.open_window()
-        self.load_url(self.bg_url, wait_on_site=1)
+        # switch back to Badger's background page
+        switch_to_window_with_url(self.driver, self.bg_url)
 
         # check that we detected the fingerprinting domain as a tracker
         self.assertTrue(
             self.detected_tracking(FINGERPRINTING_DOMAIN, PAGE_URL),
             "Canvas fingerprinting resource was detected as a tracker."
+        )
+
+        # check that we detected canvas fingerprinting
+        self.assertTrue(
+            self.detected_fingerprinting(FINGERPRINTING_DOMAIN),
+            "Canvas fingerprinting resources was detected as a fingerprinter."
         )
 
 

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import unittest
+
+import pbtest
+
+
+class FingerprintingDetectionTest(pbtest.PBSeleniumTest):
+    """Tests to make sure fingerprinting detection works as expected."""
+
+    def detected_tracking(self, domain, page_url):
+        return self.js("""let tracker_origin = window.getBaseDomain("{}"),
+  site_origin = window.getBaseDomain(utils.makeURI("{}").host),
+  map = badger.storage.snitch_map.getItemClones();
+
+return (
+  map.hasOwnProperty(tracker_origin) &&
+    map[tracker_origin].indexOf(site_origin) != -1
+);""".format(domain, page_url))
+
+    def test_canvas_fingerprinting_detection(self):
+        PAGE_URL = (
+            "https://cdn.rawgit.com/ghostwords"
+            "/ff6347b93ec126d4f73a9ddfd8b09919/raw/2332f82d3982bd4a84cd2380aed90228955d1f2a"
+            "/privacy_badger_fingerprint_test_fixture.html"
+        )
+        FINGERPRINTING_DOMAIN = "cdn.jsdelivr.net"
+
+        # visit the page
+        self.load_url(PAGE_URL)
+
+        # open Badger's background page
+        self.open_window()
+        self.load_url(self.bg_url, wait_on_site=1)
+
+        # check that we detected the fingerprinting domain as a tracker
+        self.assertTrue(
+            self.detected_tracking(FINGERPRINTING_DOMAIN, PAGE_URL),
+            "Canvas fingerprinting resource was detected as a tracker."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1158, fixes #1268.

This brings in [how we used to acquire stack traces in the legacy Firefox add-on](https://github.com/EFForg/privacybadgerfirefox-legacy/blob/00d88bbf42649d31bba181b49a7886c8381682ae/data/fingerprinting.js#L101).

[OpenWPM](https://github.com/citp/OpenWPM/blob/a6eb64afd48fe0e2b09be0b65d243f5d64a37a18/automation/Extension/firefox/data/content.js#L183), Brave (potentially), #1520, and #1524 contain ideas for future improvements.