### PR TITLE
Remove web_accessible_resources

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -27,12 +27,7 @@ var pbStorage = require("storage");
 var HeuristicBlocking = require("heuristicblocking");
 var FirefoxAndroid = require("firefoxandroid");
 var webrequest = require("webrequest");
-var SocialWidgetLoader = require("socialwidgetloader");
-
-window.SocialWidgetList = [];
-SocialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json", function(socialWidgets) {
-  window.SocialWidgetList = socialWidgets;
-});
+var socialWidgetLoader = require("socialwidgetloader");
 
 var Migrations = require("migrations").Migrations;
 var incognito = require("incognito");
@@ -42,7 +37,14 @@ var incognito = require("incognito");
 */
 function Badger() {
   var badger = this;
+
   this.webRTCAvailable = checkWebRTCBrowserSupport();
+
+  badger.socialWidgetList = [];
+  socialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json", (response) => {
+    badger.socialWidgetList = response;
+  });
+
   this.storage = new pbStorage.BadgerPen(function(thisStorage) {
     if (badger.INITIALIZED) { return; }
     badger.heuristicBlocking = new HeuristicBlocking.HeuristicBlocker(thisStorage);

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -42,7 +42,6 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-/* globals chrome, document, window, console*/
 
 /**
  * Social widget tracker data, read from file.

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -138,12 +138,8 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
       var iframeUrl = details + encodeURIComponent(window.location.href);
 
       button.addEventListener("click", function() {
-        // for some reason, the callback function can execute more than
-        // once when the user clicks on a replacement button
-        // (it executes for the buttons that have been previously
-        // clicked as well)
         replaceButtonWithIframeAndUnblockTracker(button, buttonData.unblockDomains, iframeUrl);
-      });
+      }, { once: true });
 
       break;
 
@@ -151,18 +147,14 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
     // specified in the Trackers file
     case 2:
       button.addEventListener("click", function() {
-        // for some reason, the callback function can execute more than
-        // once when the user clicks on a replacement button
-        // (it executes for the buttons that have been previously
-        // clicked as well)
         replaceButtonWithHtmlCodeAndUnblockTracker(button, buttonData.unblockDomains, details);
-      });
+      }, { once: true });
       break;
 
     case 3:
       button.addEventListener("click", function() {
         replaceButtonWithHtmlCodeAndUnblockTracker(button, buttonData.unblockDomains, trackerElem);
-      });
+      }, { once: true });
       break;
 
     default:
@@ -223,8 +215,6 @@ function replaceButtonWithHtmlCodeAndUnblockTracker(button, tracker, html) {
       button.parentNode.replaceChild(codeContainer, button);
 
       replaceScriptsRecurse(codeContainer);
-
-      button.removeEventListener("click");
     }
   });
 }

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -42,7 +42,6 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-/* globals chrome */
 
 var utils = require('utils');
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -25,9 +25,9 @@ require.scopes.utils = (function() {
 /**
 * Generic interface to make an XHR request
 *
-* @param url The url to get
-* @param callback The callback to call after request has finished
-* @param method GET/POST
+* @param {String} url The url to get
+* @param {Function} callback The callback to call after request has finished
+* @param {String} method GET/POST
 */
 function xhrRequest(url, callback, method) {
   if (!method) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -345,24 +345,23 @@ function getHostFromDomainInput(input) {
 }
 
 /************************************** exports */
-var exports = {};
-
-exports.arrayBufferToBase64 = arrayBufferToBase64;
-exports.estimateMaxEntropy = estimateMaxEntropy;
-exports.explodeSubdomains = explodeSubdomains;
-exports.getHostFromDomainInput = getHostFromDomainInput;
-exports.nDaysFromNow = nDaysFromNow;
-exports.oneDayFromNow = oneDayFromNow;
-exports.oneDay = oneDay;
-exports.oneHour = oneHour;
-exports.oneMinute = oneMinute;
-exports.oneSecond = oneSecond;
-exports.parseCookie = parseCookie;
-exports.rateLimit = rateLimit;
-exports.removeElementFromArray = removeElementFromArray;
-exports.sha1 = sha1;
-exports.xhrRequest = xhrRequest;
-
+var exports = {
+  arrayBufferToBase64,
+  estimateMaxEntropy,
+  explodeSubdomains,
+  getHostFromDomainInput,
+  nDaysFromNow,
+  oneDayFromNow,
+  oneDay,
+  oneHour,
+  oneMinute,
+  oneSecond,
+  parseCookie,
+  rateLimit,
+  removeElementFromArray,
+  sha1,
+  xhrRequest,
+};
 return exports;
 /************************************** exports */
 })(); //require scopes

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -61,6 +61,25 @@ function xhrRequest(url, callback, method, opts) {
 }
 
 /**
+ * Converts binary data to base64-encoded text suitable for use in data URIs.
+ *
+ * Adapted from https://stackoverflow.com/a/9458996.
+ *
+ * @param {ArrayBuffer} buffer binary data
+ *
+ * @returns {String} base64-encoded text
+ */
+function arrayBufferToBase64(buffer) {
+  var binary = '';
+  var bytes = new Uint8Array(buffer);
+  var len = bytes.byteLength;
+  for (var i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
 * Return an array of all subdomains in an FQDN, ordered from the FQDN to the
 * eTLD+1. e.g. [a.b.eff.org, b.eff.org, eff.org]
 * if 'all' is passed in then the array will include all domain levels, not
@@ -328,6 +347,7 @@ function getHostFromDomainInput(input) {
 /************************************** exports */
 var exports = {};
 
+exports.arrayBufferToBase64 = arrayBufferToBase64;
 exports.estimateMaxEntropy = estimateMaxEntropy;
 exports.explodeSubdomains = explodeSubdomains;
 exports.getHostFromDomainInput = getHostFromDomainInput;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -36,11 +36,11 @@ function xhrRequest(url, callback, method) {
   var xhr = new XMLHttpRequest();
   xhr.onload = function () {
     if (xhr.status == 200) {
-      callback(null, xhr.responseText);
+      callback(null, xhr.response);
     } else {
       var error = {
         status: xhr.status,
-        message: xhr.responseText,
+        message: xhr.response,
         object: xhr
       };
       callback(error, error.message);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -28,12 +28,18 @@ require.scopes.utils = (function() {
 * @param {String} url The url to get
 * @param {Function} callback The callback to call after request has finished
 * @param {String} method GET/POST
+* @param {Object} opts XMLHttpRequest options
 */
-function xhrRequest(url, callback, method) {
+function xhrRequest(url, callback, method, opts) {
   if (!method) {
     method = "GET";
   }
   var xhr = new XMLHttpRequest();
+  if (opts) {
+    _.each(opts, function (value, key) {
+      xhr[key] = value;
+    });
+  }
   xhr.onload = function () {
     if (xhr.status == 200) {
       callback(null, xhr.response);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -552,10 +552,9 @@ function getSocialWidgetBlockList() {
   var socialWidgetsToReplace = {};
 
   badger.socialWidgetList.forEach(function (socialwidget) {
-    // Only replace social widgets that the user has not manually allowed
-    var socialWidgetName = socialwidget.name;
-    socialWidgetsToReplace[socialWidgetName] = (
-      badger.storage.getAction(socialwidget.domain) != constants.USER_ALLOW
+    // Only replace blocked and yellowlisted widgets
+    socialWidgetsToReplace[socialwidget.name] = constants.BLOCKED_ACTIONS.has(
+      badger.storage.getBestAction(socialwidget.domain)
     );
   });
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -550,8 +550,7 @@ function getSocialWidgetBlockList() {
   // whether the content script should replace that tracker's social buttons
   var socialWidgetsToReplace = {};
 
-  window.SocialWidgetList.forEach(function(socialwidget) {
-
+  badger.socialWidgetList.forEach(function (socialwidget) {
     // Only replace social widgets that the user has not manually allowed
     var socialWidgetName = socialwidget.name;
     socialWidgetsToReplace[socialWidgetName] = (
@@ -560,8 +559,8 @@ function getSocialWidgetBlockList() {
   });
 
   return {
-    "trackers" : window.SocialWidgetList,
-    "trackerButtonsToReplace" : socialWidgetsToReplace
+    trackers: badger.socialWidgetList,
+    trackerButtonsToReplace: socialWidgetsToReplace
   };
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -28,6 +28,7 @@ var constants = require('constants');
 var getSurrogateURI = require('surrogates').getSurrogateURI;
 var mdfp = require('multiDomainFP');
 var incognito = require("incognito");
+var utils = require("utils");
 
 require.scopes.webrequest = (function() {
 
@@ -645,6 +646,35 @@ function dispatcher(request, sender, sendResponse) {
     var socialWidgetUrls = request.buttonUrls;
     unblockSocialWidgetOnTab(sender.tab.id, socialWidgetUrls);
     sendResponse();
+
+  } else if (request.getReplacementButton) {
+
+    let button_path = chrome.extension.getURL(
+      "skin/socialwidgets/" + request.getReplacementButton);
+
+    let image_type = button_path.slice(button_path.lastIndexOf('.') + 1);
+
+    let xhrOptions = {};
+    if (image_type != "svg") {
+      xhrOptions.responseType = "arraybuffer";
+    }
+
+    // fetch replacement button image data
+    utils.xhrRequest(button_path, function (err, response) {
+      // one data URI for SVGs
+      if (image_type == "svg") {
+        return sendResponse('data:image/svg+xml;utf8,' + response);
+      }
+
+      // another data URI for all other image formats
+      sendResponse(
+        'data:image/' + image_type + ';base64,' +
+        utils.arrayBufferToBase64(response)
+      );
+    }, "GET", xhrOptions);
+
+    // indicate this is an async response to chrome.runtime.onMessage
+    return true;
 
   // Canvas fingerprinting
   } else if (request.fpReport) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -663,7 +663,7 @@ function dispatcher(request, sender, sendResponse) {
     utils.xhrRequest(button_path, function (err, response) {
       // one data URI for SVGs
       if (image_type == "svg") {
-        return sendResponse('data:image/svg+xml;utf8,' + response);
+        return sendResponse('data:image/svg+xml;charset=utf-8,' + encodeURIComponent(response));
       }
 
       // another data URI for all other image formats

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -102,8 +102,5 @@
     "page": "/skin/options.html",
     "open_in_tab": true
   },
-  "web_accessible_resources": [
-    "skin/socialwidgets/*"
-  ],
   "update_url": "https://clients2.google.com/service/update2/crx"
 }


### PR DESCRIPTION
- [x] Removed `web_accessible_resources` to work around [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1372288).
- [x] Changed replacement to happen for blocked/cookieblocked widget domains only (previously, all domains except user-allowed). It doesn't make much sense to replace something that already fully loaded, plus this is closer to [what we say in the FAQ](https://www.eff.org/privacybadger#faq-How-does-Privacy-Badger-handle-social-media-widgets?).
- [ ] Replacing yellowlisted domains is more of a gray area. Domains covered by widget replacement should probably not be on the yellowlist, but the most popular widgets (Facebook, Google, Twitter) have also already been yellowlisted. We should follow up by seeing if it makes sense to remove them from the yellowlist (related to #1474 and #1593), and if it does, do so and then update widget replacement to happen for blocked domains only.
- [ ] This PR introduces a race condition with replacing a yellowlisted domain where the replacement can fail if the widget's JavaScript removes the element we want to replace and gets to do so before we do.
- [x] Fixed click handler removal bug that was breaking replaced AddThis widgets in Chrome.