### PR TITLE
Fix Tracking Domains options page tab page width

### DIFF
--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -124,14 +124,15 @@ var htmlUtils = exports.htmlUtils = {
    * @param {Integer} tabId ID of tab trackers are associated with.
    * @returns {String} HTML for empty tracker container.
    */
-  getTrackerContainerHtml: function(tabId) {
+  getTrackerContainerHtml: function(tabId, scrollbarWidth) {
     if (tabId === undefined) {
       tabId = "000";
     }
+
     var trackerHtml = '' +
       '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
       '<div class="keyContainer">' +
-      '<div class="key">' +
+      '<div class="key" style="margin-left: -' + scrollbarWidth + 'px;">' +
       '<img src="/icons/UI-icons-red.svg" class="tooltip" title="' + i18n.getMessage("tooltip_block") + '">' +
       '<img src="/icons/UI-icons-yellow.svg" class="tooltip" title="' + i18n.getMessage("tooltip_cookieblock") + '">' +
       '<img src="/icons/UI-icons-green.svg" class="tooltip" title="' + i18n.getMessage("tooltip_allow") + '">' +
@@ -179,9 +180,10 @@ var htmlUtils = exports.htmlUtils = {
     var originHtml = '' +
       '<div class="' + classes.join(' ') + '" data-origin="' + origin + '" data-original-action="' + action + '">' +
       '<div class="origin tooltip" title="' + actionDescription + '">' + whitelistedText + origin + '</div>' +
-      '<div class="removeOrigin">&#10006</div>' +
+      '<div class="clickables-container">' +
       htmlUtils.getToggleHtml(origin, action) +
       '<div class="honeybadgerPowered tooltip" title="'+ UNDO_ARROW_TOOLTIP_TEXT + '"></div>' +
+      '<div class="removeOrigin">&#10006</div></div>' +
       '</div>';
 
     return originHtml;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -362,6 +362,16 @@ function removeWhitelistDomain(event) {
   reloadWhitelist();
 }
 
+function getScrollbarWidth() {
+  var div = $('<div style="width:50px;height:50px;overflow:hidden;position:absolute;top:-200px;left:-200px;"><div style="height:100px;"></div>');
+  $('body').append(div);
+  var w1 = $('div', div).innerWidth();
+  div.css('overflow-y', 'scroll');
+  var w2 = $('div', div).innerWidth();
+  $(div).remove();
+  return (w1 - w2);
+}
+
 // filter slider functions
 
 /**
@@ -456,7 +466,7 @@ function refreshFilterPage() {
   }
 
   // Get containing HTML for domain list along with toggle legend icons.
-  $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
+  $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml(undefined, getScrollbarWidth());
 
   // activate tooltips
   $('.tooltip').tooltipster();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -57,8 +57,6 @@ let migrations = require("migrations").Migrations;
  * Loads options from pb storage and sets UI elements accordingly.
  */
 function loadOptions() {
-  $('#blockedResources').css('max-height',$(window).height() - 300);
-
   // Set page title to i18n version of "Privacy Badger Options"
   document.title = i18n.getMessage("options_title");
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -362,14 +362,27 @@ function removeWhitelistDomain(event) {
   reloadWhitelist();
 }
 
+/**
+ * Gets width of scrollbar
+ * @return {String}
+ */
 function getScrollbarWidth() {
-  var div = $('<div style="width:50px;height:50px;overflow:hidden;position:absolute;top:-200px;left:-200px;"><div style="height:100px;"></div>');
+  // Add out of view div with taller div inside it; parent has "overflow: hidden"
+  var div = $('<div style="width:50px;height:50px;overflow:hidden;position:absolute;top:-200px;left:-200px;">' +
+    '<div style="height:100px;">' +
+    '</div>');
   $('body').append(div);
-  var w1 = $('div', div).innerWidth();
+
+  // Measure inner width
+  var widthWithoutScrollbar = $('div', div).innerWidth();
+
+  // Make parent div scroll on overflow, and measure new inner width (lower, thanks to scrollbar)
   div.css('overflow-y', 'scroll');
-  var w2 = $('div', div).innerWidth();
+  var widthWithScrollbar = $('div', div).innerWidth();
+
+  // Remove div from body, and return width of scrollbar
   $(div).remove();
-  return (w1 - w2);
+  return (widthWithoutScrollbar - widthWithScrollbar);
 }
 
 // filter slider functions

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -141,7 +141,17 @@ a, a:hover, a:active, a:visited{
     width: auto;
   }
 
+  #settingsSuffix{
+    width: auto;
+    left: 0;
+    padding-left: 50px;
+  }
+
   .origin {
     max-width: 250px;
+  }
+
+  table, tbody, tr, td {
+    display: block;
   }
 }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -137,6 +137,10 @@ a, a:hover, a:active, a:visited{
     min-width: none;
   }
 
+  #tracking-domains-overlay {
+    padding: 1em 1.4em;
+  }
+
   #tab-tracking-domains {
     padding: 0;
   }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -102,10 +102,9 @@ button
   }
 
   .key {
-    left: auto;
-    right: auto;
-    right: 215px;
+    text-align: right;
     padding-left: 0;
+    padding-right: 215px;
   }
 }
 

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -155,7 +155,7 @@ a, a:hover, a:active, a:visited{
     max-width: 250px;
   }
 
