### PR TITLE
Add American Express domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -14,6 +14,32 @@ var multiDomainFirstPartiesArray = [
   ["altra.org", "altraonline.org"],
   ["amazon.com", "amazon.com.au", "amazon.ca", "amazon.co.jp", "amazon.co.uk", "amazon.de",
     "amazon.es", "amazon.fr", "amazon.it", "ssl-images-amazon.com", "media-amazon.com"],
+  [
+    "americanexpress.com",
+
+    "americanexpress.ca",
+    "americanexpress.ch",
+    "americanexpress.com.au",
+    "americanexpress.co.uk",
+    "americanexpress.no",
+
+    "membershiprewards.ca",
+    "membershiprewards.com.ar",
+    "membershiprewards.com.au",
+    "membershiprewards.com.sg",
+    "membershiprewards.co.uk",
+    "membershiprewards.de",
+
+    "aetclocator.com",
+    "americanexpressfhr.com",
+    "amexnetwork.com",
+    "amextravel.com",
+    "amextravelresources.com",
+    "thecenturionlounge.com",
+    "yourcarrentalclaim.com",
+
+    "aexp-static.com",
+  ],
   ["ameritrade.com", "tdameritrade.com"],
   ["ancestry.com", "mfcreative.com"],
   ["androidcentral.com", "mobilenations.com"],


### PR DESCRIPTION
`www.americanexpress.com` is a top site domain in error reports. Most reports seem to complain about messed up stylesheets, which seems to be caused by learning to block `aexp-static.com` resources.

Sample pages:
- https://faq.amextravel.com/
- https://www.americanexpressfhr.com/featured-hotel-searches
- https://www.americanexpress.com/
- https://www.bluebird.com/ (didn't add to MDFP list since it's not clear this is entirely American Express and not AmEx + Walmart, and it's not clear anything is broken (nothing yet in error reports; see below))
- http://catalogue.membershiprewards.com.au/
- https://travel.americanexpress.com.au/
- https://insurance.americanexpress.co.uk/

Example [debugging info](https://gist.github.com/anonymous/8aebb8e48a1ce3c256b21dcfe37af84b):
```
**** ACTION_MAP for aexp-static 
www.aexp-static.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 1509695035764
} 
aexp-static.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
} 
icm.aexp-static.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 1510061711832
} 
qweb.aexp-static.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 1509676928798
} 
web.aexp-static.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 1509734394063
} 
**** SNITCH_MAP for aexp-static 
aexp-static.com [
  "americanexpress.com",
  "thecenturionlounge.com",
  "bluebird.com",
  "americanexpressfhr.com"
]
```

Error report counts of blocked `aexp-static.com` domains by month:
```
+---------+----------+
| ym      | COUNT(*) |
+---------+----------+
| 2017-10 |       59 |
| 2017-09 |       26 |
| 2017-08 |       15 |
| 2017-07 |       12 |
| 2017-06 |       20 |
| 2017-05 |       13 |
| 2017-04 |       18 |
| 2017-03 |        4 |
| 2017-02 |        8 |
| 2017-01 |        3 |
| 2016-12 |        4 |
| 2016-11 |        2 |
| 2016-10 |        1 |
| 2016-08 |        1 |
| 2016-05 |        4 |
| 2016-04 |        1 |
| 2016-01 |        3 |
| 2015-12 |        1 |
| 2015-10 |        4 |
| 2015-08 |        1 |
+---------+----------+
```

Error report counts of blocked `aexp-static.com` domains by site domain and exact blocked `aexp-static.com` subdomain (country code TLDs again, #1253 would help here):
```
+--------------------------------------------+----------------------+-------+
| fqdn                                       | blocked_fqdn         | count |
+--------------------------------------------+----------------------+-------+
| www.americanexpress.com                    | www.aexp-static.com  |    58 |
| online.americanexpress.com                 | www.aexp-static.com  |    25 |
| global.americanexpress.com                 | www.aexp-static.com  |    19 |
| www.americanexpress.com                    | icm.aexp-static.com  |    18 |
| travel.americanexpress.com                 | www.aexp-static.com  |    10 |
| www.americanexpress.com                    | web.aexp-static.com  |     9 |
| www.amextravel.com                         | www.aexp-static.com  |     8 |
| travel.americanexpress.com                 | icm.aexp-static.com  |     7 |
| global.americanexpress.com                 | icm.aexp-static.com  |     7 |
| global.americanexpress.com                 | web.aexp-static.com  |     6 |
| thecenturionlounge.com                     | www.aexp-static.com  |     3 |
| rewards.americanexpress.com                | icm.aexp-static.com  |     3 |
| rewards.americanexpress.com                | www.aexp-static.com  |     3 |
| online.americanexpress.com                 | icm.aexp-static.com  |     3 |
| rewarddollars.americanexpress.com          | www.aexp-static.com  |     3 |
| online.americanexpress.com                 | qwww.aexp-static.com |     2 |
| www.americanexpressfhr.com                 | www.aexp-static.com  |     1 |
| insurance.americanexpress.co.uk            | www.aexp-static.com  |     1 |
| offers.amexnetwork.com                     | www.aexp-static.com  |     1 |
| www209.americanexpress.com                 | icm.aexp-static.com  |     1 |
| faq.amextravel.com                         | www.aexp-static.com  |     1 |
| cardappdacq.americanexpress.com            | www.aexp-static.com  |     1 |
| cardappdacq.americanexpress.com            | icm.aexp-static.com  |     1 |
| www295.americanexpress.com                 | www.aexp-static.com  |     1 |
| www298.americanexpress.com                 | icm.aexp-static.com  |     1 |
| www298.americanexpress.com                 | www.aexp-static.com  |     1 |
| www437.americanexpress.com                 | www.aexp-static.com  |     1 |
| www437.americanexpress.com                 | web.aexp-static.com  |     1 |
| www.airbnb.com                             | icm.aexp-static.com  |     1 |
| travel.americanexpress.ca                  | www.aexp-static.com  |     1 |
| travel.americanexpress.ca                  | qwww.aexp-static.com |     1 |
| globaldiningcollection.americanexpress.com | www.aexp-static.com  |     1 |
+--------------------------------------------+----------------------+-------+
```

