### PR TITLE
Add gfycat.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -191,6 +191,7 @@ geoplugin.net
 geotrust.com
 getpocket.com
 giant.gfycat.com
+gfycat.com
 ggpht.com
 giphy.com
 github.com


### PR DESCRIPTION
Examples:
- http://miegakure.com
- https://www.reddit.com/r/blackmagicfuckery/comments/73u1uq/slinky_telekinesis_class_at_chinese_hogwarts/
- http://mgoblog.com
- http://marctenbosch.com/news/

Sets various cookies and localStorage.

Distinct blocked domains in error reports:
```
+-------+-------------------+
| count | blocked_fqdn      |
+-------+-------------------+
|    88 | gfycat.com        |
|    27 | zippy.gfycat.com  |
|    26 | thumbs.gfycat.com |
|    23 | fat.gfycat.com    |
|    17 | giant.gfycat.com  |
|    11 | assets.gfycat.com |
|     3 | pixel.gfycat.com  |
|     2 | test.gfycat.com   |
|     2 | upload.gfycat.com |
|     1 | www.gfycat.com    |
+-------+-------------------+
```

Previously: #532.