-  table, tbody, tr, td {
+  #whitelistForm table, #whitelistForm tbody, #whitelistForm tr, #whitelistForm td {
     display: block;
   }
 

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -101,9 +101,9 @@ button
   width: 115px;
 }
 
-.honeybadgerPowered{
+.userset .honeybadgerPowered{
   bottom: 0;
-  display: inline-block !important;
+  display: inline-block;
   margin-left: 117px;
   margin-right: 10px;
   left: 0;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -78,8 +78,6 @@ button
 }
 
 #tracking-domains-div {
-  min-width: 384px;
-  width: 70%;
   max-width: 750px;
 }
 
@@ -118,8 +116,9 @@ button
   left: 50px;
 }
 
+/* Set max length of Tracking Domain origin in list to a relative value */
 .origin {
-  max-width: 226px;
+  max-width: 60%;
 }
 
 #trackingDomainSearch {
@@ -149,11 +148,6 @@ a, a:hover, a:active, a:visited{
     width: auto;
     left: 0;
     padding-left: 50px;
-  }
-
-  /* Set shorter max-chars for Tracking Domains because of less space */
-  .origin {
-    max-width: 250px;
   }
 
   /* Display elements on "Whitelisted Domains" under eachother */

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -3,7 +3,9 @@ body
   font-family: Arial, Helvetica, sans-serif;
   font-size: 13px;
   padding: 20px;
+  margin: 0 auto;
   width: 100%;
+  max-width: 1400px;
 }
 
 td
@@ -80,32 +82,35 @@ button
 
 #tracking-domains-div {
   min-width: 390px;
-  width: 89vw;
+  width: 70%;
+  max-width: 750px;
 }
 
-@media (min-width: 798px) {
-  #tracking-domains-div {
-    width: auto;
-    min-width: 750px;
-  }
+.switch-container{
+  float: right;
+  margin-left: 0;
+  margin-right: 23px;
 
-  .switch-container{
-      float: right;
-      margin-left: 0;
-      margin-right: 193px;
-  }
+}
 
-  .honeybadgerPowered{
-    float: right;
-    left: 148px;
-    bottom: 0;
-  }
+.options .switch-container {
+  max-width: none;
+}
 
-  .key {
-    text-align: right;
-    padding-left: 0;
-    padding-right: 215px;
-  }
+.honeybadgerPowered{
+  float: right;
+  left: 148px;
+  bottom: 0;
+}
+
+.key {
+  text-align: right;
+  padding-left: 0;
+  padding-right: 46px;
+}
+
+.clickerContainer {
+  max-height: none;
 }
 
 #settingsSuffix{

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -78,7 +78,7 @@ button
 }
 
 #tracking-domains-div {
