### PR TITLE
Broaden Googleplus widget selector

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -73,7 +73,8 @@
 		"domain": "apis.google.com",
 		"buttonSelectors": [
 			"g\\:plusone",
-			".g-plusone"
+			".g-plusone",
+      "#___plus_0"
 		],
 		"replacementButton": {
 			"details": "https://plusone.google.com/se/0/_/+1/fastbutton?url=",

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -74,7 +74,7 @@
 		"buttonSelectors": [
 			"g\\:plusone",
 			".g-plusone",
-      "#___plus_0"
+			"#___plus_0"
 		],
 		"replacementButton": {
 			"details": "https://plusone.google.com/se/0/_/+1/fastbutton?url=",


### PR DESCRIPTION
closes #1734 

This solves the problem in the case of this URL: http://www.syntaxsuccess.com/viewarticle/caching-with-rxjs-observables-in-angular-2.0

The ID selector I used looks generic so hopefully it will apply to many cases of the google plus widget.  If wanted I can put more time into looking at all the widgets and making sure they're being blocked as intended.

This is my first contribution so let me know if I've done anything incorrectly or if you have any suggestions.  