### PR TITLE
Add staticxx.facebook.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -155,6 +155,7 @@ ethn.io
 evcdn.com
 ebmedia.eventbrite.com
 s-static.ak.facebook.com
+staticxx.facebook.com
 www.facebook.com
 fansonly.com
 travis-ci-org.global.ssl.fastly.net


### PR DESCRIPTION
Fixes #263. Fixes half of #1815.

Follows up on 68ed094c2ae98317086612262590783458d8fc3e and 346914dde5d270993f65ff833b38800291424dce.

"Facebook Comments Plugin" should eventually be handled by widget replacement (#1467) instead.

Some example pages with Facebook-powered comment sections:
- https://www.huffingtonpost.com/entry/donald-trump-steve-bannon_us_5a4d200ce4b0b0e5a7aa6f15 (click on the speech balloon on the left)
- http://newsok.com/oklahoma-city-pilot-and-anesthesiologist-missing-thursday-search-for-airplane-continues-over-gulf-of-mexico/article/5578224 (similar to above)
- http://www.news9.com/story/37193153/oklahoma-utility-regulators-consider-request-for-rate-cut
- https://fivethirtyeight.com/features/chesss-new-best-player-is-a-fearless-swashbuckling-algorithm/

Yellowlisting `staticxx.facebook.com` also seems to fix clicking Sign up with Facebook on Coursera (https://www.coursera.org/learn/inferential-statistics-intro?authMode=signup) and videos on https://nasdaily.com/videos.
  