-  min-width: 390px;
+  min-width: 485px;
   width: 70%;
   max-width: 750px;
 }
@@ -146,17 +146,13 @@ a, a:hover, a:active, a:visited{
   }
 
   #tracking-domains-div {
-    width: auto;
+    width: calc(70% - 2.8em);
   }
 
   #settingsSuffix{
     width: auto;
     left: 0;
     padding-left: 50px;
-  }
-
-  .origin {
-    max-width: 250px;
   }
 
   #whitelistForm table, #whitelistForm tbody, #whitelistForm tr, #whitelistForm td {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -160,7 +160,7 @@ a, a:hover, a:active, a:visited{
   }
 
   #excludedDomainsBox {
-    width: auto !important;
+    width: 100% !important;
   }
 
   #trackingDomainSearch {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -24,9 +24,6 @@ button
 {
   white-space: pre;
 }
-#tabs {
-  min-width: 750px;
-}
 
 .tooltipArrow {
   bottom: 27px;
@@ -128,4 +125,23 @@ button
 a, a:hover, a:active, a:visited{
   color: #00aaaa;
   text-decoration: underline;
+}
+
+@media (max-width: 749px) {
+  body {
+    padding: 0;
+    min-width: none;
+  }
+
+  #tab-tracking-domains {
+    padding: 0;
+  }
+
+  #tracking-domains-div {
+    width: auto;
+  }
+
+  .origin {
+    max-width: 250px;
+  }
 }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -4,8 +4,14 @@ body
   font-size: 13px;
   padding: 20px;
   margin: 0 auto;
+  min-width: 430px;
   width: 100%;
   max-width: 1400px;
+}
+
+/* Set minimum viewport size */
+#tabs {
+  min-width: 432px;
 }
 
 td
@@ -82,30 +88,38 @@ button
 }
 
 .switch-container{
-  float: right;
   margin-left: 0;
-  margin-right: 23px;
-
+  position: absolute;
+  display: inline;
 }
 
 .options .switch-container {
   max-width: none;
 }
 
+.switch-toggle {
+  width: 115px;
+}
+
 .honeybadgerPowered{
-  float: right;
-  left: 148px;
   bottom: 0;
+  display: inline-block !important;
+  margin-left: 117px;
+  margin-right: 10px;
+  left: 0;
+}
+
+.removeOrigin {
+  display: inline;
 }
 
 .key {
-  text-align: right;
-  padding-left: 0;
-  padding-right: 46px;
+  padding-left: calc(100% - 172px);
 }
 
 .clickerContainer {
   max-height: 50vh;
+  min-width: 378px;
 }
 
 #settingsSuffix{
@@ -118,7 +132,13 @@ button
 
 /* Set max length of Tracking Domain origin in list to a relative value */
 .origin {
-  max-width: 60%;
+  width: calc(100% - 157px);
+  max-width: 593px;
+}
+
+.clickables-container {
+  display: inline-block;
+  width: 157px;
 }
 
 #trackingDomainSearch {
@@ -158,10 +178,5 @@ a, a:hover, a:active, a:visited{
   /* Set width of whitelist-box */
   #excludedDomainsBox {
     width: 100% !important;
-  }
-
-  /* Adjust width to align with list of Tracking Domains */
-  #trackingDomainSearch {
-    width: 98% !important;
   }
 }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -107,7 +107,7 @@ button
 }
 
 .clickerContainer {
-  max-height: none;
+  max-height: 50vh;
 }
 
 #settingsSuffix{

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -78,7 +78,7 @@ button
 }
 
 #tracking-domains-div {
-  min-width: 408px;
+  min-width: 384px;
   width: 70%;
   max-width: 750px;
 }
@@ -119,7 +119,7 @@ button
 }
 
 .origin {
-  max-width: 325px;
+  max-width: 226px;
 }
 
 #trackingDomainSearch {
@@ -131,42 +131,42 @@ a, a:hover, a:active, a:visited{
   text-decoration: underline;
 }
 
