### PR TITLE
Fix d.rip

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -319,6 +319,7 @@ www.kaltura.com
 kampyle.com
 kataweb.it
 kickapps.com
+kickstarter.com
 kickstatic.com
 kingfeatures.com
 kinja.com

--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -36,9 +36,8 @@ function insertCcScript(text) {
 chrome.runtime.sendMessage({checkLocation:document.location.href}, function(blocked) {
   if (blocked) {
     var code = '('+ function() {
-      var dummyCookie = "x=y";
-      document.__defineSetter__("cookie", function(/*value*/) { return dummyCookie; });
-      document.__defineGetter__("cookie", function() { return dummyCookie; });
+      document.__defineSetter__("cookie", function(/*value*/) { });
+      document.__defineGetter__("cookie", function() { return ""; });
     } +')();';
 
     insertCcScript(code);

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -44,7 +44,7 @@ chrome.runtime.sendMessage({checkLocation:document.location.href}, function(bloc
       '('+ function() {
         try {
           window.localStorage.getItem = function() {
-            return {};
+            return null;
           };
           window.localStorage.setItem = function(/*newValue*/) {
             //doNothing

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -110,6 +110,7 @@ var multiDomainFirstPartiesArray = [
   ["discountbank.co.il", "telebank.co.il"],
   ["discover.com", "discovercard.com"],
   ["dropbox.com", "dropboxstatic.com", "getdropbox.com"],
+  ["d.rip", "kickstarter.com"],
   ["ea.com", "origin.com", "play4free.com", "tiberiumalliance.com"],
   [
     "ebay.com",


### PR DESCRIPTION
Privacy Badger learns to block `kickstarter.com` after visiting the following three pages (without this patch):
- https://d.rip/rifftrax
- https://www.theverge.com/circuitbreaker/2017/3/13/14908218/eye-esti-inc-iphone-case-android-why-kickstarter
- http://flowingdata.com/2013/03/22/a-visualization-of-pi-for-high-school-math-students/

Drip and Kickstarter are the same entity, hence the MDFP entry.

`kickstarter.com` resources get embedded on other websites, such as to provide the Kickstarter video player in the two examples above, hence the yellowlist entry.

Having `localStorage.getItem` always return `{}` for "cookieblocked" domains is problematic. The Kickstarter player starts throwing JavaScript exceptions causing its playback controls to malfunction. [`localStorage.getItem`](https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem) is expected to (A) return strings (not objects!) and (B) return `null` when the key being retrieved isn't found. It seems to make more sense for us to return `null` for cookieblocked domains.

Similarly, we should probably return an empty cookie (`""`) instead of a specific cookie value (`"a=b"`) from `document.cookie` for cookieblocked domains.