### PR TITLE
Add textalk.se to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -518,6 +518,7 @@ targetimg1.com
 targetimg2.com
 technorati.com
 tegna-media.com
+textalk.se
 theplatform.com
 tile.thunderforest.com
 timeinc.net


### PR DESCRIPTION
This follows up on #1824. Looks like we successfully fixed Klarna problems because we haven't gotten any more Klarna-related complaints. We are getting similar complaints regarding Textalk Webshop though.

Example pages:
- http://gripenbro.se/artiklar/watches/
- http://islina.se/
- http://www.vio.se/vara-produkter/kyrkljus/julgransljus-1-2x11cm-storpack

Error report counts by date and exact blocked subdomain:
```
+---------+----------------------+-------+
| ym      | blocked_fqdn         | count |
+---------+----------------------+-------+
| 2018-02 | shopcdn.textalk.se   |     1 |
| 2018-02 | themesorg.textalk.se |     1 |
| 2018-01 | shopcdn.textalk.se   |     1 |
| 2017-12 | shop.textalk.se      |     1 |
| 2017-12 | themesorg.textalk.se |     1 |
| 2017-09 | shop.textalk.se      |     2 |
| 2017-08 | shop.textalk.se      |     1 |
| 2017-08 | shopcdn.textalk.se   |     2 |
| 2017-07 | shopcdn.textalk.se   |     1 |
...
```