### PR TITLE
Stop recording non-tracking domains

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -522,6 +522,7 @@ Badger.prototype = {
       Migrations.unblockIncorrectlyBlockedDomains,
       Migrations.forgetBlockedDNTDomains,
       Migrations.reapplyYellowlist,
+      Migrations.forgetNontrackingDomains,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -214,7 +214,7 @@ Badger.prototype = {
    * @param {Integer} [frame_id=0] Frame ID to check for.
    *  Optional, defaults to frame 0 (the main document frame).
    *
-   * @returns {Object|null} Frame data object or null
+   * @returns {?Object} Frame data object or null
    */
   getFrameData: function (tab_id, frame_id) {
     let self = this;

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -88,8 +88,6 @@ HeuristicBlocker.prototype = {
   /**
    * Wraps _recordPrevalence for use from webRequest listeners.
    * Also saves tab (page) origins. TODO Should be handled by tabData instead.
-   * Also sets a timeout for checking DNT policy for third-party FQDNs.
-   * TODO Does too much, should be broken up ...
    *
    * Called from performance-critical webRequest listeners!
    * Use updateTrackerPrevalence for non-webRequest initiated bookkeeping.
@@ -120,10 +118,6 @@ HeuristicBlocker.prototype = {
     if (!tabOrigin || origin == tabOrigin) {
       return {};
     }
-
-    window.setTimeout(function () {
-      badger.checkForDNTPolicy(fqdn);
-    }, 10);
 
     // abort if we already made a decision for this FQDN
     let action = this.storage.getAction(fqdn);
@@ -181,6 +175,13 @@ HeuristicBlocker.prototype = {
     if (firstParties.indexOf(page_origin) != -1) {
       return; // We already know about the presence of this tracker on the given domain
     }
+
+    // Check this just-seen-tracking-on-this-site,
+    // not-yet-blocked domain for DNT policy.
+    // We check heuristically-blocked domains in webrequest.js.
+    window.setTimeout(function () {
+      badger.checkForDNTPolicy(tracker_fqdn);
+    }, 10);
 
     // record that we've seen this tracker on this domain (in snitch map)
     firstParties.push(page_origin);

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -212,6 +212,20 @@ exports.Migrations= {
     }
   },
 
+  forgetNontrackingDomains: function (badger) {
+    console.log("Forgetting non-tracking domains ...");
+
+    const actionMap = badger.storage.getBadgerStorageObject("action_map"),
+      actions = actionMap.getItemClones();
+
+    for (const domain in actions) {
+      const map = actions[domain];
+      if (map.userAction == "" && map.heuristicAction == "") {
+        actionMap.deleteItem(domain);
+      }
+    }
+  },
+
 };
 
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -191,6 +191,9 @@ function parseUserDataFile(storageMapsList) {
   // fix yellowlist getting out of sync
   migrations.reapplyYellowlist(badger);
 
+  // remove any non-tracking domains (in exports from older Badger versions)
+  migrations.forgetNontrackingDomains(badger);
+
   // Update list to reflect new status of map
   reloadWhitelist();
   refreshFilterPage();

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -328,10 +328,10 @@ BadgerPen.prototype = {
   revertUserAction: function(domain) {
     this._setupDomainAction(domain, "", "userAction");
 
-    // if unsetting userAction returns the domain's action map to all defaults,
-    // remove the action map for the domain
+    // if Privacy Badger never recorded tracking for this domain,
+    // remove the domain's entry from Privacy Badger's database
     const actionMap = this.getBadgerStorageObject("action_map");
-    if (_.isEqual(actionMap.getItem(domain), _newActionMapObject())) {
+    if (actionMap.getItem(domain).heuristicAction == "") {
       log("Removing %s from action_map", domain);
       actionMap.deleteItem(domain);
     }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -499,7 +499,8 @@ BadgerStorage.prototype = {
         for (let origin in firstPartyOrigins) {
           badger.heuristicBlocking.updateTrackerPrevalence(
             tracker_fqdn,
-            firstPartyOrigins[origin]
+            firstPartyOrigins[origin],
+            true // skip DNT policy checking on data import
           );
         }
       }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -323,10 +323,18 @@ BadgerPen.prototype = {
 
   /**
    * Remove user set action from a domain
-  * @param domain FQDN string
-  **/
+   * @param domain FQDN string
+   */
   revertUserAction: function(domain) {
     this._setupDomainAction(domain, "", "userAction");
+
+    // if unsetting userAction returns the domain's action map to all defaults,
+    // remove the action map for the domain
+    const actionMap = this.getBadgerStorageObject("action_map");
+    if (_.isEqual(actionMap.getItem(domain), _newActionMapObject())) {
+      log("Removing %s from action_map", domain);
+      actionMap.deleteItem(domain);
+    }
   }
 };
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -94,7 +94,7 @@ BadgerPen.prototype = {
    * Get the current presumed action for a specific fully qualified domain name (FQDN),
    * ignoring any rules for subdomains below or above it
    *
-   * @param {Object|String} domain domain object from action_map
+   * @param {(Object|String)} domain domain object from action_map
    * @returns {String} the presumed action for this FQDN
    **/
   getAction: function (domain, ignoreDNT) {
@@ -244,8 +244,8 @@ BadgerPen.prototype = {
   /**
    * Get the number of domains that the given FQDN has been seen tracking on
    *
-   * @param fqdn domain to check status of
-   * @return int the number of domains fqdn has been tracking on
+   * @param {String} fqdn domain to check status of
+   * @return {Integer} the number of domains fqdn has been tracking on
    */
   getTrackingCount: function(fqdn) {
     var snitch_map = this.getBadgerStorageObject('snitch_map');
@@ -259,9 +259,9 @@ BadgerPen.prototype = {
   /**
    * Set up an action for a domain of the given action type in action_map
    *
-   * @param domain the domain to set the action for
-   * @param action the action to take e.g. BLOCK || COOKIEBLOCK || DNT
-   * @param actionType the type of action we are setting, one of "userAction", "heuristicAction", "dnt"
+   * @param {String} domain the domain to set the action for
+   * @param {String} action the action to take e.g. BLOCK || COOKIEBLOCK || DNT
+   * @param {String} actionType the type of action we are setting, one of "userAction", "heuristicAction", "dnt"
    * @private
    */
   _setupDomainAction: function (domain, action, actionType) {
@@ -305,7 +305,7 @@ BadgerPen.prototype = {
 
   /**
    * Remove DNT setting from a domain*
-   * @param domain FQDN string
+   * @param {String} domain FQDN string
    */
   revertDNT: function(domain) {
     this._setupDomainAction(domain, false, "dnt");
@@ -323,7 +323,7 @@ BadgerPen.prototype = {
 
   /**
    * Remove user set action from a domain
-   * @param domain FQDN string
+   * @param {String} domain FQDN string
    */
   revertUserAction: function(domain) {
     this._setupDomainAction(domain, "", "userAction");
@@ -392,7 +392,7 @@ BadgerStorage.prototype = {
    * Check if this storage object has an item
    *
    * @param {String} key - the key for the item
-   * @return boolean
+   * @return {Boolean}
    **/
   hasItem: function(key) {
     var self = this;
@@ -403,7 +403,7 @@ BadgerStorage.prototype = {
    * Get an item
    *
    * @param {String} key - the key for the item
-   * @return the value for that key or null
+   * @return {?*} the value for that key or null
    **/
   getItem: function(key) {
     var self = this;

--- a/src/js/surrogates.js
+++ b/src/js/surrogates.js
@@ -34,7 +34,7 @@ const db = require('surrogatedb');
  * parameter. This is an optimization: the calling context should already have
  * this information.
  *
- * @return {String|Boolean} The surrogate script as a data URI when there is a
+ * @return {(String|Boolean)} The surrogate script as a data URI when there is a
  * match, or boolean false when there is no match.
  */
 function getSurrogateURI(script_url, script_hostname) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -116,9 +116,13 @@ function onBeforeRequest(details) {
   };
   chrome.tabs.sendMessage(tab_id, msg);
 
-  window.setTimeout(function () {
-    badger.checkForDNTPolicy(requestDomain);
-  }, 10);
+  // if this is a heuristically- (not user-) blocked domain
+  if (requestAction == constants.BLOCK) {
+    // check for DNT policy
+    window.setTimeout(function () {
+      badger.checkForDNTPolicy(requestDomain);
+    }, 10);
+  }
 
   if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
     return {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -487,7 +487,7 @@ function forgetTab(tabId) {
  * @param {Integer} tabId The relevant tab
  * @param {String} requestHost The FQDN
  * @param {Integer} frameId The id of the frame
- * @returns {String|Boolean} false or the action to take
+ * @returns {(String|Boolean)} false or the action to take
  */
 function checkAction(tabId, requestHost, frameId) {
   // Ignore requests from temporarily unblocked social widgets.


### PR DESCRIPTION
Fixes #1446. Fixes #1405 by virtue of no longer checking DNT for non-tracking domains.

- [x] Stop checking DNT for non-tracking domains.
- [x] Add test to verify that non-tracking domains do not go into `action_map`.
- [x] Stop checking DNT for user-blocked domains.
- [x] Start checking DNT for domains seen tracking via localStorage or canvas fingerprinting.
- [x] Upon reverting control of user-controlled domains, check if the domain's `action_map` entry is set to all defaults (meaning no tracking recorded), and if it is, remove it.
- [x] Add migration to remove non-tracking domains on upgrade and on data import. (Preserve user-controlled non-tracking domains.)
- [ ] See whether we can remove the `unlimitedStorage` permission now, or we have to do another release first (to get non-tracking domains removed before we remove `unlimitedStorage`).
- [ ] Review performance impact.

Follows up on #1642 in terms of continuing to evolve our DNT checking approach.
  