### PR TITLE
Fix Fox News video

### DIFF
--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -18,12 +18,22 @@
 
 require.scopes.surrogatedb = (function() {
 
-// "hostnames" maps hostnames to arrays of surrogate pattern tokens.
-//
-// A hostname can have one or more surrogate scripts.
-//
-// Surrogate pattern tokens are used to look up the actual
-// surrogate script code (stored in "surrogates" object below).
+/**
+ * A hostname can have one or more surrogate scripts.
+ *
+ * "hostnames" maps hostnames to surrogate pattern tokens.
+ *
+ * Surrogate pattern tokens are used to look up the actual
+ * surrogate script code (stored in "surrogates" object below).
+ *
+ * There are currently two types of surrogate pattern tokens:
+ *
+ * - {Array} one or more suffix tokens:
+ *   Does the script URL (querystring excluded) end with the token?
+ *
+ * - {String} wildcard token:
+ *   Matches any script URL for the hostname.
+ */
 const hostnames = {
   'b.scorecardresearch.com': [
     '/beacon.js',
@@ -55,10 +65,9 @@ const hostnames = {
   ],
 };
 
-// "surrogates" maps surrogate pattern tokens to surrogate script code.
-//
-// There is currently one type of surrogate pattern token: suffix.
-// Does the script URL (querystring excluded) end with the token?
+/**
+ * "surrogates" maps surrogate pattern tokens to surrogate script code.
+ */
 const surrogates = {
   /* eslint-disable no-extra-semi, space-in-parens */
 

--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -63,6 +63,7 @@ const hostnames = {
     '/JS/gigya.js',
     '/JS/socialize.js',
   ],
+  'cdn.krxd.net': 'noopjs',
 };
 
 /**
@@ -471,6 +472,12 @@ const surrogates = {
       }
     } + ')();',
   /* eslint-enable no-empty */
+
+  // https://github.com/uBlockOrigin/uAssets/blob/0efcadb2ecc2a9f0daa5a1df79841d794b83860f/filters/resources.txt#L38-L41
+  'noopjs': '(' +
+    function() {
+      ;
+    } + ')();',
 
   /* eslint-enable no-extra-semi, space-in-parens */
 };

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -218,6 +218,7 @@ var lowEntropyCookieValues = {
   "no":3,
   "true":3,
   "false":3,
+  "dnt":3,
   "opt-out":3,
   "optout":3,
   "opt_out":3,

--- a/src/js/surrogates.js
+++ b/src/js/surrogates.js
@@ -42,10 +42,19 @@ function getSurrogateURI(script_url, script_hostname) {
   if (db.hostnames.hasOwnProperty(script_hostname)) {
     const tokens = db.hostnames[script_hostname];
 
-    // do any of the pattern tokens for that hostname match the script URL?
+    // it's a wildcard token
+    if (_.isString(tokens)) {
+      if (db.surrogates.hasOwnProperty(tokens)) {
+        // return the surrogate code
+        return 'data:application/javascript;base64,' + btoa(db.surrogates[tokens]);
+      }
+    }
+
+    // must be an array of suffix tokens
     const qs_start = script_url.indexOf('?');
 
     for (let i = 0; i < tokens.length; i++) {
+      // do any of the suffix tokens match the script URL?
       const token = tokens[i];
 
       let match = false;

--- a/src/js/surrogates.js
+++ b/src/js/surrogates.js
@@ -43,9 +43,10 @@ function getSurrogateURI(script_url, script_hostname) {
     const tokens = db.hostnames[script_hostname];
 
     // do any of the pattern tokens for that hostname match the script URL?
+    const qs_start = script_url.indexOf('?');
+
     for (let i = 0; i < tokens.length; i++) {
-      const token = tokens[i],
-        qs_start = script_url.indexOf('?');
+      const token = tokens[i];
 
       let match = false;
 

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -92,6 +92,8 @@
   });
 
   QUnit.test("surrogate script URL lookups", function (assert) {
+    const surrogatedb = require('surrogatedb');
+    const SURROGATE_PREFIX = 'data:application/javascript;base64,';
     const GA_JS_TESTS = [
       {
         url: 'http://www.google-analytics.com/ga.js',
@@ -106,6 +108,9 @@
         msg: "Google Analytics ga.js querystring URL should match"
       },
     ];
+    const NYT_SCRIPT_PATH = '/assets/homepage/20160920-111441/js/foundation/lib/framework.js';
+    const NYT_URL = 'https://a1.nyt.com' + NYT_SCRIPT_PATH;
+
     let ga_js_surrogate;
 
     for (let i = 0; i < GA_JS_TESTS.length; i++) {
@@ -117,17 +122,42 @@
     }
 
     assert.ok(
-      ga_js_surrogate.startsWith('data:application/javascript;base64,'),
+      ga_js_surrogate.startsWith(SURROGATE_PREFIX),
       "The returned ga.js surrogate is a base64-encoded JavaScript data URI"
     );
 
-    assert.ok(
-      !getSurrogateURI(
-        'https://a1.nyt.com/assets/homepage/20160920-111441/js/foundation/lib/framework.js',
-        'a1.nyt.com'
-      ),
+    // test negative match
+    assert.notOk(
+      getSurrogateURI(NYT_URL, window.extractHostFromURL(NYT_URL)),
       "New York Times script URL should not match any surrogates"
     );
+
+    // test surrogate suffix token response contents
+    surrogatedb.hostnames[window.extractHostFromURL(NYT_URL)] = [
+      NYT_SCRIPT_PATH
+    ];
+    surrogatedb.surrogates[NYT_SCRIPT_PATH] = _.noop;
+    assert.equal(
+      getSurrogateURI(NYT_URL, window.extractHostFromURL(NYT_URL)),
+      SURROGATE_PREFIX + btoa(_.noop),
+      "New York Times script URL should now match the _.noop surrogate"
+    );
+
+    // set up test data for wildcard token tests
+    surrogatedb.hostnames['cdn.example.com'] = 'noop';
+    surrogatedb.surrogates.noop = _.noop;
+
+    // test wildcard tokens
+    for (let i = 0; i < 25; i++) {
+      let url = 'http://cdn.example.com/' + _.sample(
+        'abcdefghijklmnopqrstuvwxyz0123456789', _.random(5, 15)).join('');
+
+      assert.equal(
+        getSurrogateURI(url, window.extractHostFromURL(url)),
+        SURROGATE_PREFIX + btoa(_.noop),
+        "A wildcard token should match all URLs for the hostname: " + url
+      );
+    }
   });
 
   QUnit.test("rateLimit", (assert) => {


### PR DESCRIPTION
Fixes #1359.

This adds a new surrogate script token type that can be used to match all paths for a given hostname.

I noticed `krxd.net` setting cookies with the content of "DNT". We already ignore various versions of "OPTOUT", so we should also ignore "DNT". Privacy Badger still seems to learn to block `krdx.net` thanks to `cdn.krxd.net` setting non-trivial localStorage data.

[Debug info](gist.github.com/anonymous/8aebb8e48a1ce3c256b21dcfe37af84b) for `krxd.net`:
```
**** ACTION_MAP for krxd.net
beacon.krxd.net {
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 0,
  "userAction": ""
}
cdn.krxd.net {
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0,
  "userAction": ""
}
krxd.net {
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0,
  "userAction": ""
}
**** SNITCH_MAP for krxd.net
krxd.net [
  "foxnews.com",
  "cnn.com",
  "teamcoco.com"
]
```