### PR TITLE
Add box.com and boxcdn.net to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -29,6 +29,7 @@ var multiDomainFirstPartiesArray = [
   ["bank-yahav.co.il", "bankhapoalim.co.il"],
   ["belkin.com", "seedonk.com"],
   ["booking.com", "bstatic.com"],
+  ["box.com", "boxcdn.net"],
   ["capitalone.com", "capitalone360.com"],
   ["century21.com", "21online.com"],
   ["chart.io", "chartio.com"],


### PR DESCRIPTION
From a support email:

>cdn01.boxcdn.net was used by buffalo.app.box.com (box.com using buffalo.edu credentials). Moving the slider from blocked to cookies did the trick for that site.


Error report counts by page domain and exact blocked subdomain:
```
+----------------------------+------------------+-------+
| fqdn                       | blocked_fqdn     | count |
+----------------------------+------------------+-------+
| app.box.com                | cdn01.boxcdn.net |     2 |
| cisco.account.box.com      | cdn01.boxcdn.net |     1 |
| downstream.account.box.com | cdn01.boxcdn.net |     1 |
| geant.app.box.com          | cdn01.boxcdn.net |     1 |
| icscreative.app.box.com    | cdn01.boxcdn.net |     1 |
| lendup.account.box.com     | cdn01.boxcdn.net |     1 |
| lion.app.box.com           | cdn01.boxcdn.net |     1 |
| m.box.com                  | cdn01.boxcdn.net |     1 |
| members.simpleroptions.com | cdn01.boxcdn.net |     1 |
| mmodal.account.box.com     | cdn01.boxcdn.net |     1 |
| rootcapital.app.box.com    | cdn01.boxcdn.net |     1 |
| skamarin.app.box.com       | cdn01.boxcdn.net |     1 |
| sonoco.app.box.com         | cdn01.boxcdn.net |     1 |
| unl.app.box.com            | cdn01.boxcdn.net |     1 |
| uofi.app.box.com           | cdn01.boxcdn.net |     1 |
| www.box.com                | cdn01.boxcdn.net |     1 |
+----------------------------+------------------+-------+
```

Error report counts by date and exact blocked subdomain:
```
+---------+------------------+-------+
| ym      | blocked_fqdn     | count |
+---------+------------------+-------+
| 2017-10 | cdn01.boxcdn.net |     1 |
| 2017-07 | cdn01.boxcdn.net |     1 |
| 2017-06 | cdn01.boxcdn.net |     1 |
| 2017-05 | cdn01.boxcdn.net |     1 |
| 2017-04 | cdn01.boxcdn.net |     2 |
| 2017-03 | cdn01.boxcdn.net |     3 |
| 2017-01 | cdn01.boxcdn.net |     3 |
| 2016-04 | cdn01.boxcdn.net |     1 |
| 2016-02 | cdn01.boxcdn.net |     1 |
| 2015-11 | cdn01.boxcdn.net |     1 |
| 2015-10 | cdn01.boxcdn.net |     2 |
+---------+------------------+-------+
```

It's not clear why or how Badger learns to block `cdn01.boxcdn.net` on `box.com` domains (a (residual) result of attribution bugs?), but the fix is straightforward.