### PR TITLE
Add flipcause.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -161,6 +161,7 @@ dialog.filepicker.io
 financialcontent.com
 findnsave.com
 firstlook.org
+flipcause.com
 framasoft.org
 frz.io
 build.origami.ft.com


### PR DESCRIPTION
Examples:
- http://matplotlib.org (click either Support button on the right-hand side)
- https://veinternational.org/get-involved/donate/ (embedded donation form)
- http://fcclainc.org/ (Support button on page bottom)
- http://www.opvrs.com/get-involved.html (embedded form)