### PR TITLE
Add cdn.cnetcontent.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -95,6 +95,7 @@ gr-assets.com
 guardian.co.uk
 media-imdb.com
 mediaworks.co.nz
+cdn.cnetcontent.com
 com.com
 complex.com
 convio.net


### PR DESCRIPTION
I see cookies from `ws.cnetcontent.com` (one low entropy month-long cookie and two high-entropy session cookies, #1545), and nothing from `cdn.cnetcontent.com`.

Examples:
- https://www.cdw.com/shop/products/Tripp-Lite-DVI-over-Cat5-Cat6-Video-Extender-Kit-1920x1080-TAA/2090126.aspx?pfm=srh&expand=URV#URV
- http://www.argos.co.uk/product/9269213
- http://www.bjs.com/mac-motion-oslo-collection-air-leather-recliner-with-ottoman---whisky.product.3000000000000944616
- http://www.compumail.dk/vare-oversigt.php?varenummer=992502035&type=hardware&RefId=pricerunner (broken images)
- https://www.pcworldbusiness.co.uk/catalogue/item/P231837P (broken images)