### PR TITLE
Add some Bloomberg domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -96,6 +96,7 @@ var multiDomainFirstPartiesArray = [
     "stride.com",
     "trello.com",
   ],
+  ["bloomberg.com", "bbthat.com", "bwbx.io"],
   ["booking.com", "bstatic.com"],
   ["box.com", "boxcdn.net"],
   ["capitalone.com", "capitalone360.com"],


### PR DESCRIPTION
`www.bloomberg.com` is a top error reports site domain this week. Blocking `assets.bwbx.io` breaks the layout, but I can't reproduce tracking. Perhaps this is caused by another mis-attribution bug, maybe what I describe in https://github.com/EFForg/privacybadger/pull/1642#issuecomment-328681731?

Error report counts by page domain and exact blocked subdomain for `bwbx.io`:
```
+-----------------------+----------------+-------+
| fqdn                  | blocked_fqdn   | count |
+-----------------------+----------------+-------+
| www.bloomberg.com     | assets.bwbx.io |   135 |
| www.bloombergview.com | assets.bwbx.io |     2 |
| bloombergview.com     | assets.bwbx.io |     1 |
+-----------------------+----------------+-------+
```
Error report counts by date and exact blocked subdomain for `bwbx.io`:
```
+---------+----------------+-------+
| ym      | blocked_fqdn   | count |
+---------+----------------+-------+
| 2018-01 | assets.bwbx.io |     5 |
| 2017-12 | assets.bwbx.io |     4 |
| 2017-11 | assets.bwbx.io |     9 |
| 2017-10 | assets.bwbx.io |    14 |
| 2017-09 | assets.bwbx.io |     7 |
| 2017-08 | assets.bwbx.io |     8 |
| 2017-07 | assets.bwbx.io |     5 |
| 2017-06 | assets.bwbx.io |     7 |
| 2017-05 | assets.bwbx.io |     6 |
| 2017-04 | assets.bwbx.io |     5 |
| 2017-03 | assets.bwbx.io |     6 |
| 2017-02 | assets.bwbx.io |     6 |
| 2017-01 | assets.bwbx.io |     4 |
...
```
Users write:
>This site loads without images or text formatting when I load it with Privacy Badger.

>no page formatting

>The layout is messed up.

>looks like the css is missing completely?