+/* Handle smaller viewports */
 @media (max-width: 749px) {
+  /* Remove padding to better use available space */
   body {
     padding: 0;
     min-width: none;
   }
 
+  /* Add removed padding for acknowledgement text */
   #tracking-domains-overlay {
     padding: 1em 1.4em;
   }
 
-  #tab-tracking-domains {
-    padding: 0;
-  }
-
-  #tracking-domains-div {
-    width: calc(70% - 2.8em);
-  }
-
+  /* Fix padding on WebRTC notice */
   #settingsSuffix{
     width: auto;
     left: 0;
     padding-left: 50px;
   }
 
+  /* Set shorter max-chars for Tracking Domains because of less space */
   .origin {
     max-width: 250px;
   }
 
+  /* Display elements on "Whitelisted Domains" under eachother */
   #whitelistForm table, #whitelistForm tbody, #whitelistForm tr, #whitelistForm td {
     display: block;
   }
 
+  /* Set width of whitelist-box */
   #excludedDomainsBox {
     width: 100% !important;
   }
 
+  /* Adjust width to align with list of Tracking Domains */
   #trackingDomainSearch {
     width: 98% !important;
   }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -80,7 +80,7 @@ button
 }
 
 #tracking-domains-div {
-  width: 390px;
+  min-width: 750px;
 }
 
 #settingsSuffix{

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -78,7 +78,7 @@ button
 }
 
 #tracking-domains-div {
-  min-width: 485px;
+  min-width: 408px;
   width: 70%;
   max-width: 750px;
 }
@@ -153,6 +153,10 @@ a, a:hover, a:active, a:visited{
     width: auto;
     left: 0;
     padding-left: 50px;
+  }
+
+  .origin {
+    max-width: 250px;
   }
 
   #whitelistForm table, #whitelistForm tbody, #whitelistForm tr, #whitelistForm td {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -32,7 +32,6 @@ button
 
 #pbInstructions {
   margin-bottom: 20px;
-  width: 500px;
 }
 
 #rawFilters {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -86,7 +86,7 @@ button
 @media (min-width: 798px) {
   #tracking-domains-div {
     width: auto;
-    min-with: 750px;
+    min-width: 750px;
   }
 
   .switch-container{

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -121,6 +121,10 @@ button
   left: 50px;
 }
 
+.origin {
+  max-width: 325px;
+}
+
 a, a:hover, a:active, a:visited{
   color: #00aaaa;
   text-decoration: underline;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -80,7 +80,34 @@ button
 }
 
 #tracking-domains-div {
-  min-width: 750px;
+  min-width: 390px;
+  width: 89vw;
+}
+
+@media (min-width: 798px) {
+  #tracking-domains-div {
+    width: auto;
+    min-with: 750px;
+  }
+
+  .switch-container{
+      float: right;
+      margin-left: 0;
+      margin-right: 193px;
+  }
+
+  .honeybadgerPowered{
+    float: right;
+    left: 148px;
+    bottom: 0;
+  }
+
+  .key {
+    left: auto;
+    right: auto;
+    right: 215px;
+    padding-left: 0;
+  }
 }
 
 #settingsSuffix{

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -114,12 +114,15 @@ button
 }
 
 .key {
-  padding-left: calc(100% - 172px);
+  /* Position legend icons using width of .clickables-container,
+      and accounting for paddings in the list and margins on .key>img
+  */
+  padding-left: calc(calc(100% - 157px) - 15px);
 }
 
 .clickerContainer {
   max-height: 50vh;
-  min-width: 378px;
+  min-width: 378px; /* Minimum width of Tracking Domains list; fit origin + buttons */
 }
 
 #settingsSuffix{
@@ -132,7 +135,7 @@ button
 
 /* Set max length of Tracking Domain origin in list to a relative value */
 .origin {
-  width: calc(100% - 157px);
+  width: calc(100% - 157px); /* Use full width MINUS the width of .clickables-container (switch + buttons) */
   max-width: 593px;
 }
 

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -122,6 +122,10 @@ button
   max-width: 325px;
 }
 
