### PR TITLE
Stop errors from leaking to the console

### DIFF
--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -48,7 +48,8 @@ chrome.runtime.sendMessage({checkLocation:document.location.href}, function(bloc
           window.localStorage.setItem = function(/*newValue*/) {
             //doNothing
           };
-        } catch(ex) {
+        } catch (ex) {
+          // ignore error
         }
       } +')()';
 

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -41,12 +41,15 @@ chrome.runtime.sendMessage({checkLocation:document.location.href}, function(bloc
   if (blocked) {
     var code =
       '('+ function() {
-        window.localStorage.getItem = function () {
-          return {};
-        };
-        window.localStorage.setItem=function (/*newValue*/) {
-          //doNothing
-        };
+        try {
+          window.localStorage.getItem = function() {
+            return {};
+          };
+          window.localStorage.setItem = function(/*newValue*/) {
+            //doNothing
+          };
+        } catch(ex) {
+        }
       } +')()';
 
     insertClsScript(code);


### PR DESCRIPTION
The local storage clobbering can cause security errors when third-party cookies are being blocked. Previously, the error would leak out onto the console producing noise that makes debugging sites harder. This commit catches the error and ignores it.