### PR TITLE
Add bazaarvoice.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -47,6 +47,7 @@ bac-assets.com
 bandcamp.com
 bankid.no
 bankrate.com
+bazaarvoice.com
 bcbits.com
 betterttv.net
 www.bing.com


### PR DESCRIPTION
Fixes #1498.

More sample pages:
- https://www.thefryecompany.com/sale/womens/sacha-zip-shootie-d-77983
- https://www.marksandspencer.com/nl/katoenrijke-jegging/p/P22468863.html
- https://www.eastbay.com/product/model:277664/sku:80839004/nike-free-rn-2017-mens/grey/light-green/
- http://www.dell.com/en-us/shop/dell-24-ultrasharp-monitor-u2417h/apd/210-ahgf/monitors-monitor-accessories

<details><summary>Error report counts by page domain and exact blocked subdomain:</summary>

```
+----------------------------------+-----------------------------------------+-------+
| fqdn                             | blocked_fqdn                            | count |
+----------------------------------+-----------------------------------------+-------+
| www.target.com                   | magpie-static.ugc.bazaarvoice.com       |   100 |
| www.homedepot.com                | homedepot.ugc.bazaarvoice.com           |    82 |
| www.rei.com                      | display.ugc.bazaarvoice.com             |    67 |
| www.uniqlo.com                   | uniqloenus.ugc.bazaarvoice.com          |    58 |
| www.johnlewis.com                | johnlewis.ugc.bazaarvoice.com           |    52 |
| shop.lenovo.com                  | display.ugc.bazaarvoice.com             |    46 |
| www.brooksbrothers.com           | display.ugc.bazaarvoice.com             |    42 |
| www.petsmart.com                 | display.ugc.bazaarvoice.com             |    39 |
| www.homedepot.com                | apps.nexus.bazaarvoice.com              |    33 |
| www.bedbathandbeyond.com         | bedbathandbeyond.ugc.bazaarvoice.com    |    32 |
| www.canadiantire.ca              | api.bazaarvoice.com                     |    29 |
| www.bestbuy.com                  | bestbuy.ugc.bazaarvoice.com             |    28 |
| www.patagonia.com                | display.ugc.bazaarvoice.com             |    28 |
| www.levi.com                     | levistrauss.ugc.bazaarvoice.com         |    28 |
| www.macys.com                    | macys.ugc.bazaarvoice.com               |    28 |
| www.argos.co.uk                  | argos.ugc.bazaarvoice.com               |    25 |
| www.lowes.com                    | lowes.ugc.bazaarvoice.com               |    24 |
| www.dsw.com                      | static.curations.bazaarvoice.com        |    24 |
| www.anthropologie.com            | anthropologie.ugc.bazaarvoice.com       |    23 |
| www.costco.com                   | display.ugc.bazaarvoice.com             |    23 |
| www.michaels.com                 | display.ugc.bazaarvoice.com             |    22 |
| www.rei.com                      | analytics-static.ugc.bazaarvoice.com    |    20 |
| www.levi.com                     | api.bazaarvoice.com                     |    20 |
| shop.panasonic.com               | panasonic.reviews.bazaarvoice.com       |    20 |
| www.burpee.com                   | display.ugc.bazaarvoice.com             |    19 |
| www.homedepot.com                | analytics-static.ugc.bazaarvoice.com    |    18 |
| shop.lenovo.com                  | api.bazaarvoice.com                     |    18 |
| www.jcpenney.com                 | jcpenney.ugc.bazaarvoice.com            |    18 |
| www.argos.co.uk                  | magpie-static.ugc.bazaarvoice.com       |    18 |
...
```
</details>
<br>
<details><summary>Error report counts by date and exact blocked subdomain:</summary>

```
+---------+-----------------------------------------+-------+
| ym      | blocked_fqdn                            | count |
+---------+-----------------------------------------+-------+
| 2018-02 | display.ugc.bazaarvoice.com             |    70 |
| 2018-02 | analytics-static.ugc.bazaarvoice.com    |    66 |
| 2018-02 | apps.nexus.bazaarvoice.com              |    62 |
| 2018-02 | api.bazaarvoice.com                     |    51 |
| 2018-02 | network.bazaarvoice.com                 |    43 |
| 2018-02 | photos-us.bazaarvoice.com               |     9 |
| 2018-02 | apps.bazaarvoice.com                    |     6 |
| 2018-02 | network-a.bazaarvoice.com               |     6 |
| 2018-02 | seo.bazaarvoice.com                     |     6 |
| 2018-02 | static.curations.bazaarvoice.com        |     6 |
| 2018-02 | homedepot.ugc.bazaarvoice.com           |     3 |
| 2018-02 | johnlewis.ugc.bazaarvoice.com           |     3 |
| 2018-02 | lowes.ugc.bazaarvoice.com               |     3 |
| 2018-02 | network-eu.bazaarvoice.com              |     3 |
| 2018-02 | eastbay.ugc.bazaarvoice.com             |     2 |
| 2018-02 | finishline.ugc.bazaarvoice.com          |     2 |
| 2018-02 | macys.ugc.bazaarvoice.com               |     2 |
| 2018-02 | sl-ui.bazaarvoice.com                   |     2 |
| 2018-02 | sl.bazaarvoice.com                      |     2 |
| 2018-02 | uniqloenus.ugc.bazaarvoice.com          |     2 |
| 2018-02 | urbandecay.ugc.bazaarvoice.com          |     2 |
| 2018-01 | display.ugc.bazaarvoice.com             |    52 |
| 2018-01 | analytics-static.ugc.bazaarvoice.com    |    24 |
| 2018-01 | apps.nexus.bazaarvoice.com              |    22 |
| 2018-01 | api.bazaarvoice.com                     |    17 |
| 2018-01 | network.bazaarvoice.com                 |    16 |
| 2018-01 | photos-us.bazaarvoice.com               |     5 |
| 2018-01 | display-stg.ugc.bazaarvoice.com         |     3 |
| 2018-01 | homedepot.ugc.bazaarvoice.com           |     3 |
| 2018-01 | macys.ugc.bazaarvoice.com               |     3 |
| 2018-01 | apps.bazaarvoice.com                    |     2 |
| 2018-01 | evanscycles-uk.ugc.bazaarvoice.com      |     2 |
| 2018-01 | magpie-static.ugc.bazaarvoice.com       |     2 |
| 2018-01 | seo.bazaarvoice.com                     |     2 |
| 2018-01 | uniqloenus.ugc.bazaarvoice.com          |     2 |
| 2018-01 | wiggle.ugc.bazaarvoice.com              |     2 |
| 2017-12 | display.ugc.bazaarvoice.com             |    42 |
| 2017-12 | analytics-static.ugc.bazaarvoice.com    |    12 |
| 2017-12 | apps.nexus.bazaarvoice.com              |     9 |
| 2017-12 | api.bazaarvoice.com                     |     6 |
| 2017-12 | apps.bazaarvoice.com                    |     6 |
| 2017-12 | homedepot.ugc.bazaarvoice.com           |     4 |
| 2017-12 | display-stg.ugc.bazaarvoice.com         |     3 |
| 2017-12 | macys.ugc.bazaarvoice.com               |     3 |
| 2017-12 | photos-us.bazaarvoice.com               |     3 |
| 2017-12 | bedbathandbeyond.ugc.bazaarvoice.com    |     2 |
| 2017-12 | network.bazaarvoice.com                 |     2 |
| 2017-12 | static.curations.bazaarvoice.com        |     2 |
| 2017-12 | uniqloenus.ugc.bazaarvoice.com          |     2 |
...
```
</details>