### PR TITLE
Redirect blocked iframes to 'about:blank'

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -473,6 +473,7 @@ Badger.prototype = {
   defaultSettings: {
     checkForDNTPolicy: true,
     disabledSites: [],
+    hideBlockedElements: true,
     isFirstRun: true,
     migrationLevel: 0,
     seenComic: false,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -107,6 +107,12 @@ function onBeforeRequest(details) {
         badger.checkForDNTPolicy(requestDomain);
       }, 10);
 
+      if (type == 'sub_frame') {
+        return {
+          redirectUrl: 'about:blank'
+        };
+      }
+
       return {cancel: true};
     }
   }
@@ -179,6 +185,12 @@ function onBeforeSendHeaders(details) {
       window.setTimeout(function () {
         badger.checkForDNTPolicy(requestDomain);
       }, 10);
+
+      if (type == 'sub_frame') {
+        return {
+          redirectUrl: 'about:blank'
+        };
+      }
 
       return {cancel: true};
     }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -107,7 +107,7 @@ function onBeforeRequest(details) {
         badger.checkForDNTPolicy(requestDomain);
       }, 10);
 
-      if (type == 'sub_frame') {
+      if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
         return {
           redirectUrl: 'about:blank'
         };
@@ -186,7 +186,7 @@ function onBeforeSendHeaders(details) {
         badger.checkForDNTPolicy(requestDomain);
       }, 10);
 
-      if (type == 'sub_frame') {
+      if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
         return {
           redirectUrl: 'about:blank'
         };


### PR DESCRIPTION
This hides "Requests to the server have been blocked by an extension" messages in Chrome and Opera.

Fixes part of #1754 and #907, but not #442, as the extra space is still there.

Collapsing seems to be more involved ... Probably requires a content script modifying pages to hide or remove elements associated with blocked requests (for example, [`domCollapser` in uBlock Origin](https://github.com/gorhill/uBlock/blob/2db377f577a01943c6e3759465c147ec3b596d78/src/js/contentscript.js#L40), [`checkCollapse` in Adblock Plus](https://github.com/adblockplus/adblockpluschrome/blob/ddb764dff1047b5671deb58158930051b2e19052/include.preload.js#L514-L524)).

Only replaces iframes and not images.

Before:
![screenshot from 2017-11-08 12 29 04](https://user-images.githubusercontent.com/794578/32564289-cc5196a8-c481-11e7-82b4-c0b0496d8d92.png)

After:
![screenshot from 2017-11-08 12 29 30](https://user-images.githubusercontent.com/794578/32564291-ce71f680-c481-11e7-95ba-9716553673da.png)

@andresbase @PinkLouie @Werwa In your opinion, is this change an overall improvement, or is it not worth doing without also collapsing the resulting white space on pages? I think Disconnect does this replacement, but does not do the collapsing.