### PR TITLE
issue #1743: Enhance the tutorial message in popup

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -59,15 +59,30 @@ function showNagMaybe() {
   }
 
   if (!seenComic) {
-    nag.show();
-    outer.show();
-    // Attach event listeners
-    $('#fittslaw').click(_hideNag);
-    $("#firstRun").click(function() {
-      chrome.tabs.create({
-        url: chrome.extension.getURL("/skin/firstRun.html#slideshow")
-      });
-      _hideNag();
+    chrome.tabs.query({active: true, currentWindow: true}, function (focusedTab) {
+      var firstRunUrl = chrome.extension.getURL("/skin/firstRun.html");
+
+      // Show the popup instruction if the active tab is not firstRun.html page
+      if (!focusedTab[0].url.startsWith(firstRunUrl)) {
+        nag.show();
+        outer.show();
+        // Attach event listeners
+        $('#fittslaw').click(_hideNag);
+        $("#firstRun").click(function() {
+          // If there is a firstRun.html tab, switch to the tab.
+          // Otherwise, create a new tab
+          chrome.tabs.query({url: firstRunUrl}, function (tabs) {
+            if (tabs.length == 0) {
+              chrome.tabs.create({
+                url: chrome.extension.getURL("/skin/firstRun.html#slideshow")
+              });
+            } else {
+              chrome.tabs.update(tabs[0].id, {active: true});
+            }
+            _hideNag();
+          });
+        });
+      }
     });
   }
 }

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -41,8 +41,11 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.driver.switch_to.window(new_handle.pop())
 
-    def open_popup(self, close_overlay=True):
+    def open_popup(self, close_overlay=True, new_url=True):
         """Open popup and optionally close overlay."""
+        if new_url:
+            self.load_url("http://eff-tracker-site1-test.s3-website-us-west-2.amazonaws.com")
+
         self.load_url(self.popup_url, wait_on_site=1)
 
         # hack to get tabData populated for the popup's tab
@@ -63,7 +66,7 @@ class PopupTest(pbtest.PBSeleniumTest):
             message="Timed out waiting for getTab() to complete."
         )
 
-        if close_overlay:
+        if close_overlay and new_url:
             # Click 'X' element to close overlay.
             try:
                 close_element = self.driver.find_element_by_id("fittslaw")
@@ -243,6 +246,42 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.assertEqual(self.driver.current_url, EFF_URL,
             "EFF website should open after clicking donate button on popup")
+
+    def test_not_show_instruction(self):
+        """Ensure the instruction message doesn't display on firstRun.html ."""
+        self.open_popup(new_url=False)
+
+        try:
+            instruction = self.driver.find_element_by_id("instruction")
+        except NoSuchElementException:
+            self.fail("Unable to find instruction on popup")
+        self.assertEqual(instruction.value_of_css_property("display"), "none",
+            "Instruction message should not display when the active tab is firstRun.html")
+
+    def test_switch_existing_first_run_tab(self):
+        """Ensure click the comic link switch to an existing tab"""
+
+        self.open_popup(close_overlay=False)
+
+        try:
+            comic_link = self.driver.find_element_by_id("firstRun")
+        except NoSuchElementException:
+            self.fail("Unable to find link to comic on popup overlay")
+        comic_link.click()
+
+        # Make sure first run comic not opened in same window.
+        time.sleep(1)
+
+        self.assertEqual(len(self.driver.window_handles), 2,
+            "Click firstrun link should switch existing tab")
+
+        # Look for first run page and return if found.
+        for window in self.driver.window_handles:
+            self.driver.switch_to.window(window)
+            if self.driver.current_url.startswith(self.first_run_url):
+                return
+
+        self.fail("First run comic not switched to existing tab after clicking link in popup overlay")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The pull request fix issue #1743 . Please take a look.

It contains the following changes for comic in popup:
- The instruction message doesn't show when the current page is firstRun.html.
- If the first run link in popup is clicked, it switched into existing firstRun.html tab or create a new tab. 