### PR TITLE
Add Cloudinary (CDN) to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -84,6 +84,7 @@ cleanprint.net
 cleveland.com
 cloudflare.com
 cloudfront.net
+cloudinary.com
 bbb.org
 bbc.co.uk
 bbci.co.uk


### PR DESCRIPTION
Fixes #1153. See https://github.com/EFForg/privacybadger/issues/1153#issuecomment-368580638 for more information.