### PR TITLE
Add kxcdn.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -328,6 +328,7 @@ kinja-static.com
 klarna.com
 klarnacdn.net
 klm.com
+kxcdn.com
 licdn.com
 licensebuttons.net
 addon.lidl.de


### PR DESCRIPTION
I've been in touch with KeyCDN regarding customer reports of Privacy Badger learning to block `kxcdn.com` resources. We think what happened was a customer's Google Analytics cookie was scoped for the entire `.kxcdn.com` domain (instead of their specific subdomain), which means browsing several KeyCDN-powered sites would teach Badger to block `kxcdn.com`. We weren't able to find where exactly this happens, however.

It seems like this is a potential issue with any CDN that uses the same base domain across multiple customer accounts.

There is history of us adding CDNs to the yellowlist (f35b16dc773e86289fb51aec884aa9322d98e207, cfe3cf95e141f161071bfb0930692ca37e3fd32c).