### PR TITLE
change author key to a string in the manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2017.9.12.1",
-  "author": { "email": "eff.software.projects@gmail.com" },
+  "author": "eff.software.projects@gmail.com",
   "applications": {
     "gecko": {
       "id": "jid1-MnnxcxisBPnSXQ@jetpack"


### PR DESCRIPTION
The specification for Firefox extensions [specifies that the value of author should be a string](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/author). Fixes #1728 

Changing the value of "Author" to just the email address, instead of a JSON object containing an email field