### PR TITLE
Browser Detection update

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -246,6 +246,8 @@ function exportUserData() {
 
     // TODO remove browser check and simplify code once Firefox 58 goes away
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1420419
+
+    /**** Change the following to the browser detection method used in popup.js? ****/
     if (chrome.runtime.getBrowserInfo) {
       chrome.runtime.getBrowserInfo((info) => {
         if (info.name == "Firefox") {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -32,6 +32,8 @@ var reloadTab = chrome.tabs.reload;
 // TODO hack: disable Tooltipster tooltips on Firefox
 // to avoid hangs on pages with enough domains to produce a scrollbar
 (function () {
+
+/**** Change the following to the browser detection method used in options.js? ****/
 let [, browser, ] = navigator.userAgent.match(
   // from https://gist.github.com/ticky/3909462
   /(MSIE|(?!Gecko.+)Firefox|(?!AppleWebKit.+Chrome.+)Safari|(?!AppleWebKit.+)Chrome|AppleWebKit(?!.+Chrome|.+Safari)|Gecko(?!.+Firefox))(?: |\/)([\d.apre]+)/


### PR DESCRIPTION
I noticed that popup.js and options.js each use a different way to detect if it is running in Firefox.  Would it be better to use the same way in both files or move this to a common utility?   If so which method would be better?  One of the positives I like about the one in popup.js is it doesn't require a callback.  Then the options.js code would be cleaner without having to use the callback and a nested if statement.