### PR TITLE
change author key to a string in the manifest

### DIFF
--- a/release-utils/make-signed-xpi.sh
+++ b/release-utils/make-signed-xpi.sh
@@ -28,7 +28,7 @@ if [ $# -ne 1 ]; then
 fi
 
 echo "change author value"
-sed -i 's/"author": { "email": "eff.software.projects@gmail.com" },/"author": "privacybadger-owner@eff.org",/' ../checkout/src/manifest.json
+sed -i 's/"eff.software.projects@gmail.com"/"privacybadger-owner@eff.org"/' ../checkout/src/manifest.json
 
 echo "making zip file for AMO"
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2017.9.12.1",
-  "author": { "email": "eff.software.projects@gmail.com" },
+  "author": "eff.software.projects@gmail.com",
   "applications": {
     "gecko": {
       "id": "jid1-MnnxcxisBPnSXQ@jetpack"


### PR DESCRIPTION
The specification for Firefox extensions specifies the value of author should be a string. Fixes #1728 

Also, updated the release utils script that modifies the email when building the Firefox extension. Simplified, since we aren't changing from object to string any more.

Published then updated in Chrome Web Store to verify that changing the author from an object to a string wouldn't break anything on the Chrome side. Manually executed the `sed` script to verify that only the author value gets changed.