### PR TITLE
Localize a bunch of hardcoded messages

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -414,5 +414,15 @@
     "whitelist_form_domain_input_placeholder": {
         "message": "e.g. www.domain.com, *.domain.net, domain.org",
         "description": "Placeholder text for the Add domain input under the Whitelisted Domains tab on the options page."
+    },
+    "share_button_title": {
+        "message": "Share on $SOCIAL_SERVICE$",
+        "description": "Tooltips that come up when you hover over the social sharing buttons on the introductory slideshow page.",
+        "placeholders": {
+            "social_service": {
+                "content": "$1",
+                "example": "Twitter"
+            }
+        }
     }
 }

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -367,6 +367,10 @@
         "message": " If you want to change other settings, you can click this gear icon.",
         "description": ""
     },
+    "popup_help_button": {
+        "message": "Help",
+        "description": "Tooltip that comes up when you hover over the question mark button in the upper right corner of the popup."
+    },
     "popup_options_button": {
         "message": "Options",
         "description": ""

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -331,10 +331,6 @@
         "message": " on ",
         "description": ""
     },
-    "new_filters_added": {
-        "message": "New filters added; see <a id='options_url' target='_blank'>Options</a> to manage them.",
-        "description": ""
-    },
     "intro_red": {
         "message": "Red",
         "description": ""

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -406,5 +406,13 @@
     "slideshow_10": {
         "message": " If you think that I've made the wrong decision for a tracker, you can move the slider to red to block it, yellow to partly block it, and green to allow it.",
         "description": ""
+    },
+    "what_is_a_tracker": {
+        "message": "What is a tracker?",
+        "description": "Tooltip that comes up when you hover over the 'tracking domains' link under the Tracking Domains tab on the options page."
+    },
+    "whitelist_form_domain_input_placeholder": {
+        "message": "e.g. www.domain.com, *.domain.net, domain.org",
+        "description": "Placeholder text for the Add domain input under the Whitelisted Domains tab on the options page."
     }
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -52,7 +52,6 @@ function loadOptions() {
   $('#exportTrackers').click(exportUserData);
 
   // Set up input for searching through tracking domains.
-  $("#trackingDomainSearch").attr("placeholder", i18n.getMessage("options_domain_search"));
   $("#trackingDomainSearch").on("input", filterTrackingDomains);
 
   // Add event listeners for origins container.

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -72,7 +72,6 @@ function init() {
       url: "https://supporters.eff.org/donate/support-privacy-badger"
     });
   });
