### PR TITLE
Add codecov.io to yellowlist (code coverage badges)

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -83,6 +83,7 @@ cleanprint.net
 cleveland.com
 cloudflare.com
 cloudfront.net
+codecov.io
 bbb.org
 bbc.co.uk
 bbci.co.uk


### PR DESCRIPTION
Okay, is this a stupid niche? Honestly, I just kind of didn't understand why some badges were okay and codecov wasn't, so figured it's conventional to yellow list these open source do-gooders :)

![image](https://user-images.githubusercontent.com/374612/35197658-a5016416-fee2-11e7-9c40-ce443685d361.png)

https://github.com/codecov/support/issues/469