### PR TITLE
Add type/status filters to tracking domains list

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -148,8 +148,40 @@
         "description": ""
     },
     "options_domain_search": {
-        "message": "Search domains",
-        "description": ""
+        "message": "Search domains:",
+        "description": "Label for a text input box on the Tracking Domains options page tab."
+    },
+    "options_domain_type_filter": {
+        "message": "Filter by type:",
+        "description": "Label for a dropdown control on the Tracking Domains options page tab."
+    },
+    "options_domain_status_filter": {
+        "message": "Filter by status:",
+        "description": "Label for a dropdown control on the Tracking Domains options page tab."
+    },
+    "options_domain_filter_all": {
+        "message": "all",
+        "description": "Dropdown control setting on the Tracking Domains options page tab."
+    },
+    "options_domain_filter_user": {
+        "message": "user-controlled",
+        "description": "Dropdown control setting on the Tracking Domains options page tab."
+    },
+    "options_domain_filter_dnt": {
+        "message": "DNT-compliant",
+        "description": "Dropdown control setting on the Tracking Domains options page tab."
+    },
+    "options_domain_filter_block": {
+        "message": "blocked",
+        "description": "Dropdown control setting on the Tracking Domains options page tab."
+    },
+    "options_domain_filter_cookieblock": {
+        "message": "partially-blocked",
+        "description": "Dropdown control setting on the Tracking Domains options page tab."
+    },
+    "options_domain_filter_allow": {
+        "message": "allowed",
+        "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "show_counter_checkbox": {
         "message": "Show count of blocked items",

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -57,8 +57,6 @@ let migrations = require("migrations").Migrations;
  * Loads options from pb storage and sets UI elements accordingly.
  */
 function loadOptions() {
-  $('#blockedResources').css('max-height',$(window).height() - 300);
-
   // Set page title to i18n version of "Privacy Badger Options"
   document.title = i18n.getMessage("options_title");
 
@@ -83,6 +81,8 @@ function loadOptions() {
 
   // Set up input for searching through tracking domains.
   $("#trackingDomainSearch").on("input", filterTrackingDomains);
+  $("#tracking-domains-type-filter").on("change", filterTrackingDomains);
+  $("#tracking-domains-status-filter").on("change", filterTrackingDomains);
 
   // Add event listeners for origins container.
   $(function () {
@@ -320,22 +320,49 @@ function refreshOriginCache() {
 
 /**
  * Gets array of encountered origins.
- * @param filterText {String} Text to filter origins with.
+ *
+ * @param filter_text {String} Text to filter origins with.
+ * @param type_filter {String} Type (user-controlled, DNT-compliant) to filter
+ *   origins by.
+ * @param status_filter {String} Status (blocked, cookieblocked, allowed) to
+ *   filter origins by.
+ *
  * @return {Array}
  */
-function getOriginsArray(filterText) {
-  // Make sure filterText is lower case for case-insensitive matching.
-  if (filterText) {
-    filterText = filterText.toLowerCase();
+function getOriginsArray(filter_text, type_filter, status_filter) {
+  // Make sure filter_text is lower case for case-insensitive matching.
+  if (filter_text) {
+    filter_text = filter_text.toLowerCase();
   } else {
-    filterText = "";
+    filter_text = "";
   }
 
-  // Include only origins containing given filter text.
-  function containsFilterText(origin) {
-    return origin.toLowerCase().indexOf(filterText) !== -1;
+  function matchesFormFilters(origin) {
+    const value = originCache[origin];
+
+    if (type_filter) {
+      if (type_filter == "user") {
+        if (!value.startsWith("user")) {
+          return false;
+        }
+      } else {
+        if (value != type_filter) {
+          return false;
+        }
+      }
+    }
+
+    if (status_filter) {
+      if (status_filter != value.replace("user_", "")) {
+        return false;
+      }
+    }
+
+    return origin.toLowerCase().indexOf(filter_text) !== -1;
   }
-  return Object.keys(originCache).filter(containsFilterText);
+
+  // Include only origins that match given filters.
+  return Object.keys(originCache).filter(matchesFormFilters);
 }
 
 function addWhitelistDomain(event) {
@@ -464,14 +491,13 @@ function refreshFilterPage() {
   $('.tooltip').tooltipster();
 
   // Display tracking domains.
-  var originsToDisplay;
-  var searchText = $("#trackingDomainSearch").val();
-  if (searchText.length > 0) {
-    originsToDisplay = getOriginsArray(searchText);
-  } else {
-    originsToDisplay = allTrackingDomains;
-  }
-  showTrackingDomains(originsToDisplay);
+  showTrackingDomains(
+    getOriginsArray(
+      $("#trackingDomainSearch").val(),
+      $('#tracking-domains-type-filter').val(),
+      $('#tracking-domains-status-filter').val()
+    )
+  );
 
   log("Done refreshing options page");
 }
@@ -481,6 +507,15 @@ function refreshFilterPage() {
  * @param event Input event triggered by user.
  */
 function filterTrackingDomains(/*event*/) {
+  const $typeFilter = $('#tracking-domains-type-filter');
+  const $statusFilter = $('#tracking-domains-status-filter');
+
+  if ($typeFilter.val() == "dnt") {
+    $statusFilter.prop("disabled", true).val("");
+  } else {
+    $statusFilter.prop("disabled", false);
+  }
+
   var initialSearchText = $('#trackingDomainSearch').val().toLowerCase();
 
   // Wait a short period of time and see if search text has changed.
@@ -494,7 +529,11 @@ function filterTrackingDomains(/*event*/) {
     }
 
     // Show filtered origins.
-    var filteredOrigins = getOriginsArray(searchText);
+    var filteredOrigins = getOriginsArray(
+      searchText,
+      $typeFilter.val(),
+      $statusFilter.val()
+    );
     showTrackingDomains(filteredOrigins);
   }, timeToWait);
 }
@@ -522,7 +561,7 @@ function addOrigins(e) {
 
 /**
  * Displays list of tracking domains along with toggle controls.
- * @param domains Tracking domains to display.
+ * @param domains {Array} Tracking domains to display.
  */
 function showTrackingDomains(domains) {
   domains.sort(htmlUtils.compareReversedDomains);

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -45,17 +45,34 @@ button
   width: 0;
 }
 
-#tracking-domains-div {
+#blockedResources {
   width: 390px;
 }
 
 #tracking-domains-filters {
+    color: #505050;
+    font-size: 14px;
+    list-style-type: none;
     margin: 10px 0;
+    padding: 0;
+    max-width: 390px;
 }
 
-#tracking-domains-filters input, #tracking-domains-filters select {
+#tracking-domains-filters li {
     margin: 5px 0;
-    width: 100%;
+
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+#tracking-domains-filters > li > label {
+    flex: 1 0 150px; /* at least this wide */
+    max-width: 150px; /* at most this wide */
+}
+
+#tracking-domains-filters > li > label + * {
+    flex: 1 0 200px; /* at least this wide or wrap */
 }
 
 .clickerContainer {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -22,9 +22,6 @@ button
 {
   white-space: pre;
 }
-#tabs {
-  min-width: 750px;
-}
 
 .tooltipArrow {
   bottom: 27px;
@@ -32,7 +29,6 @@ button
 
 #pbInstructions {
   margin-bottom: 20px;
-  width: 500px;
 }
 
 #rawFilters {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -83,6 +83,19 @@ button
   width: 390px;
 }
 
+#tracking-domains-filters {
+    margin: 10px 0;
+}
+
+#tracking-domains-filters input, #tracking-domains-filters select {
+    margin: 5px 0;
+    width: 100%;
+}
+
+.clickerContainer {
+    max-height: 400px; /* override popup.css */
+}
+
 #settingsSuffix{
   color: #555;
   font-size: 12px;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -23,32 +23,8 @@ button
   white-space: pre;
 }
 
-.tooltipArrow {
-  bottom: 27px;
-}
-
 #pbInstructions {
   margin-bottom: 20px;
-}
-
-#rawFilters {
-  display: none;
-}
-
-.okMsg {
-    display: none;
-    color: #ffffff;
-    background: #30e030;
-    font-weight: bold;
-    padding: 3px;
-}
-
-.errMsg {
-    display: none;
-    color: #ffffff;
-    background: #e03030;
-    font-weight:bold;
-    padding:3px;
 }
 
 #tab-manage-data {
