### PR TITLE
Add api-cdn.embed.ly to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -139,11 +139,12 @@ edgekey.net
 files.edx.org
 elasticbeanstalk.com
 eltrafiko.com
+api-cdn.embed.ly
 api.embed.ly
 cdn.embed.ly
 cdn.embedly.com
-i.embed.ly
 i-cdn.embed.ly
+i.embed.ly
 epoch.com
 estara.com
 ethn.io


### PR DESCRIPTION
I don't see tracking from `api-cdn.embed.ly`, but it gets blocked when its base domain gets marked for blocking.

Examples:
- https://www.reddit.com/live/zl0eib0kgh90
- https://www.hln.be/sport/time-out/nieuwe-kledingvoorschriften-voor-golfsters-daar-heeft-deze-blondine-een-wel-heel-erg-duidelijke-mening-over~a0de9ec4/
- https://www.businessoffashion.com/daily-digest/2017/08/08#marc-jacobs-on-hip-hop-and-charges-of-cultural-appropriation-maybe-ive-been-insensitive

Previously: 1480d03578ecd4c43b9bb2827c0f4bfcf086ba70, a174a14f81808ba4bf6cfd56845265b1bcd6d71c, 41095cdd27419f2017a6b0d93aacd1c18100b84e. Might have been easier to yellowlist all of `embed.ly` / `embedly.com` instead.

