### PR TITLE
Add cds.cern.ch and mediarchive.cern.ch to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -76,6 +76,7 @@ cbsimg.net
 cbsistatic.com
 cdninstagram.com
 cdnpk.com
+cern.ch
 charter.com
 civicscience.com
 cleanprint.net


### PR DESCRIPTION
Hello,

as reported by @RaoOfPhysics, some users at CERN are using privacybadger and it's blocking content coming from [cds.cern.ch](https://cds.cern.ch) and [mediaarchive.cern.ch](mediaarchive.cern.ch), which is a bit inconvenient for users as it simply blocks images (from CDS) and videos (from mediarchive).
cds.cern.ch (CERN Document Server) is using Piwik (an instance that is hosted at CERN) for gathering usage statistics and mediaarchive.cern.ch is a streaming server for videos, so it doesn't have any scripts.
Would it be possible to add those 2 websites to the yellowlist?
If not, is there anything we should do on our side.
cc @ludmilamarian and @jbenito3 as service managers of CDS.