@@ -61,12 +37,6 @@ button
 #export {
   width: 350px;
   float: left;
-}
-
-/* Filter list entry status message */
-.flMsg {
-    display: none;
-    color: #b0b0b0;
 }
 
 .importInput{

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -74,7 +74,21 @@
         <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" style="display:none"></span>
       </p>
       <div id="tracking-domains-div">
-          <input id="trackingDomainSearch" type="text" value="" style="width:100%" placeholder="i18n_options_domain_search">
+          <div id="tracking-domains-filters">
+              <input id="trackingDomainSearch" type="text" value="" placeholder="i18n_options_domain_search">
+              <!-- TODO i18n -->
+              <select id="tracking-domains-type-filter">
+                  <option value="">Show all domain types</option>
+                  <option value="user">Show user-controlled domains</option>
+                  <option value="dnt">Show DNT-compliant domains</option>
+              </select>
+              <select id="tracking-domains-status-filter">
+                  <option value="">Show all domain statuses</option>
+                  <option value="block">Show blocked domains</option>
+                  <option value="cookieblock">Show partially-blocked domains</option>
+                  <option value="allow">Show allowed domains</option>
+              </select>
+          </div>
           <div id="blockedResources"><span class="i18n_options_loading"></span></div>
       </div>
     </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -77,30 +77,29 @@
           <ul id="tracking-domains-filters">
               <li>
                   <label for="trackingDomainSearch">
-                      <span class="i18n_options_domain_search"></span>:
+                      <span class="i18n_options_domain_search"></span>
                   </label>
                   <input id="trackingDomainSearch" type="text" value="">
               </li>
-              <!-- TODO i18n -->
               <li>
                   <label for="tracking-domains-type-filter">
-                      Filter by type:
+                      <span class="i18n_options_domain_type_filter"></span>
                   </label>
                   <select id="tracking-domains-type-filter">
-                      <option value="">all</option>
-                      <option value="user">user-controlled</option>
-                      <option value="dnt">DNT-compliant</option>
+                      <option value="" class="i18n_options_domain_filter_all"></option>
+                      <option value="user" class="i18n_options_domain_filter_user"></option>
+                      <option value="dnt" class="i18n_options_domain_filter_dnt"></option>
                   </select>
               </li>
               <li>
                   <label for="tracking-domains-status-filter">
-                      Filter by status:
+                      <span class="i18n_options_domain_status_filter"></span>
                   </label>
                   <select id="tracking-domains-status-filter">
-                      <option value="">all</option>
-                      <option value="block">blocked</option>
-                      <option value="cookieblock">partially-blocked</option>
-                      <option value="allow">allowed</option>
+                      <option value="" class="i18n_options_domain_filter_all"></option>
+                      <option value="block" class="i18n_options_domain_filter_block"></option>
+                      <option value="cookieblock" class="i18n_options_domain_filter_cookieblock"></option>
+                      <option value="allow" class="i18n_options_domain_filter_allow"></option>
                   </select>
               </li>
           </ul>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -74,21 +74,36 @@
         <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" style="display:none"></span>
       </p>
       <div id="tracking-domains-div">
-          <div id="tracking-domains-filters">
-              <input id="trackingDomainSearch" type="text" value="" placeholder="i18n_options_domain_search">
+          <ul id="tracking-domains-filters">
+              <li>
+                  <label for="trackingDomainSearch">
+                      <span class="i18n_options_domain_search"></span>:
+                  </label>
+                  <input id="trackingDomainSearch" type="text" value="">
+              </li>
               <!-- TODO i18n -->
-              <select id="tracking-domains-type-filter">
-                  <option value="">Show all domain types</option>
-                  <option value="user">Show user-controlled domains</option>
-                  <option value="dnt">Show DNT-compliant domains</option>
-              </select>
-              <select id="tracking-domains-status-filter">
-                  <option value="">Show all domain statuses</option>
-                  <option value="block">Show blocked domains</option>
-                  <option value="cookieblock">Show partially-blocked domains</option>
-                  <option value="allow">Show allowed domains</option>
-              </select>
-          </div>
+              <li>
+                  <label for="tracking-domains-type-filter">
+                      Filter by type:
+                  </label>
+                  <select id="tracking-domains-type-filter">
+                      <option value="">all</option>
+                      <option value="user">user-controlled</option>
+                      <option value="dnt">DNT-compliant</option>
+                  </select>
+              </li>
+              <li>
+                  <label for="tracking-domains-status-filter">
+                      Filter by status:
+                  </label>
+                  <select id="tracking-domains-status-filter">
+                      <option value="">all</option>
+                      <option value="block">blocked</option>
+                      <option value="cookieblock">partially-blocked</option>
+                      <option value="allow">allowed</option>
+                  </select>
+              </li>
+          </ul>
           <div id="blockedResources"><span class="i18n_options_loading"></span></div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #1422.

No mass controls yet (or #971, a way to reset settings), just new domain list filters. Is this good enough for now? Screenshots follow.

<details><summary>No filtering</summary>

![screenshot from 2017-12-11 17 22 53](https://user-images.githubusercontent.com/794578/33857060-3a3b2bfe-de98-11e7-83fd-bc648c78a6b8.png)
</details>

<details><summary>Show DNT-compliant only (disables status filter)</summary>

![screenshot from 2017-12-11 17 23 02](https://user-images.githubusercontent.com/794578/33857064-3d800d84-de98-11e7-90c4-c1b6196be96d.png)
</details>

<details><summary>Show user-controlled, partially-blocked only</summary>

![screenshot from 2017-12-11 17 23 37](https://user-images.githubusercontent.com/794578/33857066-416956a8-de98-11e7-9f9c-88257cc776e4.png)
</details>