### PR TITLE
Add Slickdeals to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -331,6 +331,7 @@ var multiDomainFirstPartiesArray = [
   ["siriusxm.com", "sirius.com"],
   ["skygo.co.nz", "skytv.co.nz"],
   ["skysports.com", "skybet.com", "skyvegas.com"],
+  ["slickdeals.net", "slickdealscdn.com"],
   ["snapfish.com", "snapfish.ca"],
   ["sony.com", "sonyrewards.com"],
   ["soundcu.com", "netteller.com"],


### PR DESCRIPTION
I don't know why Privacy Badger learns to block `slickdealscdn.com`, but it does, and we consistently get a few reports about it every month.

Error report counts by page domain and exact blocked subdomain (or, where and how many times were the different `slickdealscdn.com` subdomains reported as blocked in user error reports):
```
+----------------+--------------------------+-------+
| fqdn           | blocked_fqdn             | count |
+----------------+--------------------------+-------+
| slickdeals.net | css.slickdealscdn.com    |   102 |
| slickdeals.net | static.slickdealscdn.com |    99 |
| slickdeals.net | js.slickdealscdn.com     |    53 |
+----------------+--------------------------+-------+
```

Error report counts by date and exact blocked subdomain (or, how often do we get user error reports of `slickdealscdn.com` subdomains being blocked):
```
+---------+--------------------------+-------+
| ym      | blocked_fqdn             | count |
+---------+--------------------------+-------+
| 2018-02 | css.slickdealscdn.com    |     4 |
| 2018-02 | static.slickdealscdn.com |     4 |
| 2018-01 | css.slickdealscdn.com    |     2 |
| 2018-01 | static.slickdealscdn.com |     2 |
| 2017-12 | css.slickdealscdn.com    |     2 |
| 2017-12 | static.slickdealscdn.com |     2 |
| 2017-11 | css.slickdealscdn.com    |     4 |
| 2017-11 | static.slickdealscdn.com |     4 |
| 2017-10 | css.slickdealscdn.com    |     3 |
| 2017-10 | static.slickdealscdn.com |     3 |
| 2017-09 | css.slickdealscdn.com    |     2 |
| 2017-09 | static.slickdealscdn.com |     1 |
| 2017-08 | css.slickdealscdn.com    |     3 |
| 2017-08 | static.slickdealscdn.com |     3 |
| 2017-07 | css.slickdealscdn.com    |     4 |
| 2017-07 | static.slickdealscdn.com |     4 |
...
```