### PR TITLE
Changing fingerprinting script to load conditionally

### DIFF
--- a/src/js/contentscripts/fingerprinting.js
+++ b/src/js/contentscripts/fingerprinting.js
@@ -320,10 +320,11 @@ function insertFpScript(text, data) {
   parent.removeChild(script);
 }
 
+// TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({checkEnabled: true},
   function (enabled) {
     if (!enabled) {
-        return;
+      return;
     }
     /**
      * Communicating to webrequest.js

--- a/src/js/contentscripts/fingerprinting.js
+++ b/src/js/contentscripts/fingerprinting.js
@@ -320,19 +320,26 @@ function insertFpScript(text, data) {
   parent.removeChild(script);
 }
 
-/**
- * Communicating to webrequest.js
- */
-var event_id = Math.random();
+chrome.runtime.sendMessage({checkEnabled: true},
+  function (enabled) {
+    if (!enabled) {
+        return;
+    }
+    /**
+     * Communicating to webrequest.js
+     */
+    var event_id = Math.random();
 
-// listen for messages from the script we are about to insert
-document.addEventListener(event_id, function (e) {
-  // pass these on to the background page
-  chrome.runtime.sendMessage({
-    'fpReport': e.detail
-  });
-});
+    // listen for messages from the script we are about to insert
+    document.addEventListener(event_id, function (e) {
+      // pass these on to the background page
+      chrome.runtime.sendMessage({
+        'fpReport': e.detail
+      });
+    });
 
-insertFpScript(getFpPageScript(), {
-  event_id: event_id
-});
+    insertFpScript(getFpPageScript(), {
+      event_id: event_id
+    });
+  }
+);


### PR DESCRIPTION
Fixes #1854.

When the site being visited is whitelisted, the fingerprinting detection content script will no longer be injected.