### PR TITLE
Improve popup on special pages

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -175,21 +175,36 @@ Badger.prototype = {
   updateTabList: function() {
     // Initialize the tabData/frames object if it is falsey
     this.tabData = this.tabData || {};
-    var self = this;
-    chrome.tabs.query({currentWindow: true, status: 'complete'}, function(tabs) {
-      for (var i = 0; i < tabs.length; i++) {
-        var tab = tabs[i];
-        self.tabData[tab.id] = {
-          frames: {
-            0: {
-              parent: -1,
-              url: tab.url
-            }
-          },
-          origins: {}
-        };
-      }
+    let self = this;
+    chrome.tabs.query({}, tabs => {
+      tabs.forEach(tab => {
+        self.recordFrame(tab.id, 0, -1, tab.url);
+      });
     });
+  },
+
+  /**
+   * Generate representation in internal data structure for frame
+   *
+   * @param tabId ID of the tab
+   * @param frameId ID of the frame
+   * @param parentFrameId ID of the parent frame
+   * @param frameUrl The url of the frame
+   */
+  recordFrame: function(tabId, frameId, parentFrameId, frameUrl) {
+    let self = this;
+
+    if (!self.tabData.hasOwnProperty(tabId)) {
+      self.tabData[tabId] = {
+        frames: {},
+        origins: {}
+      };
+    }
+
+    self.tabData[tabId].frames[frameId] = {
+      url: frameUrl,
+      parent: parentFrameId
+    };
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -507,11 +507,14 @@ Badger.prototype = {
 
   /**
    * Helper function returns a list of all third party origins for a tab
-   * @param {Integer} tabId requested tab id as provided by chrome
+   * @param {Integer} tab_id requested tab id as provided by chrome
    * @returns {*} A dictionary of third party origins and their actions
    */
-  getAllOriginsForTab: function(tabId) {
-    return Object.keys(this.tabData[tabId].origins);
+  getAllOriginsForTab: function (tab_id) {
+    return (
+      this.tabData.hasOwnProperty(tab_id) &&
+      Object.keys(this.tabData[tab_id].origins)
+    );
   },
 
   /**

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -63,7 +63,7 @@ function showNagMaybe() {
 /**
  * Init function. Showing/hiding popup.html elements and setting up event handler
  */
-function init() {
+function init(tab) {
   showNagMaybe();
 
   $("#activate_site_btn").click(active_site);
@@ -94,19 +94,16 @@ function init() {
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
   });
 
-  //toggle activation buttons if privacy badger is not enabled for current url
-  getTab(function(t) {
-    if (!badger.isPrivacyBadgerEnabled(backgroundPage.extractHostFromURL(t.url))) {
-      $("#blockedResourcesContainer").hide();
-      $("#activate_site_btn").show();
-      $("#deactivate_site_btn").hide();
-    }
-  });
+  // toggle activation buttons if privacy badger is not enabled for current url
+  if (!badger.isPrivacyBadgerEnabled(backgroundPage.extractHostFromURL(tab.url))) {
+    $("#blockedResourcesContainer").hide();
+    $("#activate_site_btn").show();
+    $("#deactivate_site_btn").hide();
+  }
 
   var version = i18n.getMessage("version") + " " + chrome.runtime.getManifest().version;
   $("#version").text(version);
 }
-$(init);
 
 /**
 * Close the error reporting overlay
@@ -467,8 +464,9 @@ function getTab(callback) {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  getTab(function(t) {
-    refreshPopup(t.id);
+  getTab(function (tab) {
+    refreshPopup(tab.id);
+    init(tab);
   });
 });
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -250,8 +250,29 @@ function registerToggleHandlers() {
 * @param {Integer} tabId The id of the tab
 */
 function refreshPopup(tabId) {
-  //TODO this is calling get action and then being used to call get Action
-  var origins = badger.getAllOriginsForTab(tabId);
+  // must be a special browser page,
+  // or a page that loaded everything before our most recent initialization
+  if (!badger.tabData.hasOwnProperty(tabId)) {
+    // replace inapplicable summary text with a Badger logo
+    $('#pbInstructions').html(
+      "<img src='" +
+      chrome.extension.getURL('icons/badger-128.png') +
+      "' alt=''>"
+    ).css({
+      "text-align": "center"
+    });
+
+    // hide inapplicable buttons
+    $('#deactivate_site_btn').hide();
+    $('#error').hide();
+
+    // activate tooltips
+    $('.tooltip').tooltipster();
+
+    return;
+  }
+
+  let origins = badger.getAllOriginsForTab(tabId);
 
   if (!origins || origins.length === 0) {
     $("#blockedResources").html(i18n.getMessage("popup_blocked"));

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -257,13 +257,8 @@ function refreshPopup(tabId) {
   // or a page that loaded everything before our most recent initialization
   if (!badger.tabData.hasOwnProperty(tabId)) {
     // replace inapplicable summary text with a Badger logo
-    $('#pbInstructions').html(
-      "<img src='" +
-      chrome.extension.getURL('icons/badger-128.png') +
-      "' alt=''>"
-    ).css({
-      "text-align": "center"
-    });
+    $('#blockedResourcesContainer').hide();
+    $('#big-badger-logo').show();
 
     // hide inapplicable buttons
     $('#deactivate_site_btn').hide();
@@ -273,6 +268,14 @@ function refreshPopup(tabId) {
     $('.tooltip').tooltipster();
 
     return;
+
+  } else {
+    // revert any hiding/showing above for cases when refreshPopup gets called
+    // more than once for the same popup, such as during functional testing
+    $('#blockedResourcesContainer').show();
+    $('#big-badger-logo').hide();
+    $('#deactivate_site_btn').show();
+    $('#error').show();
   }
 
   let origins = badger.getAllOriginsForTab(tabId);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -182,6 +182,7 @@ function active_site() {
     badger.enablePrivacyBadgerForOrigin(backgroundPage.extractHostFromURL(tab.url));
     badger.refreshIconAndContextMenu(tab);
     reloadTab(tab.id);
+    window.close();
   });
 }
 
@@ -196,6 +197,7 @@ function deactive_site() {
     badger.disablePrivacyBadgerForOrigin(backgroundPage.extractHostFromURL(tab.url));
     badger.refreshIconAndContextMenu(tab);
     reloadTab(tab.id);
+    window.close();
   });
 }
 
@@ -216,6 +218,7 @@ function revertDomainControl(e) {
   selector.click();
   $elm.removeClass('userset');
   reloadTab(tabId);
+  window.close();
   return false;
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -61,7 +61,7 @@ function onBeforeRequest(details) {
     if (type == "main_frame" && frame_id != 0) {
       frame_id = 0;
     }
-    recordFrame(tab_id, frame_id, details.parentFrameId, url);
+    badger.recordFrame(tab_id, frame_id, details.parentFrameId, url);
   }
 
   // Block ping requests sent by navigator.sendBeacon (see, #587)
@@ -319,28 +319,6 @@ function getHostForTab(tabId) {
     return '';
   }
   return window.extractHostFromURL(badger.tabData[tabId].frames[mainFrameIdx].url);
-}
-
-/**
- * Generate representation in internal data structure for frame
- *
- * @param tabId ID of the tab
- * @param frameId ID of the frame
- * @param parentFrameId ID of the parent frame
- * @param frameUrl The url of the frame
- */
-function recordFrame(tabId, frameId, parentFrameId, frameUrl) {
-  if (!badger.tabData.hasOwnProperty(tabId)) {
-    badger.tabData[tabId] = {
-      frames: {},
-      origins: {}
-    };
-  }
-
-  badger.tabData[tabId].frames[frameId] = {
-    url: frameUrl,
-    parent: parentFrameId
-  };
 }
 
 /**

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -363,6 +363,7 @@ font-size: 16px;
 }
 #siteControls button {
   font-size: 12px;
+  display: block;
 }
 
 #version{

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -77,10 +77,10 @@
 </div>
 
 <div id="siteControls">
-    <center><button id="deactivate_site_btn" class="pbButton" style="display:block"><span class="i18n_popup_disable_for_site"></span></button></center>
-  <center><button id="activate_site_btn" class="pbButton" style="display:none"> <span class="i18n_popup_enable_for_site"></span></button></center>
-  <center><button id="error" class="pbButton" style="display:block" target="blank"><span class="i18n_report_broken_site"></span></button></center>
-  <center><button id="donate" class="pbButton" style="display:block" target="blank"><span class="i18n_donate_to_eff"></span></button></center>
+    <button id="deactivate_site_btn" class="pbButton"><span class="i18n_popup_disable_for_site"></span></button>
+    <button id="activate_site_btn" class="pbButton" style="display:none"> <span class="i18n_popup_enable_for_site"></span></button>
+    <button id="error" class="pbButton" target="blank"><span class="i18n_report_broken_site"></span></button>
+    <button id="donate" class="pbButton" target="blank"><span class="i18n_donate_to_eff"></span></button>
 </div>
 <div class='clear'></div>
 </body>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -70,10 +70,15 @@
   <div class='clear'></div>
   <div id="subtitle"><span id="version" class="i18n_version"></span></div>
 </div>
+
 <div id="blockedResourcesContainer">
   <p id="pbInstructions"> <span class="i18n_pb_detected"></span> <span id='number_trackers'></span> <span class="i18n_popup_instructions"></span></p>
   <div class="spacer"></div>
   <div id="blockedResources"><span class="options_loading"></span></div>
+</div>
+
+<div id="big-badger-logo" style="display:none; text-align:center; margin:18px 0;">
+    <img src="/icons/badger-128.png" alt="">
 </div>
 
 <div id="siteControls">

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -44,6 +44,25 @@ class PopupTest(pbtest.PBSeleniumTest):
     def open_popup(self, close_overlay=True):
         """Open popup and optionally close overlay."""
         self.load_url(self.popup_url, wait_on_site=1)
+
+        # hack to get tabData populated for the popup's tab
+        # to get the popup shown for regular pages
+        # as opposed to special (no-tabData) browser pages
+        # TODO instead use a proper popup-opening function to open the popup
+        # for some test page like https://www.eff.org/files/badgertest.txt;
+        # for example, see https://github.com/EFForg/privacybadger/issues/1634
+        self.js("""getTab(function (tab) {
+  badger.recordFrame(tab.id, 0, -1, tab.url);
+  refreshPopup(tab.id);
+  window.DONE_REFRESHING = true;
+});""")
+        # wait until the async getTab function is done
+        self.wait_for_script(
+            "return typeof window.DONE_REFRESHING != 'undefined'",
+            timeout=5,
+            message="Timed out waiting for getTab() to complete."
+        )
+
         if close_overlay:
             # Click 'X' element to close overlay.
             try:

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -170,41 +170,6 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.assertEqual(self.driver.current_url, EFF_URL,
             "EFF website should open after clicking trackers link on popup")
 
-    def test_disable_enable_buttons(self):
-        """Ensure disable/enable buttons change popup state."""
-        self.open_popup()
-
-        disable_button = self.get_disable_button()
-        disable_button.click()
-
-        WebDriverWait(self.driver, 3).until(
-            expected_conditions.presence_of_element_located(
-                (By.ID, "deactivate_site_btn")))
-
-        displayed_error = " should not be displayed on popup"
-        not_displayed_error = " should be displayed on popup"
-
-        # Check that popup state changed after disabling.
-        disable_button = self.get_disable_button()
-        self.assertFalse(disable_button.is_displayed(),
-                         "Disable button" + displayed_error)
-        enable_button = self.get_enable_button()
-        self.assertTrue(enable_button.is_displayed(),
-                        "Enable button" + not_displayed_error)
-
-        enable_button.click()
-
-        WebDriverWait(self.driver, 3).until(
-            expected_conditions.presence_of_element_located(
-                (By.ID, "activate_site_btn")))
-
-        # Check that popup state changed after re-enabling.
-        disable_button = self.get_disable_button()
-        self.assertTrue(disable_button.is_displayed(),
-                        "Disable button" + not_displayed_error)
-        enable_button = self.get_enable_button()
-        self.assertFalse(enable_button.is_displayed(),
-                         "Enable button" + displayed_error)
     def test_error_button(self):
         """Ensure error button opens report error overlay."""
         self.open_popup()


### PR DESCRIPTION
Fixes #1625.

Fixes #1311, fixes #1492 by virtue of reloading the popup after clicking the undo arrow (as well as the enable/disable Badger buttons). This doesn't need to be in this PR; if it causes trouble, let's break it out.

Related to #1627.

Does not fix:
- Poor button placement on whitelisted sites
- Unneeded scrollbars in Firefox (#1610)
- Not recognizing `chrome://extensions` (or Chrome Web Store, or `about:debugging` in Firefox, ...) as a special browser page
- Popup showing the tutorial message when opened on the tutorial page following a new install
- Browser button not getting updated to reflect site whitelist updates in tabs outside of the active tab when enabling/disabling Badger on a site open in multiple tabs

Before:
![screenshot from 2017-10-18 11 21 26](https://user-images.githubusercontent.com/794578/31727159-e81d4648-b3f6-11e7-8730-02ee17c887b1.png)

After:
![screenshot from 2017-10-19 10 12 13](https://user-images.githubusercontent.com/794578/31775237-0b06c750-b4b6-11e7-9a13-57430c034e3a.png)