+#trackingDomainSearch {
+  width: 99% !important;
+}
+
 a, a:hover, a:active, a:visited{
   color: #00aaaa;
   text-decoration: underline;
@@ -153,5 +157,13 @@ a, a:hover, a:active, a:visited{
 
   table, tbody, tr, td {
     display: block;
+  }
+
+  #excludedDomainsBox {
+    width: auto !important;
+  }
+
+  #trackingDomainSearch {
+    width: 98% !important;
   }
 }

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -87,7 +87,7 @@
       <table>
         <tr>
           <td style="max-width:100%">
-            <input type="text" value="" id="newWhitelistDomain" style="width:100%" placeholder="i18n_whitelist_form_domain_input_placeholder">
+            <input type="text" value="" id="newWhitelistDomain" style="width:99%" placeholder="i18n_whitelist_form_domain_input_placeholder">
           </td>
           <td>
             <button class="addButton" type="submit"><span class="i18n_add_domain_button"></span></button>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -74,7 +74,7 @@
         <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" style="display:none"></span>
       </p>
       <div id="tracking-domains-div">
-          <input id="trackingDomainSearch" type="text" value="" style="width:100%" placeholder="i18n_options_domain_search">
+          <input id="trackingDomainSearch" type="text" value="" placeholder="i18n_options_domain_search">
           <div id="blockedResources"><span class="i18n_options_loading"></span></div>
       </div>
     </div>

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -108,8 +108,7 @@ a:hover { color: #ec9329 }
 .switch-container{
   width: 115px;
   display: block;
-  float: right;
-  margin-right: 193px;
+  margin-left: 220px;
 }
 .options .switch-container{
   max-width: 114px;
@@ -142,8 +141,8 @@ a:hover { color: #ec9329 }
   width: 20px;
   height: 20px;
   position: relative;
-  float: right;
-  left: 148px;
+  left: 337px;
+  bottom: 15px;
   cursor: pointer;
 }
 .userset .honeybadgerPowered{
@@ -215,10 +214,12 @@ font-size: 16px;
 .key {
   position: absolute;
   height: 25px;
-  right: 215px;
+  left: 0;
+  right: 0;
   z-index: 30;
   background: #fefefe;
   padding-top: 4px;
+  padding-left: 215px;
 }
 .key img{
   margin-left: 19px;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -108,7 +108,8 @@ a:hover { color: #ec9329 }
 .switch-container{
   width: 115px;
   display: block;
-  margin-left: 220px;
+  float: right;
+  margin-right: 193px;
 }
 .options .switch-container{
   max-width: 114px;
@@ -141,8 +142,8 @@ a:hover { color: #ec9329 }
   width: 20px;
   height: 20px;
   position: relative;
-  left: 337px;
-  bottom: 15px;
+  float: right;
+  left: 148px;
   cursor: pointer;
 }
 .userset .honeybadgerPowered{
@@ -214,12 +215,10 @@ font-size: 16px;
 .key {
   position: absolute;
   height: 25px;
-  left: 0;
-  right: 0;
+  right: 215px;
   z-index: 30;
   background: #fefefe;
   padding-top: 4px;
-  padding-left: 215px;
 }
 .key img{
   margin-left: 19px;

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -124,6 +124,7 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
         try:
             remove_origin_element = origins.find_element_by_xpath(
                 './/div[@data-origin="pbtest.org"]' +
+                '//div[@class="clickables-container"]' +
                 '//div[@class="removeOrigin"]')
         except NoSuchElementException:
             self.fail("Tracking origin is not displayed")


### PR DESCRIPTION
This PR fixes #1599.
![skjermbilde 2018-01-16 kl 21 39 25](https://user-images.githubusercontent.com/939844/35011451-6d1d5e18-fb06-11e7-8b8c-3aa656453075.png)
Domains Options page tab page width is now only constrained by #1669.