### PR TITLE
Add ecwid.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -133,6 +133,7 @@ ebay.com
 ebayimg.com
 ebayrtm.com
 ebaystatic.com
+ecwid.com
 edgecastcdn.net
 edgefcs.net
 edgekey.net


### PR DESCRIPTION
Session cookies (#1545) and localStorage from `wix.ecwid.com`.

Examples:

- https://www.csgoknives.co.uk/online-store/
- https://www.titan1918-russia.com
- https://www.titan1918.com

More examples can be found [here](https://publicwww.com/websites/"wix.ecwid.com"/).

An Ecwid representative's `action_map` also shows tracking from `app.ecwid.com` and `my.ecwid.com`, hence the base domain. Inquired in the same email thread about Ecwid adopting DNT.