### PR TITLE
Add Newegg to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -297,6 +297,7 @@ var multiDomainFirstPartiesArray = [
   ["myuv.com", "uvvu.com"],
   ["nefcuonline.com", "nefcu.com"],
   ["netflix.com", "nflxext.com", "nflximg.net", "nflxvideo.net"],
+  ["newegg.com", "neweggbusiness.com", "newegg.ca"],
   ["norsk-tipping.no", "buypass.no"],
   ["nymag.com", "vulture.com", "grubstreet.com"],
   ["nypublicradio.org", "radiolab.org", "wnyc.org", "wqxr.org", "thegreenespace.org"],


### PR DESCRIPTION
Also not clear how Badger learns to block `newegg.com` but it does. Logging in is probably part of it, which I tried, but I don't know what the third domain for Badger to learn from is.

My [debug info](gist.github.com/anonymous/8aebb8e48a1ce3c256b21dcfe37af84b):
```
**** ACTION_MAP for newegg.com
secure.newegg.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "allow",
  "nextUpdateTime": 1519787876865
}
newegg.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "allow",
  "nextUpdateTime": 0
}
ssl-images.newegg.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "allow",
  "nextUpdateTime": 1519470707776
}
 **** SNITCH_MAP for newegg
newegg.com [
  "newegg.ca",
  "neweggbusiness.com"
]
```

Error report counts by page domain and exact blocked subdomain:
```
+---------------------------+------------------------+-------+
| fqdn                      | blocked_fqdn           | count |
+---------------------------+------------------------+-------+
| www.newegg.ca             | images10.newegg.com    |    62 |
| www.newegg.ca             | amber.newegg.com       |    57 |
| www.newegg.ca             | secure.newegg.com      |    25 |
| www.newegg.ca             | images17.newegg.com    |    16 |
| www.neweggbusiness.com    | promotions.newegg.com  |    13 |
| www.neweggbusiness.com    | ssl-images.newegg.com  |    10 |
| www.neweggbusiness.com    | images10.newegg.com    |     9 |
| secure.newegg.ca          | ssl-images.newegg.com  |     8 |
| www.newegg.ca             | promotions.newegg.com  |     6 |
| secure.newegg.ca          | amber.newegg.com       |     5 |
| www.neweggbusiness.com    | amber.newegg.com       |     5 |
| www.newegg.ca             | pf.newegg.com          |     5 |
| secure.neweggbusiness.com | promotions.newegg.com  |     4 |
| secure.neweggbusiness.com | ssl-images.newegg.com  |     4 |
| kb.newegg.ca              | amber.newegg.com       |     3 |
| www.neweggbusiness.com    | pf.newegg.com          |     3 |
| help.newegg.ca            | amber.newegg.com       |     2 |
| help.newegg.ca            | images10.newegg.com    |     2 |
| secure.neweggbusiness.com | images10.newegg.com    |     2 |
| www.neweggbusiness.com    | images17.newegg.com    |     2 |
| secure.newegg.ca          | promotions.newegg.com  |     2 |
| secure.newegg.ca          | secure.newegg.com      |     2 |
| kb.newegg.ca              | ssl-images.newegg.com  |     2 |
| promotions.newegg.ca      | amber.newegg.com       |     1 |
| secure.neweggbusiness.com | amber.newegg.com       |     1 |
| www.newegg.ca             | apis.newegg.com        |     1 |
| outlook.live.com          | click.email.newegg.com |     1 |
| www.newegg.ca             | content.newegg.com     |     1 |
| kb.newegg.ca              | images10.newegg.com    |     1 |
| outlook.live.com          | images10.newegg.com    |     1 |
| promotions.newegg.ca      | images10.newegg.com    |     1 |
| slickdeals.net            | images10.newegg.com    |     1 |
| secure.newegg.ca          | pf.newegg.com          |     1 |
| help.newegg.ca            | promotions.newegg.com  |     1 |
| outlook.live.com          | promotions.newegg.com  |     1 |
| promotions.newegg.ca      | promotions.newegg.com  |     1 |
+---------------------------+------------------------+-------+
```
Error report counts by date and exact blocked subdomain:
```
+---------+------------------------+-------+
| ym      | blocked_fqdn           | count |
+---------+------------------------+-------+
| 2018-02 | amber.newegg.com       |     4 |
| 2018-02 | images10.newegg.com    |     5 |
| 2018-02 | pf.newegg.com          |     3 |
| 2018-02 | promotions.newegg.com  |     3 |
| 2018-02 | secure.newegg.com      |     3 |
| 2018-02 | ssl-images.newegg.com  |     3 |
| 2018-01 | amber.newegg.com       |     2 |
| 2018-01 | apis.newegg.com        |     1 |
| 2018-01 | images10.newegg.com    |     4 |
| 2018-01 | pf.newegg.com          |     1 |
| 2018-01 | promotions.newegg.com  |     3 |
| 2018-01 | secure.newegg.com      |     3 |
| 2018-01 | ssl-images.newegg.com  |     1 |
| 2017-12 | amber.newegg.com       |     7 |
| 2017-12 | images10.newegg.com    |     5 |
| 2017-12 | pf.newegg.com          |     1 |
| 2017-12 | secure.newegg.com      |     5 |
| 2017-11 | amber.newegg.com       |     5 |
| 2017-11 | images10.newegg.com    |     7 |
| 2017-11 | promotions.newegg.com  |     3 |
| 2017-11 | secure.newegg.com      |     3 |
| 2017-11 | ssl-images.newegg.com  |     3 |
| 2017-10 | amber.newegg.com       |     4 |
| 2017-10 | images10.newegg.com    |     3 |
| 2017-10 | promotions.newegg.com  |     4 |
| 2017-10 | secure.newegg.com      |     1 |
| 2017-10 | ssl-images.newegg.com  |     7 |
...
```