### PR TITLE
Preserve selected options tab on page reload

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -68,7 +68,13 @@ function loadOptions() {
   });
 
   // Display jQuery UI elements
-  $("#tabs").tabs();
+  $("#tabs").tabs({
+    activate: function (event, ui) {
+      // update options page URL fragment identifier
+      // to preserve selected tab on page reload
+      window.location.hash = ui.newPanel.attr('id');
+    }
+  });
   $("button").button();
   $(".refreshButton").button("option", "icons", {primary: "ui-icon-refresh"});
   $(".addButton").button("option", "icons", {primary: "ui-icon-plus"});

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -54,8 +54,7 @@ button
     padding:3px;
 }
 
-#tab-import-export {
-  width: 750px;
+#tab-manage-data {
   overflow: auto;
 }
 #import {

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -49,12 +49,12 @@
 <div id="tabs">
   <ul>
     <li><a href="#tab-general-settings"><span class="i18n_options_general_settings"></span></a></li>
-    <li><a href="#tab-whitelisted"><span class="i18n_whitelisted_domains"></span></a></li>
-    <li><a href="#tab-pb-status"><span class="i18n_options_domain_list_tab"></span></a></li>
-    <li><a href="#tab-import-export"><span class="i18n_data_settings"></span></a></li>
+    <li><a href="#tab-whitelisted-domains"><span class="i18n_whitelisted_domains"></span></a></li>
+    <li><a href="#tab-tracking-domains"><span class="i18n_options_domain_list_tab"></span></a></li>
+    <li><a href="#tab-manage-data"><span class="i18n_data_settings"></span></a></li>
   </ul>
 
-  <div id="tab-pb-status">
+  <div id="tab-tracking-domains">
     <p class=""></p>
     <div id="blockedResourcesContainer">
       <p id="pbInstructions">
@@ -71,7 +71,7 @@
   </div>
 
 
-  <div id="tab-whitelisted">
+  <div id="tab-whitelisted-domains">
     <p class="i18n_disabled_for_these_domains"></p>
 
     <form id="whitelistForm" action="#">
@@ -131,8 +131,7 @@
     </form>
   </div>
 
-  <div id="tab-import-export">
-      <p class=""></p>
+  <div id="tab-manage-data">
 
     <div id="import">
       <h3><span class="i18n_import_user_data"></span></h3>

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -23,7 +23,7 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
             (By.CSS_SELECTOR, css_selector)))
 
     def select_domain_list_tab(self):
-        self.driver.find_element_by_css_selector('a[href="#tab-pb-status"]').click()
+        self.driver.find_element_by_css_selector('a[href="#tab-tracking-domains"]').click()
 
     def load_options_page(self):
         self.load_url(self.bg_url)  # load a dummy page


### PR DESCRIPTION
Follows up on #1669. This saves having to re-select the domain list tab every time you reload the options page.