### PR TITLE
Add webmention.io to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -572,6 +572,7 @@ weather.gov
 weatherbug.com
 weathernationtv.com
 weatherzone.com.au
+webmention.io
 webs.com
 websimages.com
 webtype.com


### PR DESCRIPTION
Webmention.io is a hosted service for receiving Webmentions (which are somewhat analogous to trackbacks, but more modern and simpler). I'm not sure if putting it on the yellowlist is the right approach since this _could_ be a bug in Privacy Badger - I think it's possible it's recognizing it as a tracker because a lot of [IndieWeb](https://indieweb.org) sites I visit - including my own - make XHR requests to it, plus I'm signed in, so it's sent a session ID which might look like a tracking ID to Privacy Badger.

Happy to run code to dump data for this domain if that'd be helpful.

/cc @aaronpk