### PR TITLE
Change options_page to options_ui

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -99,7 +99,10 @@
     "default_popup": "skin/popup.html",
     "default_title": "__MSG_name__"
   },
-  "options_page": "/skin/options.html",
+  "options_ui": {
+  	"page": "/skin/options.html",
+  	"open_in_tab": true
+  },
   "web_accessible_resources": [
     "skin/socialwidgets/*"
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -100,8 +100,8 @@
     "default_title": "__MSG_name__"
   },
   "options_ui": {
-  	"page": "/skin/options.html",
-  	"open_in_tab": true
+    "page": "/skin/options.html",
+    "open_in_tab": true
   },
   "web_accessible_resources": [
     "skin/socialwidgets/*"


### PR DESCRIPTION
Fixes #1774

Available for Firefox for Android since 57, see https://github.com/gorhill/uBlock/wiki/Firefox-WebExtensions#firefox-for-android. Tested in 57.0b15

Available for Firefox since 52, see https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/options_ui, Tested in 57.0