### PR TITLE
When using Firefox, add an iframe to put the export settings link in

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -201,6 +201,14 @@ function exportUserData() {
     var a = document.createElement('a');
     a.setAttribute('download', filename || '');
 
+    var blob = new Blob([mapJSON], { type: 'application/json' }); // pass a useful mime type here
+    a.href = URL.createObjectURL(blob);
+
+    function clickBlobLink() {
+      a.dispatchEvent(new MouseEvent('click'));
+      URL.revokeObjectURL(blob);
+    }
+
     // TODO remove browser check and simplify code once Firefox 52 goes away
     // https://github.com/EFForg/privacybadger/pull/1532#issuecomment-318702372
     if (chrome.runtime.getBrowserInfo) {
@@ -224,21 +232,11 @@ function exportUserData() {
             iframe.contentWindow.document.body.removeChild(oldElement);
           }
           iframe.contentWindow.document.body.appendChild(a);
-
-          a.href = 'data:application/json;charset=utf-8,' + encodeURIComponent(mapJSON);
-          a.dispatchEvent(new MouseEvent('click'));
-        } else {
-          var blob = new Blob([mapJSON], {type: 'application/json'}); // pass a useful mime type here
-          a.href = URL.createObjectURL(blob);
-          a.dispatchEvent(new MouseEvent('click'));
-          URL.revokeObjectURL(blob);
         }
+        clickBlobLink();
       });
     } else {
-      var blob = new Blob([mapJSON], {type: 'application/json'}); // pass a useful mime type here
-      a.href = URL.createObjectURL(blob);
-      a.dispatchEvent(new MouseEvent('click'));
-      URL.revokeObjectURL(blob);
+      clickBlobLink();
     }
   });
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -209,29 +209,35 @@ function exportUserData() {
       URL.revokeObjectURL(blob);
     }
 
+    /**
+     * Firefox workaround to insert the blob link in an iFrame
+     */
+    function addBlobWorkAroundForFirefox() {
+      // Create or use existing iframe for the blob 'a' element
+      var iframe = document.getElementById('exportUserDataIframe');
+      if (!iframe) {
+        iframe = document.createElement('iframe');
+        iframe.id = "exportUserDataIframe";
+        iframe.setAttribute("style", "visibility: hidden; height: 0; width: 0");
+        document.getElementById('export').appendChild(iframe);
+
+        iframe.contentWindow.document.open();
+        iframe.contentWindow.document.write('<html><head></head><body></body></html>');
+        iframe.contentWindow.document.close();
+      } else {
+        // Remove the old 'a' element from the iframe
+        var oldElement = iframe.contentWindow.document.body.lastChild;
+        iframe.contentWindow.document.body.removeChild(oldElement);
+      }
+      iframe.contentWindow.document.body.appendChild(a);
+    }
+
     // TODO remove browser check and simplify code once Firefox 52 goes away
     // https://github.com/EFForg/privacybadger/pull/1532#issuecomment-318702372
     if (chrome.runtime.getBrowserInfo) {
       chrome.runtime.getBrowserInfo((info) => {
         if (info.name == "Firefox") {
-          //TODO no longer need the following iframe when https://bugzilla.mozilla.org/show_bug.cgi?id=1379960 is fixed
-          // Create or use existing iframe for the 'a' element
-          var iframe = document.getElementById('exportUserDataIframe');
-          if (!iframe) {
-            iframe = document.createElement('iframe');
-            iframe.id = "exportUserDataIframe";
-            iframe.setAttribute("style", "visibility: hidden; height: 0; width: 0");
-            document.getElementById('export').appendChild(iframe);
-
-            iframe.contentWindow.document.open();
-            iframe.contentWindow.document.write('<html><head></head><body></body></html>');
-            iframe.contentWindow.document.close();
-          } else {
-            // Remove the old 'a' element from the iframe
-            var oldElement = iframe.contentWindow.document.body.lastChild;
-            iframe.contentWindow.document.body.removeChild(oldElement);
-          }
-          iframe.contentWindow.document.body.appendChild(a);
+          addBlobWorkAroundForFirefox();
         }
         clickBlobLink();
       });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -211,6 +211,7 @@ function exportUserData() {
 
     /**
      * Firefox workaround to insert the blob link in an iFrame
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1420419#c18
      */
     function addBlobWorkAroundForFirefox() {
       // Create or use existing iframe for the blob 'a' element
@@ -232,8 +233,8 @@ function exportUserData() {
       iframe.contentWindow.document.body.appendChild(a);
     }
 
-    // TODO remove browser check and simplify code once Firefox 52 goes away
-    // https://github.com/EFForg/privacybadger/pull/1532#issuecomment-318702372
+    // TODO remove browser check and simplify code once Firefox 58 goes away
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1420419
     if (chrome.runtime.getBrowserInfo) {
       chrome.runtime.getBrowserInfo((info) => {
         if (info.name == "Firefox") {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -206,6 +206,25 @@ function exportUserData() {
     if (chrome.runtime.getBrowserInfo) {
       chrome.runtime.getBrowserInfo((info) => {
         if (info.name == "Firefox") {
+          //TODO no longer need the following iframe when https://bugzilla.mozilla.org/show_bug.cgi?id=1379960 is fixed
+          // Create or use existing iframe for the 'a' element
+          var iframe = document.getElementById('exportUserDataIframe');
+          if (!iframe) {
+            iframe = document.createElement('iframe');
+            iframe.id = "exportUserDataIframe";
+            iframe.setAttribute("style", "visibility: hidden; height: 0; width: 0");
+            document.getElementById('export').appendChild(iframe);
+
+            iframe.contentWindow.document.open();
+            iframe.contentWindow.document.write('<html><head></head><body></body></html>');
+            iframe.contentWindow.document.close();
+          } else {
+            // Remove the old 'a' element from the iframe
+            var oldElement = iframe.contentWindow.document.body.lastChild;
+            iframe.contentWindow.document.body.removeChild(oldElement);
+          }
+          iframe.contentWindow.document.body.appendChild(a);
+
           a.href = 'data:application/json;charset=utf-8,' + encodeURIComponent(mapJSON);
           a.dispatchEvent(new MouseEvent('click'));
         } else {


### PR DESCRIPTION
I was able to fix #1674 on my mac firefox 57.0.1 by doing this.  I ran the unit tests and it pasts but I wasn't able to get the functional tests working on my computer so I don't know if those will pass or not.  Can you let me know if you think this is a good fix or if you have suggestions on modifying it?