### PR TITLE
Remove unlimited storage

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -67,6 +67,10 @@
         "message": "Report an Error",
         "description": ""
     },
+    "extension_error_text": {
+        "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
+        "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
+    },
     "whitelist_form_domain_input_placeholder": {
         "message": "e.g. www.domain.com, *.domain.net, domain.org",
         "description": "Placeholder text for the Add domain input under the Whitelisted Domains tab on the options page."

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -597,6 +597,12 @@ Badger.prototype = {
         return;
       }
 
+      if (badger.error) {
+        chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#cc0000"});
+        chrome.browserAction.setBadgeText({tabId: tab_id, text: "!"});
+        return;
+      }
+
       let count = self.getBlockedOriginCount(tab_id);
 
       if (count === 0) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -584,6 +584,12 @@ Badger.prototype = {
         return;
       }
 
+      if (badger.error) {
+        chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#cc0000"});
+        chrome.browserAction.setBadgeText({tabId: tab_id, text: "!"});
+        return;
+      }
+
       // don't show the counter for any of these:
       // - the counter is disabled
       // - we don't have tabData for whatever reason (special browser pages)
@@ -594,12 +600,6 @@ Badger.prototype = {
         !self.isPrivacyBadgerEnabled(self.getFrameData(tab_id).host)
       ) {
         chrome.browserAction.setBadgeText({tabId: tab_id, text: ""});
-        return;
-      }
-
-      if (badger.error) {
-        chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#cc0000"});
-        chrome.browserAction.setBadgeText({tabId: tab_id, text: "!"});
         return;
       }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -602,7 +602,7 @@ Badger.prototype = {
       if (count === 0) {
         chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#00cc00"});
       } else {
-        chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#cc0000"});
+        chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#ec9329"});
       }
 
       chrome.browserAction.setBadgeText({tabId: tab_id, text: count + ""});

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -91,7 +91,7 @@ function showNagMaybe() {
     });
   } else if (badger.error) {
     $('#instruction-text').hide();
-    $('#error-text').show();
+    $('#error-text').show().find('a').attr('id', 'firstRun').css('padding', '5px');
     $('#error-message').text(badger.error);
     _showNag();
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -89,6 +89,11 @@ function showNagMaybe() {
         _showNag();
       }
     });
+  } else if (badger.error) {
+    $('#instruction-text').hide();
+    $('#error-text').show();
+    $('#error-message').text(badger.error);
+    _showNag();
   }
 }
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -516,10 +516,18 @@ BadgerStorage.prototype = {
 var _syncStorage = (function () {
   var debouncedFuncs = {};
 
+  function cb() {
+    if (chrome.runtime.lastError) {
+      let err = chrome.runtime.lastError.message;
+      badger.error = err;
+      console.error("Error writing to chrome.storage.local:", err);
+    }
+  }
+
   function sync(badgerStorage) {
     var obj = {};
     obj[badgerStorage.name] = badgerStorage._store;
-    chrome.storage.local.set(obj);
+    chrome.storage.local.set(obj, cb);
   }
 
   // Creates debounced versions of "sync" function,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,8 +17,7 @@
     "webNavigation",
     "storage",
     "cookies",
-    "privacy",
-    "unlimitedStorage"
+    "privacy"
   ],
   "background": {
     "scripts": [

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -38,15 +38,21 @@
   <div id="instruction-outer">
   </div>
   <div id="instruction" class="overlay">
-    <img src='/icons/badger-48.png'>
+    <img id="instruction-logo" src='/icons/badger-48.png'>
     <svg id="fittslaw" width="30" height="30" fill="white">
       <line x1="5" y1="5" x2="20" y2="20" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
       <line x1="5" y1="20" x2="20" y2="5" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
     </svg>
-    <p class="i18n_intro_text"></p>
-    <br>
-    <div id="firstRun">
-      <p class="i18n_first_run_text"></p>
+    <div id="instruction-text">
+        <p class="i18n_intro_text"></p>
+        <br>
+        <div id="firstRun">
+          <p class="i18n_first_run_text"></p>
+        </div>
+    </div>
+    <div id="error-text" style="display:none">
+        <p><span class="i18n_extension_error_text"></span></p>
+        <p style="color:#cc0000" id="error-message"></p>
     </div>
   </div>
   <div id="overlay" class="overlay">


### PR DESCRIPTION
Closes #1745, closes #1747.

This removes `unlimitedStorage` from the manifest.

I also changed the "trackers ~~detected~~ blocked" badge color from red to (Badger) orange. Less yelling at the user on basically every page, more on-brand.

Finally, to follow up on https://github.com/EFForg/privacybadger/pull/1795#issuecomment-360631265, when we fail writing to `chrome.storage.local`, we change badge color to red, badge contents to "!", and (reusing the intro reminder widget) show a message in the popup asking the user to let us know about this issue.

What the new badge looks like:

![screenshot from 2018-01-29 14 28 27](https://user-images.githubusercontent.com/794578/35529978-af2c108e-0500-11e8-96a7-558d2018a4c5.png)

What failing to write to storage looks like on the background page:

![screenshot from 2018-01-29 14 27 12](https://user-images.githubusercontent.com/794578/35529923-82d541fe-0500-11e8-841b-08098a249b8c.png)

What it looks like in the popup:

![screenshot from 2018-01-29 14 26 38](https://user-images.githubusercontent.com/794578/35529911-748b3e78-0500-11e8-83a0-e4970ed5d3dd.png)