### PR TITLE
Add library.rochester.edu to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -449,6 +449,7 @@ redditmedia.com
 redditstatic.com
 resellerratings.com
 resultspage.com
+library.rochester.edu
 rpxnow.com
 rssinclude.com
 salesforce.com


### PR DESCRIPTION
I was unable to access documents through the ProQuest database when on the University of Rochester's network, but yellowlisting www.library.rochester.edu fixed the issue. I suspect this domain is being detected as a tracker because the web pages involved do some weird voodoo to automatically authenticate traffic coming from the University's network, but this hypothesis would need more investigation to be confirmed.