### PR TITLE
Hide tracking domains list on options page behind an acknowledgement

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -426,5 +426,13 @@
     "slideshow_10": {
         "message": " If you think that I've made the wrong decision for a tracker, you can move the slider to red to block it, yellow to partly block it, and green to allow it.",
         "description": ""
+    },
+    "show_tracking_domains_message": {
+      "message": "You shouldn't need to modify anything here.",
+      "description": "Shown above the acknowledgement checkbox required to reveal the tracking domains list on the options page. This is the second paragraph; the first paragraph is the message under the \"slideshow_8\" key."
+    },
+    "show_tracking_domains_acknowledgement": {
+      "message": "I understand; please show me the tracking domains list anyway",
+      "description": "Acknowledgement shown next to the checkbox required to reveal the tracking domains list on the options page."
     }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -502,6 +502,7 @@ Badger.prototype = {
     migrationLevel: 0,
     seenComic: false,
     showCounter: true,
+    showTrackingDomains: false,
     socialWidgetReplacementEnabled: true,
   },
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -58,6 +58,18 @@ function loadOptions() {
   $('#importTrackers').change(importTrackerList);
   $('#exportTrackers').click(exportUserData);
 
+  if (settings.getItem("showTrackingDomains")) {
+    $('#tracking-domains-overlay').hide();
+  } else {
+    $('#blockedResourcesContainer').hide();
+
+    $('#show-tracking-domains-checkbox').click(() => {
+      $('#tracking-domains-overlay').hide();
+      $('#blockedResourcesContainer').show();
+      settings.setItem("showTrackingDomains", true);
+    });
+  }
+
   // Set up input for searching through tracking domains.
   $("#trackingDomainSearch").on("input", filterTrackingDomains);
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -57,6 +57,16 @@
   </ul>
 
   <div id="tab-tracking-domains">
+    <div id="tracking-domains-overlay">
+        <p class="i18n_slideshow_8"></p>
+        <p class="i18n_show_tracking_domains_message"></p>
+        <p>
+            <label>
+                <input type="checkbox" id="show-tracking-domains-checkbox">
+                <span class="i18n_show_tracking_domains_acknowledgement"></span>
+            </label>
+        </p>
+    </div>
     <div id="blockedResourcesContainer">
       <p id="pbInstructions">
         <span id="pb_has_detected" class="i18n_options_pb_has_detected"></span> <span id='count'>0</span> <span id="options_domain_list_trackers" class="i18n_options_domain_list_trackers"></span>
@@ -69,7 +79,6 @@
       </div>
     </div>
   </div>
-
 
   <div id="tab-whitelisted-domains">
     <p class="i18n_disabled_for_these_domains"></p>

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -16,6 +16,7 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
 
     def select_domain_list_tab(self):
         self.driver.find_element_by_css_selector('a[href="#tab-tracking-domains"]').click()
+        self.driver.find_element_by_id('show-tracking-domains-checkbox').click()
 
     def load_options_page(self):
         self.load_url(self.bg_url)  # load a dummy page


### PR DESCRIPTION
Follows up on #1669. Related to #1374, #1675.

![screenshot from 2017-12-13 11 39 20](https://user-images.githubusercontent.com/794578/33950403-52a53dd4-dffa-11e7-8bbf-9a08a2d016ba.png)

This uses an already-translated message from the currently unused slideshow translation set. The checkbox message is new and will need to be translated.

We should focus on what we want to say here the most; this may be good enough for now though.