### PR TITLE
Add Getty Images to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -139,6 +139,21 @@ var multiDomainFirstPartiesArray = [
   ["facebook.com", "fbcdn.com", "fbcdn.net", "facebook.net", "messenger.com"],
   ["firefox.com", "mozilla.org"],
   ["foxnews.com", "foxbusiness.com", "fncstatic.com"],
+  [
+    "gettyimages.com",
+
+    "gettyimages.ca",
+    "gettyimages.com.au",
+    "gettyimages.co.uk",
+    "gettyimages.dk",
+    "gettyimages.fi",
+    "gettyimages.nl",
+
+    "istockphoto.com",
+
+    "thinkstockphotos.com",
+    "thinkstockphotos.ca",
+  ],
   ["github.com", "githubapp.com"],
   ["gizmodo.com", "kinja-img.com", "kinja-static.com", "deadspin.com", "lifehacker.com",
     "technoratimedia.com", "kinja.com", "jalopnik.com", "jezebel.com"],


### PR DESCRIPTION
Error report counts by page domain and exact blocked subdomain:
```
+-------------------------------+---------------------------+-------+
| fqdn                          | blocked_fqdn              | count |
+-------------------------------+---------------------------+-------+
| www.gettyimages.com.au        | media.gettyimages.com     |     2 |
| www.gettyimages.nl            | media.gettyimages.com     |     2 |
| www.thinkstockphotos.com      | media.gettyimages.com     |     2 |
| www.gettyimages.ca            | metrics.gettyimages.com   |     2 |
| www.gettyimages.co.uk         | spectrum.gettyimages.com  |     2 |
| www.gettyimages.com.au        | spectrum.gettyimages.com  |     2 |
| www.gettyimages.dk            | spectrum.gettyimages.com  |     2 |
| www.gettyimages.nl            | spectrum.gettyimages.com  |     2 |
| www.gettyimages.dk            | delivery.gettyimages.com  |     1 |
| queensjewelvault.blogspot.com | embed-cdn.gettyimages.com |     1 |
| www.thecourtjeweller.com      | embed-cdn.gettyimages.com |     1 |
| on-the-t.com                  | embed.gettyimages.com     |     1 |
| www.cjr.org                   | embed.gettyimages.com     |     1 |
| www.pajiba.com                | embed.gettyimages.com     |     1 |
| www.gettyimages.ca            | media.gettyimages.com     |     1 |
| www.gettyimages.co.uk         | media.gettyimages.com     |     1 |
| www.gettyimages.dk            | media.gettyimages.com     |     1 |
| www.gettyimages.fi            | media.gettyimages.com     |     1 |
| www.thinkstockphotos.ca       | media.gettyimages.com     |     1 |
| www.gettyimages.com.au        | metrics.gettyimages.com   |     1 |
| www.gettyimages.dk            | metrics.gettyimages.com   |     1 |
| www.gettyimages.nl            | metrics.gettyimages.com   |     1 |
| www.gettyimages.co.uk         | smetrics.gettyimages.com  |     1 |
| www.gettyimages.com.au        | smetrics.gettyimages.com  |     1 |
| www.gettyimages.dk            | smetrics.gettyimages.com  |     1 |
| www.gettyimages.fi            | smetrics.gettyimages.com  |     1 |
| www.gettyimages.nl            | smetrics.gettyimages.com  |     1 |
| www.gettyimages.ca            | spectrum.gettyimages.com  |     1 |
| www.gettyimages.fi            | spectrum.gettyimages.com  |     1 |
| www.istockphoto.com           | spectrum.gettyimages.com  |     1 |
+-------------------------------+---------------------------+-------+
```

Error report counts by date and exact blocked subdomain:
```
+---------+---------------------------+-------+
| ym      | blocked_fqdn              | count |
+---------+---------------------------+-------+
| 2018-02 | media.gettyimages.com     |     3 |
| 2018-02 | smetrics.gettyimages.com  |     2 |
| 2018-02 | spectrum.gettyimages.com  |     2 |
| 2018-01 | media.gettyimages.com     |     3 |
| 2018-01 | smetrics.gettyimages.com  |     3 |
| 2018-01 | spectrum.gettyimages.com  |     4 |
| 2017-12 | embed-cdn.gettyimages.com |     1 |
| 2017-11 | embed.gettyimages.com     |     1 |
| 2017-11 | media.gettyimages.com     |     1 |
| 2017-11 | metrics.gettyimages.com   |     1 |
| 2017-11 | spectrum.gettyimages.com  |     1 |
...
```