### PR TITLE
Load socialwidgets asynchronously

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -28,7 +28,11 @@ var HeuristicBlocking = require("heuristicblocking");
 var FirefoxAndroid = require("firefoxandroid");
 var webrequest = require("webrequest");
 var SocialWidgetLoader = require("socialwidgetloader");
-window.SocialWidgetList = SocialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json");
+
+window.SocialWidgetList = [];
+SocialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json", function(socialWidgets) {
+  window.SocialWidgetList = socialWidgets;
+});
 
 var Migrations = require("migrations").Migrations;
 var incognito = require("incognito");

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -44,6 +44,8 @@
 */
 /* globals chrome */
 
+var utils = require('utils');
+
 require.scopes.socialwidgetloader = (function() {
 
 var exports = {};
@@ -54,33 +56,38 @@ exports.loadSocialWidgetsFromFile = loadSocialWidgetsFromFile;
  *
  * @param {String} filePath the path to the JSON file, relative to the
  *                          extension's data folder
- * @return {Object} the JSON at the file at filePath
+ * @param {Function} callback callback(jsonParsed)
  */
-function loadJSONFromFile(filePath) {
-  var jsonString = getFileContents(filePath);
-  var jsonParsed = JSON.parse(jsonString);
-  Object.freeze(jsonParsed); // prevent modifications to jsonParsed
+function loadJSONFromFile(filePath, callback) {
+  getFileContents(filePath, function(jsonString) {
+    var jsonParsed = JSON.parse(jsonString);
+    Object.freeze(jsonParsed); // prevent modifications to jsonParsed
 
-  return jsonParsed;
+    callback(jsonParsed);
+  });
 }
 
 /**
  * Returns the contents of the file at filePath.
  *
  * @param {String} filePath the path to the file
- *
- * @return {String} the contents of the file
+ * @param {Function} callback callback(responseText)
  */
-function getFileContents(filePath) {
+function getFileContents(filePath, callback) {
   var url = chrome.extension.getURL(filePath);
 
-  var request = new XMLHttpRequest();
-  // TODO replace synchronous main thread XHR with async
-  // TODO https://xhr.spec.whatwg.org/#sync-warning
-  request.open("GET", url, false);
-  request.send();
-
-  return request.responseText;
+  utils.xhrRequest(url, function(err, responseText) {
+    if(err) {
+      console.error(
+        "Problem fetching contents of file at",
+        filePath,
+        err.status,
+        err.message
+      );
+    } else {
+      callback(responseText);
+    }
+  });
 }
 
 /**
@@ -89,21 +96,21 @@ function getFileContents(filePath) {
  *
  * @param {String} filePath the path to the JSON file, relative to the
  *                          extension's data folder
- * @return {Array} an array of SocialWidget objects that are loaded from the file at
- *                 filePath
+ * @param {Function} callback callback(socialwidgets)
  */
-function loadSocialWidgetsFromFile(filePath) {
-  var socialwidgets = [];
-  var socialwidgetsJson = loadJSONFromFile(filePath);
+function loadSocialWidgetsFromFile(filePath, callback) {
+  loadJSONFromFile(filePath, function(socialwidgetsJson) {
+    var socialwidgets = [];
 
-  // loop over each socialwidget, making a SocialWidget object
-  for (var socialwidgetName in socialwidgetsJson) {
-    var socialwidgetProperties = socialwidgetsJson[socialwidgetName];
-    var socialwidgetObject = new SocialWidget(socialwidgetName, socialwidgetProperties);
-    socialwidgets.push(socialwidgetObject);
-  }
+    // loop over each socialwidget, making a SocialWidget object
+    for (var socialwidgetName in socialwidgetsJson) {
+      var socialwidgetProperties = socialwidgetsJson[socialwidgetName];
+      var socialwidgetObject = new SocialWidget(socialwidgetName, socialwidgetProperties);
+      socialwidgets.push(socialwidgetObject);
+    }
 
-  return socialwidgets;
+    callback(socialwidgets);
+  });
 }
 
 /**


### PR DESCRIPTION
Fixes #1477 

Using the xhrRequest helper function in utils.js in order to make the asynchronous XHR request to load socialwidgets. If there is an error making the XHR request, then the error is shown in the console, but is not propagated through the callbacks (not sure if this should be changed). window.SocialWidgetList is also given an empty list as a default value.