### PR TITLE
Retry on timeout errors when loading a URL

### DIFF
--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -8,7 +8,7 @@ import time
 from functools import wraps
 
 from selenium import webdriver
-from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
@@ -294,9 +294,16 @@ class PBSeleniumTest(unittest.TestCase):
         self.js('window.open()')
         self.driver.switch_to.window(self.driver.window_handles[-1])
 
-    def load_url(self, url, wait_on_site=0):
+    def load_url(self, url, wait_on_site=0, retries=5):
         """Load a URL and wait before returning."""
-        self.driver.get(url)
+        for i in range(retries):
+            try:
+                self.driver.get(url)
+                break
+            except TimeoutException as e:
+                if i < retries - 1:
+                    continue
+                raise e
         self.driver.switch_to.window(self.driver.current_window_handle)
         time.sleep(wait_on_site)
 


### PR DESCRIPTION
Occasionally, a request for a web page during a functional test will time out and fail, for some reason not related to Privacy Badger's correctness. e.g. https://travis-ci.org/EFForg/privacybadger/jobs/344463078.

This change would retry requests that time out up to 5 times before giving up. This should reduce the amount of false-negative test failures.