-  $("#error_input").attr("placeholder", i18n.getMessage("error_input"));
 
   var overlay = $('#overlay');
   $("#error").click(function(){

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -20,11 +20,10 @@ var i18n = chrome.i18n;
 // Loads and inserts i18n strings into matching elements. Any inner HTML already in the
 // element is parsed as JSON and used as parameters to substitute into placeholders in the
 // i18n message.
-function loadI18nStrings()
-{
-  var nodes = document.querySelectorAll("[class^='i18n_']");
-  for(var i = 0; i < nodes.length; i++)
-  {
+function loadI18nStrings() {
+  // replace span contents by their class names
+  let nodes = document.querySelectorAll("[class^='i18n_']");
+  for (let i = 0; i < nodes.length; i++) {
     var arguments = JSON.parse("[" + nodes[i].textContent + "]");
     var className = nodes[i].className;
     if (className instanceof SVGAnimatedString)
@@ -35,6 +34,37 @@ function loadI18nStrings()
       nodes[i][prop] = i18n.getMessage(stringName, arguments);
     else
       nodes[i][prop] = i18n.getMessage(stringName);
+  }
+
+  // also replace title and placeholder attributes
+  const ATTRS = [
+    'placeholder',
+    'title',
+  ];
+
+  // get all the elements that contain one or more of these attributes
+  nodes = document.querySelectorAll(
+    // for example: "[placeholder^='i18n_'], [title^='i18n_']"
+    "[" + ATTRS.join("^='i18n_'], [") + "^='i18n_']"
+  );
+
+  // for each element
+  for (let i = 0; i < nodes.length; i++) {
+    // for each attribute
+    ATTRS.forEach(attr_type => {
+      // get the translation message key
+      let key = nodes[i].getAttribute(attr_type);
+      if (key) {
+        // remove the i18n_ prefix
+        key = key.slice(5);
+      }
+
+      // if the attribute exists and looks like i18n_KEY
+      if (key) {
+        // update the attribute with the result of a translation lookup by KEY
+        nodes[i].setAttribute(attr_type, i18n.getMessage(key));
+      }
+    });
   }
 }
 

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -76,18 +76,5 @@ function loadI18nStrings() {
   }
 }
 
-// Provides a more readable string of the current date and time
-function i18n_timeDateStrings(when)
-{
-  var d = new Date(when);
-  var timeString = d.toLocaleTimeString();
-
-  var now = new Date();
-  if (d.toDateString() == now.toDateString())
-    return [timeString];
-  else
-    return [timeString, d.toLocaleDateString()];
-}
-
 // Fill in the strings as soon as possible
 window.addEventListener("DOMContentLoaded", loadI18nStrings, true);

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -61,8 +61,16 @@ function loadI18nStrings() {
 
       // if the attribute exists and looks like i18n_KEY
       if (key) {
+        // get chrome.i18n placeholders, if any
+        let placeholders = nodes[i].dataset.i18n_placeholders;
+        if (placeholders) {
+          placeholders = placeholders.split("@@");
+        } else {
+          placeholders = [];
+        }
+
         // update the attribute with the result of a translation lookup by KEY
-        nodes[i].setAttribute(attr_type, i18n.getMessage(key));
+        nodes[i].setAttribute(attr_type, i18n.getMessage(key, placeholders));
       }
     });
   }

--- a/src/skin/firstRun.html
+++ b/src/skin/firstRun.html
@@ -65,13 +65,9 @@
 
     <div id="social-links">
       <h3 class="i18n_intro_social_share"></h3>
-        <a target=_blank href="https://twitter.com/home?status=I%20just%20installed%20Privacy%20Badger%2C%20a%20new%20tool%20from%20@EFF%20to%20stop%20companies%20from%20spying%20on%20your%20browsing%20habits%20https%3A%2F%2Feff.org%2Fprivacybadger&related=eff" title="Share on Twitter"><img src="/icons/t.png" alt="Share on Twitter" title="Share on Twitter"></a>
-        <a href="https://www.facebook.com/share.php?u=https%3A%2F%2Feff.org%2Fprivacybadger" target="_blank">
-          <img src="/icons/f.png" alt="Share on Facebook" title="Share on Facebook">
-        </a>
-        <a href="https://plus.google.com/share?url=https%3A%2F%2Feff.org%2Fprivacybadger" target=_blank>
-          <img src="/icons/g.png" alt="Share on Google Plus" title="Share on Google Plus">
-        </a>
+        <a target=_blank href="https://twitter.com/home?status=I%20just%20installed%20Privacy%20Badger%2C%20a%20new%20tool%20from%20@EFF%20to%20stop%20companies%20from%20spying%20on%20your%20browsing%20habits%20https%3A%2F%2Feff.org%2Fprivacybadger&related=eff"><img src="/icons/t.png" title="i18n_share_button_title" data-i18n_placeholders="Twitter"></a>
+        <a href="https://www.facebook.com/share.php?u=https%3A%2F%2Feff.org%2Fprivacybadger" target="_blank"><img src="/icons/f.png" title="i18n_share_button_title" data-i18n_placeholders="Facebook"></a>
+        <a href="https://plus.google.com/share?url=https%3A%2F%2Feff.org%2Fprivacybadger" target=_blank><img src="/icons/g.png" title="i18n_share_button_title" data-i18n_placeholders="Google Plus"></a>
     </div>
   </body>
 </html>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -64,7 +64,7 @@
         <span class="i18n_options_so_far"></span>
       </p>
       <div class="spacer"></div>
-      <input id="trackingDomainSearch" type="text" value="" style="width:100%">
+      <input id="trackingDomainSearch" type="text" value="" style="width:100%" placeholder="i18n_options_domain_search">
       <div id="blockedResources"><span class="i18n_options_loading"></span></div>
     </div>
   </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -60,7 +60,7 @@
         <span class="i18n_options_pb_has_detected"></span>
         <span id='count'>0</span>
         <span class="i18n_options_potential"></span>
-        <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?"><span class="i18n_options_tracking_domains"></span></a>
+        <a target=_blank tabindex=-1 title="i18n_what_is_a_tracker" href="https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?"><span class="i18n_options_tracking_domains"></span></a>
         <span class="i18n_options_so_far"></span>
       </p>
       <div class="spacer"></div>
@@ -77,7 +77,7 @@
       <table>
         <tr>
           <td style="max-width:100%">
-            <input type="text" value="" id="newWhitelistDomain" style="width:100%" placeholder="e.g. www.domain.com, *.domain.net, domain.org">
+            <input type="text" value="" id="newWhitelistDomain" style="width:100%" placeholder="i18n_whitelist_form_domain_input_placeholder">
           </td>
           <td>
             <button class="addButton" type="submit"><span class="i18n_add_domain_button"></span></button>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -52,7 +52,7 @@
     <span id="report_close" class="i18n_report_close"></span>
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
-    <textarea id="error_input" name="error_input" maxlength="300" placeholder="What's wrong?"></textarea>
+    <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
     <button id="report_button" class="i18n_report_button"></button>
     <button id="report_cancel" class="i18n_report_cancel"></button>
     <span id="report_success" class="i18n_report_success hidden"></span>
@@ -62,8 +62,8 @@
   </div>
 
 <div id='privacyBadgerHeader'>
-  <a id="options" title="options" href='/skin/options.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/options.svg'></a>
-  <a id="help" title="help" href='/skin/firstRun.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/help.svg'></a>
+  <a id="options" title="i18n_popup_options_button" href='/skin/options.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/options.svg'></a>
+  <a id="help" title="i18n_popup_help_button" href='/skin/firstRun.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/help.svg'></a>
   <div id='title'><img src='/icons/badger-48.png'> <h2><span class="i18n_name"></span></h2></div>
   <div class='clear'></div>
   <div id="subtitle"><span id="version" class="i18n_version"></span></div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -60,7 +60,6 @@
     <br><br>
     <p id="report_terms" class="i18n_report_terms"></p>
   </div>
-<div id="mustReloadMsg" style="display:none"><span class="i18n_new_filters_added"></span></div>
 
 <div id='privacyBadgerHeader'>
   <a id="options" title="options" href='/skin/options.html' class="control-button grey-button" style="display:block" target="_blank"><img src='/icons/options.svg'></a>


### PR DESCRIPTION
Fixes #1688.

This adds support for attribute ("title", "placeholder") replacement. This also acts as a trial run for `chrome.i18n` placeholders (#1329).