### PR TITLE
Add Klarna domains to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -324,6 +324,8 @@ kickstatic.com
 kingfeatures.com
 kinja.com
 kinja-static.com
+klarna.com
+klarnacdn.net
 klm.com
 licdn.com
 licensebuttons.net


### PR DESCRIPTION
[Klarna](https://en.wikipedia.org/wiki/Klarna) seems to power store checkouts across many Scandinavian domains. I haven't actually confirmed that yellowlisting fixes the breakage, but it seems worth a shot.

## Error report statistics
```
Error report counts by page domain and exact blocked subdomain:
+--------------------------------+----------------------------+-------+
| fqdn                           | blocked_fqdn               | count |
+--------------------------------+----------------------------+-------+
| www.adlibris.com               | evt.klarna.com             |    11 |
| www.adlibris.com               | checkout.klarna.com        |     9 |
| www.adlibris.com               | checkout-client.klarna.com |     6 |
| www.apotea.se                  | checkout.klarna.com        |     6 |
| www.apotea.se                  | evt.klarna.com             |     5 |
| www.teknikmagasinet.se         | cdn.klarna.com             |     3 |
| onlinepizza.se                 | checkout-client.klarna.com |     3 |
| www.apotea.se                  | checkout-client.klarna.com |     3 |
| onlinepizza.se                 | checkout.klarna.com        |     3 |
| onlinepizza.se                 | evt.klarna.com             |     3 |
| www.adlibris.com               | cdn.klarna.com             |     2 |
| www.mmsports.se                | cdn.klarna.com             |     2 |
| www.nordicfeel.se              | cdn.klarna.com             |     2 |
| www.topformula.se              | cdn.klarna.com             |     2 |
| www.xxl.se                     | cdn.klarna.com             |     2 |
| www.addnature.com              | checkout.klarna.com        |     2 |
| www.ginza.se                   | checkout.klarna.com        |     2 |
| www.mmsports.se                | checkout.klarna.com        |     2 |
| www.nordicfeel.se              | checkout.klarna.com        |     2 |
| www.sliqhaq.se                 | checkout.klarna.com        |     2 |
| www.topformula.se              | checkout.klarna.com        |     2 |
| www.xxl.se                     | checkout.klarna.com        |     2 |
| www.jollyroom.se               | evt.klarna.com             |     2 |
| bakerenogkokken.no             | cards-eu.klarna.com        |     1 |
| www.lyko.no                    | cards-eu.klarna.com        |     1 |
| bokning.dekra-bilbesiktning.se | cdn.klarna.com             |     1 |
| checkout.myprotein.fi          | cdn.klarna.com             |     1 |
| confidentliving.no             | cdn.klarna.com             |     1 |
| feetfirst.se                   | cdn.klarna.com             |     1 |
| hestragloves.com               | cdn.klarna.com             |     1 |
| kabong.se                      | cdn.klarna.com             |     1 |
| mtrexpress.se                  | cdn.klarna.com             |     1 |
| scandinavianoutdoor.fi         | cdn.klarna.com             |     1 |
| www.alewalds.se                | cdn.klarna.com             |     1 |
| www.ao.de                      | cdn.klarna.com             |     1 |
| www.asos.de                    | cdn.klarna.com             |     1 |
...

Error report counts by distinct blocked subdomain:
+----------------------------+-------+
| blocked_fqdn               | count |
+----------------------------+-------+
| cards-eu.klarna.com        |     2 |
| cdn.klarna.com             |    53 |
| checkout-client.klarna.com |    20 |
| checkout-eu.klarna.com     |     8 |
| checkout.klarna.com        |    68 |
| checkout.klarnacdn.net     |     4 |
| direct-debit-eu.klarna.com |     1 |
| evt.klarna.com             |    52 |
| ondemand.klarna.com        |     1 |
| static.klarna.com          |     1 |
+----------------------------+-------+
```

## Sample reports:

https://onlinepizza.se/checkout/
>Didn't load the Klarna Checkout 3rd party integration

>We actaully need everything from *.Klarna, it's a horrible payment solution.

https://www.adlibris.com/fi/kassa/private
>Payment options are blocked.

https://www.outnorth.se/checkout
>Cannot check out

https://www.apotekhjartat.se/kassa/
>if you block klarna.com the you cant use there payment service

https://www.kumiukko.fi/kco/checkout/
>I think I can't see all relevant info on this checkout screen

https://sortiment.se/kco/checkout/
>Blocking "checkout-client.klarna.com" prevented checkout form from showing/loading.