### PR TITLE
Add dealer.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -109,6 +109,7 @@ cursecdn.com
 custhelp.com
 d3js.org
 dailymotion.com
+dealer.com
 delicious.com
 delvenetworks.com
 denverpost.com


### PR DESCRIPTION
Fixes #1501. I see a "userId" cookie and localStorage use.

More examples:
- https://www.audifairfield.com/global-incentives-search/index.htm?&ddcref=nav_SpecialsFinance
- http://www.volkswagenpasadena.com
- https://www.andersondodge.net/new/Chrysler/2018-Chrysler-Pacifica-Rockford-dd3e8ae90a0e0a1748743f962438ab88.htm
- http://www.carlburger.com

Monthly counts of blocked `dealer.com` domains in error reports:
```
+---------+----------+
| ym      | count(*) |
+---------+----------+
| 2017-10 |        7 |
| 2017-09 |       23 |
| 2017-08 |       28 |
| 2017-07 |       32 |
| 2017-06 |       45 |
| 2017-05 |       49 |
| 2017-04 |       58 |
| 2017-03 |       40 |
| 2017-02 |       31 |
| 2017-01 |       27 |
| 2016-12 |       31 |
| 2016-11 |       10 |
| 2016-10 |       13 |
| 2016-09 |       22 |
| 2016-08 |       17 |
| 2016-07 |        6 |
| 2016-06 |        7 |
| 2016-05 |       13 |
| 2016-04 |       25 |
| 2016-03 |       17 |
| 2016-02 |       26 |
| 2016-01 |       18 |
| 2015-12 |       13 |
| 2015-11 |        9 |
| 2015-10 |       18 |
| 2015-09 |        8 |
| 2015-08 |       20 |
+---------+----------+
```