### PR TITLE
Fix popup in Private Browsing windows

### DIFF
--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -23,6 +23,7 @@ function setup_firefox {
       # check that we got something
       if [ -z "$version" ]; then
         echo "Failed to determine the latest geckodriver version!"
+        sleep 10
         exit 1
       fi
     fi

--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -23,7 +23,7 @@ function setup_firefox {
       # check that we got something
       if [ -z "$version" ]; then
         echo "Failed to determine the latest geckodriver version!"
-        sleep 10
+        sleep 60
         exit 1
       fi
     fi

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -758,22 +758,16 @@ Badger.prototype = {
    * @param {Integer} tab_id the tab we are on
    * @param {String} fqdn the third party origin to add
    * @param {String} action the action we are taking
-   *
-   **/
+   */
   logThirdPartyOriginOnTab: function (tab_id, fqdn, action) {
     let self = this,
       blocked = constants.BLOCKED_ACTIONS.has(action),
       origins = self.tabData[tab_id].origins,
-      previously_seen = origins.hasOwnProperty(fqdn),
       previously_blocked = constants.BLOCKED_ACTIONS.has(origins[fqdn]);
 
     origins[fqdn] = action;
 
-    if (!blocked) {
-      return;
-    }
-
-    if (previously_seen && previously_blocked) {
+    if (!blocked || previously_blocked) {
       return;
     }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -152,11 +152,11 @@ Badger.prototype = {
   },
 
   /**
-  * saves a user preference for an origin, overriding
-  * the default setting.
-  * @param {String} userAction enum of block, cookieblock, noaction
-  * @param {String} origin the third party origin to take action on
-  */
+   * Saves a user preference for an origin, overriding the default setting.
+   *
+   * @param {String} userAction enum of block, cookieblock, noaction
+   * @param {String} origin the third party origin to take action on
+   */
   saveAction: function(userAction, origin) {
     var allUserActions = {
       'block': constants.USER_BLOCK,
@@ -755,9 +755,9 @@ Badger.prototype = {
    * Save third party origins to tabData[tab_id] object for
    * use in the popup and, if needed, call updateBadge.
    *
-   * @param tab_id the tab we are on
-   * @param fqdn the third party origin to add
-   * @param action the action we are taking
+   * @param {Integer} tab_id the tab we are on
+   * @param {String} fqdn the third party origin to add
+   * @param {String} action the action we are taking
    *
    **/
   logThirdPartyOriginOnTab: function (tab_id, fqdn, action) {

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -15,11 +15,10 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var i18n = chrome.i18n;
-
 require.scopes.htmlutils = (function() {
 
-var constants = chrome.extension.getBackgroundPage().constants;
+const i18n = chrome.i18n;
+const constants = require("constants");
 
 const UNDO_ARROW_TOOLTIP_TEXT = i18n.getMessage('feed_the_badger_title');
 
@@ -121,15 +120,11 @@ var htmlUtils = exports.htmlUtils = {
   /**
    * Get HTML for tracker container.
    *
-   * @param {Integer} tabId ID of tab trackers are associated with.
    * @returns {String} HTML for empty tracker container.
    */
-  getTrackerContainerHtml: function(tabId) {
-    if (tabId === undefined) {
-      tabId = "000";
-    }
+  getTrackerContainerHtml: function() {
     var trackerHtml = '' +
-      '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
+      '<div id="associatedTab"></div>' +
       '<div class="keyContainer">' +
       '<div class="key">' +
       '<img src="/icons/UI-icons-red.svg" class="tooltip" title="' + i18n.getMessage("tooltip_block") + '">' +

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -181,13 +181,14 @@ var htmlUtils = exports.htmlUtils = {
 
     return originHtml;
   },
+
   /**
-  * Toggle the GUI blocked status of GUI element(s)
-  *
-  * @param {String} elt Identify the object(s) to manipulate
-  * @param {String} status New status to set, optional
-  */
-  toggleBlockedStatus: function (elt,status) {
+   * Toggle the GUI blocked status of GUI element(s)
+   *
+   * @param {jQuery} elt Identify the jQuery element object(s) to manipulate
+   * @param {String} status New status to set
+   */
+  toggleBlockedStatus: function (elt, status) {
     console.log('toggle blocked status', elt, status);
     elt.removeClass([constants.BLOCK, constants.COOKIEBLOCK, constants.ALLOW, constants.NO_TRACKING].join(" ")).addClass(status);
     elt.addClass("userset");

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -189,27 +189,8 @@ var htmlUtils = exports.htmlUtils = {
   */
   toggleBlockedStatus: function (elt,status) {
     console.log('toggle blocked status', elt, status);
-    if (status) {
-      elt.removeClass([constants.BLOCK, constants.COOKIEBLOCK, constants.ALLOW, constants.NO_TRACKING].join(" ")).addClass(status);
-      elt.addClass("userset");
-      return;
-    }
-
-    var originalAction = elt.getAttribute('data-original-action');
-    if (elt.hasClass(constants.BLOCK)) {
-      elt.toggleClass(constants.BLOCK);
-    } else if (elt.hasClass(constants.COOKIEBLOCK)) {
-      elt.toggleClass(constants.BLOCK);
-      elt.toggleClass(constants.COOKIEBLOCK);
-    } else {
-      elt.toggleClass(constants.COOKIEBLOCK);
-    }
-    if (elt.hasClass(originalAction) || (originalAction == constants.ALLOW && !(elt.hasClass(constants.BLOCK) ||
-                                                                              elt.hasClass(constants.COOKIEBLOCK)))) {
-      elt.removeClass("userset");
-    } else {
-      elt.addClass("userset");
-    }
+    elt.removeClass([constants.BLOCK, constants.COOKIEBLOCK, constants.ALLOW, constants.NO_TRACKING].join(" ")).addClass(status);
+    elt.addClass("userset");
   },
 
   /**

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -185,13 +185,19 @@ var htmlUtils = exports.htmlUtils = {
   /**
    * Toggle the GUI blocked status of GUI element(s)
    *
-   * @param {jQuery} elt Identify the jQuery element object(s) to manipulate
+   * @param {jQuery} $el Identify the jQuery element object(s) to manipulate
    * @param {String} status New status to set
    */
-  toggleBlockedStatus: function (elt, status) {
-    console.log('toggle blocked status', elt, status);
-    elt.removeClass([constants.BLOCK, constants.COOKIEBLOCK, constants.ALLOW, constants.NO_TRACKING].join(" ")).addClass(status);
-    elt.addClass("userset");
+  toggleBlockedStatus: function ($el, status) {
+    $el
+      .removeClass([
+        constants.BLOCK,
+        constants.COOKIEBLOCK,
+        constants.ALLOW,
+        constants.NO_TRACKING
+      ].join(" "))
+      .addClass(status)
+      .addClass("userset");
   },
 
   /**

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -124,7 +124,6 @@ var htmlUtils = exports.htmlUtils = {
    */
   getTrackerContainerHtml: function() {
     var trackerHtml = '' +
-      '<div id="associatedTab"></div>' +
       '<div class="keyContainer">' +
       '<div class="key">' +
       '<img src="/icons/UI-icons-red.svg" class="tooltip" title="' + i18n.getMessage("tooltip_block") + '">' +

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -171,7 +171,7 @@ var htmlUtils = exports.htmlUtils = {
     // Construct HTML for origin.
     var actionDescription = htmlUtils.getActionDescription(action, origin, isWhitelisted);
     var originHtml = '' +
-      '<div class="' + classes.join(' ') + '" data-origin="' + origin + '" data-original-action="' + action + '">' +
+      '<div class="' + classes.join(' ') + '" data-origin="' + origin + '">' +
       '<div class="origin tooltip" title="' + actionDescription + '">' + whitelistedText + origin + '</div>' +
       '<div class="removeOrigin">&#10006</div>' +
       htmlUtils.getToggleHtml(origin, action) +

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -127,13 +127,6 @@ function init() {
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
   });
 
-  // toggle activation buttons if privacy badger is not enabled for current url
-  if (!POPUP_DATA.enabled) {
-    $("#blockedResourcesContainer").hide();
-    $("#activate_site_btn").show();
-    $("#deactivate_site_btn").hide();
-  }
-
   var version = i18n.getMessage("version") + " " + chrome.runtime.getManifest().version;
   $("#version").text(version);
 }
@@ -329,6 +322,13 @@ function refreshPopup() {
     $('#big-badger-logo').hide();
     $('#deactivate_site_btn').show();
     $('#error').show();
+
+    // toggle activation buttons if privacy badger is not enabled for current url
+    if (!POPUP_DATA.enabled) {
+      $("#blockedResourcesContainer").hide();
+      $("#activate_site_btn").show();
+      $("#deactivate_site_btn").hide();
+    }
   }
 
   let origins = POPUP_DATA.origins;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -139,8 +139,8 @@ function init() {
 }
 
 /**
-* Close the error reporting overlay
-*/
+ * Close the error reporting overlay
+ */
 function closeOverlay() {
   $('#overlay').toggleClass('active', false);
   $("#report_success").toggleClass("hidden", true);
@@ -149,10 +149,10 @@ function closeOverlay() {
 }
 
 /**
-* Send errors to PB error reporting server
-*
-* @param {String} message The message to send
-*/
+ * Send errors to PB error reporting server
+ *
+ * @param {String} message The message to send
+ */
 function send_error(message) {
   // get the latest domain list from the background page
   chrome.runtime.sendMessage({
@@ -216,8 +216,8 @@ function send_error(message) {
 }
 
 /**
-* activate PB for site event handler
-*/
+ * activate PB for site event handler
+ */
 function activateOnSite() {
   $("#activate_site_btn").toggle();
   $("#deactivate_site_btn").toggle();
@@ -235,8 +235,8 @@ function activateOnSite() {
 }
 
 /**
-* de-activate PB for site event handler
-*/
+ * de-activate PB for site event handler
+ */
 function deactivateOnSite() {
   $("#activate_site_btn").toggle();
   $("#deactivate_site_btn").toggle();
@@ -254,10 +254,10 @@ function deactivateOnSite() {
 }
 
 /**
-* Handler to undo user selection for a tracker
-*
-* @param e The object the event triggered on
-*/
+ * Handler to undo user selection for a tracker
+ *
+ * @param {Event} e The object the event triggered on
+ */
 function revertDomainControl(e) {
   var $elm = $(e.target).parent();
   var origin = $elm.data('origin');
@@ -301,10 +301,10 @@ function registerToggleHandlers() {
 }
 
 /**
-* Refresh the content of the popup window
-*
-* @param {Integer} tabId The id of the tab
-*/
+ * Refresh the content of the popup window
+ *
+ * @param {Integer} tabId The id of the tab
+ */
 function refreshPopup() {
   // must be a special browser page,
   // or a page that loaded everything before our most recent initialization
@@ -433,10 +433,10 @@ function refreshPopup() {
 }
 
 /**
-* Event handler for on change (blocked resources container)
-*
-* @param event
-*/
+ * Event handler for on change (blocked resources container)
+ *
+ * @param {Event} event
+ */
 function updateOrigin(event) {
   var $elm = $('label[for="' + event.currentTarget.id + '"]');
   var $switchContainer = $elm.parents('.switch-container').first();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -297,12 +297,7 @@ function revertDomainControl(e) {
   chrome.runtime.sendMessage({
     type: "revertDomainControl",
     origin: origin
-  }, (response) => {
-    var defaultAction = response.action;
-    var selectorId = "#"+ defaultAction +"-" + origin.replace(/\./g,'-');
-    var selector = $(selectorId);
-    selector.click();
-    $elm.removeClass('userset');
+  }, () => {
     chrome.tabs.reload(POPUP_DATA.tabId);
     window.close();
   });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -122,10 +122,8 @@ function init() {
   $("#report_close").on("click", function() {
     closeOverlay();
   });
-  $(document).ready(function () {
-    $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
-    $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
-  });
+  $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
+  $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
 
   var version = i18n.getMessage("version") + " " + chrome.runtime.getManifest().version;
   $("#version").text(version);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -503,16 +503,12 @@ function saveToggle($clicker) {
   let origin = $clicker.attr("data-origin"),
     action;
 
-  if ($clicker.hasClass("userset") && htmlUtils.getCurrentClass($clicker) != $clicker.attr("data-original-action")) {
-    if ($clicker.hasClass(constants.BLOCK)) {
-      action = constants.BLOCK;
-    } else if ($clicker.hasClass(constants.COOKIEBLOCK)) {
-      action = constants.COOKIEBLOCK;
-    } else if ($clicker.hasClass(constants.ALLOW)) {
-      action = constants.ALLOW;
-    } else {
-      action = constants.ALLOW;
-    }
+  if ($clicker.hasClass(constants.BLOCK)) {
+    action = constants.BLOCK;
+  } else if ($clicker.hasClass(constants.COOKIEBLOCK)) {
+    action = constants.COOKIEBLOCK;
+  } else if ($clicker.hasClass(constants.ALLOW)) {
+    action = constants.ALLOW;
   }
 
   if (action) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -729,9 +729,6 @@ function dispatcher(request, sender, sendResponse) {
 
   } else if (request.type == "revertDomainControl") {
     badger.storage.revertUserAction(request.origin);
-    sendResponse({
-      action: badger.storage.getBestAction(request.origin)
-    });
 
   } else if (request.type == "savePopupToggle") {
     let domain = request.origin,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -722,13 +722,16 @@ function dispatcher(request, sender, sendResponse) {
   } else if (request.type == "activateOnSite") {
     badger.enablePrivacyBadgerForOrigin(request.tabHost);
     badger.refreshIconAndContextMenu(request.tabId, request.tabUrl);
+    sendResponse();
 
   } else if (request.type == "deactivateOnSite") {
     badger.disablePrivacyBadgerForOrigin(request.tabHost);
     badger.refreshIconAndContextMenu(request.tabId, request.tabUrl);
+    sendResponse();
 
   } else if (request.type == "revertDomainControl") {
     badger.storage.revertUserAction(request.origin);
+    sendResponse();
 
   } else if (request.type == "savePopupToggle") {
     let domain = request.origin,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -712,6 +712,7 @@ function dispatcher(request, sender, sendResponse) {
       seenComic: badger.getSettings().getItem("seenComic"),
       tabHost: tab_host,
       tabId: tab_id,
+      isPrivateWindow: incognito.tabIsIncognito(tab_id),
       tabUrl: tab_url
     });
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -604,19 +604,17 @@ function unblockSocialWidgetOnTab(tabId, socialWidgetUrls) {
   }
 }
 
+/**
+ * sender.tab is available for content script (not popup) messages only
+ */
 function dispatcher(request, sender, sendResponse) {
-  var tabHost;
-  if (sender.tab && sender.tab.url) {
-    tabHost = window.extractHostFromURL(sender.tab.url);
-  } else {
-    log("tabhost is  blank!!");
-  }
-
   if (request.checkEnabled) {
-    sendResponse(badger.isPrivacyBadgerEnabled(tabHost));
+    sendResponse(badger.isPrivacyBadgerEnabled(
+      window.extractHostFromURL(sender.tab.url)
+    ));
 
   } else if (request.checkLocation) {
-    if (!badger.isPrivacyBadgerEnabled(tabHost)) {
+    if (!badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url))) {
       return sendResponse();
     }
 
@@ -628,7 +626,7 @@ function dispatcher(request, sender, sendResponse) {
     let requestHost = window.extractHostFromURL(request.checkLocation);
 
     // Ignore requests that aren't from a third party.
-    if (!isThirdPartyDomain(requestHost, tabHost)) {
+    if (!isThirdPartyDomain(requestHost, window.extractHostFromURL(sender.tab.url))) {
       return sendResponse();
     }
 
@@ -637,7 +635,7 @@ function dispatcher(request, sender, sendResponse) {
     sendResponse(cookieBlock);
 
   } else if (request.checkReplaceButton) {
-    if (badger.isPrivacyBadgerEnabled(tabHost) && badger.isSocialWidgetReplacementEnabled()) {
+    if (badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) && badger.isSocialWidgetReplacementEnabled()) {
       var socialWidgetBlockList = getSocialWidgetBlockList();
       sendResponse(socialWidgetBlockList);
     }
@@ -677,7 +675,7 @@ function dispatcher(request, sender, sendResponse) {
 
   // Canvas fingerprinting
   } else if (request.fpReport) {
-    if (!badger.isPrivacyBadgerEnabled(tabHost)) { return; }
+    if (!badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url))) { return; }
     if (Array.isArray(request.fpReport)) {
       request.fpReport.forEach(function (msg) {
         recordFingerprinting(sender.tab.id, msg);
@@ -690,11 +688,15 @@ function dispatcher(request, sender, sendResponse) {
     if (badger.hasSuperCookie(request.superCookieReport)) {
       recordSuperCookie(sender, request.superCookieReport);
     }
+
   } else if (request.checkEnabledAndThirdParty) {
-    var pageHost = window.extractHostFromURL(sender.url);
-    sendResponse(badger.isPrivacyBadgerEnabled(tabHost) && isThirdPartyDomain(pageHost, tabHost));
+    let tab_host = window.extractHostFromURL(sender.tab.url),
+      frame_host = window.extractHostFromURL(sender.url);
+
+    sendResponse(badger.isPrivacyBadgerEnabled(tab_host) && isThirdPartyDomain(frame_host, tab_host));
+
   } else if (request.checkSocialWidgetReplacementEnabled) {
-    sendResponse(badger.isPrivacyBadgerEnabled(tabHost) && badger.isSocialWidgetReplacementEnabled());
+    sendResponse(badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) && badger.isSocialWidgetReplacementEnabled());
   }
 }
 

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -33,8 +33,13 @@
 <script type="text/javascript" src="/lib/vendor/jquery-3.3.1.min.js"></script>
 <script type="text/javascript" src="/lib/vendor/jquery-ui-1.12.1.custom/jquery-ui.min.js"></script>
 <script type="text/javascript" src="/lib/vendor/tooltipster-4.2.5/tooltipster.bundle.min.js"></script>
-<script type="text/javascript" src="/js/popup.js"></script>
+<script type="text/javascript" src="/lib/underscore-min.js"></script>
 <script type="text/javascript" src="/lib/i18n.js"></script>
+<script type="text/javascript" src="/js/bootstrap.js"></script>
+<script type="text/javascript" src="/js/constants.js"></script>
+<script type="text/javascript" src="/js/htmlutils.js"></script>
+<script type="text/javascript" src="/js/firefoxandroid.js"></script>
+<script type="text/javascript" src="/js/popup.js"></script>
 </head>
 <body id="main">
   <div id="instruction-outer">

--- a/src/tests/tests/htmlutils.js
+++ b/src/tests/tests/htmlutils.js
@@ -95,19 +95,6 @@
     }
   });
 
-  QUnit.test("getTrackerContainerHtml", function (assert) {
-    // Test given tab ID.
-    var tabId = 1;
-    var htmlResult = htmlUtils.getTrackerContainerHtml(tabId);
-    var tabIdExists = htmlResult.indexOf('data-tab-id="' + tabId + '"') > -1;
-    assert.ok(tabIdExists, "Given tab ID should be set");
-
-    // Test missing tab ID.
-    htmlResult = htmlUtils.getTrackerContainerHtml();
-    var defaultTabIdExists = htmlResult.indexOf('data-tab-id="000"') > -1;
-    assert.ok(defaultTabIdExists, "Default tab ID should be set");
-  });
-
   QUnit.test("getOriginHtml", function (assert) {
     // Test parameters
     var tests = [

--- a/src/tests/tests/htmlutils.js
+++ b/src/tests/tests/htmlutils.js
@@ -126,11 +126,9 @@
       var existingHtmlExists = htmlResult.indexOf(existingHtml) > -1;
       assert.ok(existingHtmlExists, "Existing HTML should be present");
 
-      // Make sure origin and original action are set.
+      // Make sure origin is set.
       var originDataExists = htmlResult.indexOf('data-origin="' + origin + '"') > -1;
       assert.ok(originDataExists, "Origin should be set");
-      var originalActionExists = htmlResult.indexOf('data-original-action="' + action + '"') > -1;
-      assert.ok(originalActionExists, "Original action should be set");
 
       // Check for presence of DNT content.
       var dntExists = htmlResult.indexOf('id="dnt-compliant"') > -1;

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -156,7 +156,11 @@ function setTabToUrl(query_url) {
             self.assertTrue(origin not in self.cookieBlocked)
             self.assertTrue(origin not in self.blocked)
 
-            action_type = div.get_attribute('data-original-action')
+            # get slider state for given origin
+            label = self.driver.find_element_by_css_selector(
+                'input[name="{}"][checked] + label'.format(origin))
+            action_type = label.get_attribute('data-action')
+
             if action_type == 'allow':
                 self.nonTrackers[origin] = True
             elif action_type == 'noaction':

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -117,20 +117,21 @@ class CookieTest(pbtest.PBSeleniumTest):
         window_utils.switch_to_window_with_url(self.driver, self.popup_url)
         target_url = target_scheme_and_host + "/*"
         javascript_src = """/**
-* if the query url pattern matches a tab, switch the module's tab object to that tab
-* Convenience function for the test harness
-* Chrome URL pattern docs: https://developer.chrome.com/extensions/match_patterns
-*/
+ * if the query url pattern matches a tab, switch the module's tab object to that tab
+ */
 function setTabToUrl(query_url) {
-  chrome.tabs.query( {url: query_url}, function(ta) {
-    if (typeof ta == "undefined") {
+  chrome.tabs.query({url: query_url}, function (tabs) {
+    if (!tabs || !tabs.length) {
       return;
     }
-    if (ta.length === 0) {
-      return;
-    }
-    var tabid = ta[0].id;
-    refreshPopup(tabid);
+    chrome.runtime.sendMessage({
+      type: "getPopupData",
+      tabId: tabs[0].id,
+      tabUrl: tabs[0].url
+    }, (response) => {
+      setPopupData(response);
+      refreshPopup();
+    });
   });
 }"""
         self.js(javascript_src + "setTabToUrl('{}');".format(target_url))

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -10,6 +10,8 @@ from selenium.webdriver.support import expected_conditions as EC
 import pbtest
 import window_utils
 
+from popup_test import get_domain_slider_state
+
 SITE1_URL = "http://eff-tracker-site1-test.s3-website-us-west-2.amazonaws.com"
 SITE2_URL = "http://eff-tracker-site2-test.s3-website-us-west-2.amazonaws.com"
 SITE3_URL = "http://eff-tracker-site3-test.s3-website-us-west-2.amazonaws.com"
@@ -157,9 +159,7 @@ function setTabToUrl(query_url) {
             self.assertTrue(origin not in self.blocked)
 
             # get slider state for given origin
-            label = self.driver.find_element_by_css_selector(
-                'input[name="{}"][checked] + label'.format(origin))
-            action_type = label.get_attribute('data-action')
+            action_type = get_domain_slider_state(self.driver, origin)
 
             if action_type == 'allow':
                 self.nonTrackers[origin] = True

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -39,7 +39,7 @@ class DNTTest(pbtest.PBSeleniumTest):
         return self.js("""return (
   Object.keys(badger.tabData).some(tab_id => {{
     let origins = badger.tabData[tab_id].origins;
-    return origins.hasOwnProperty('{}') && !!origins['{}'];
+    return origins.hasOwnProperty('{}') && constants.BLOCKED_ACTIONS.has(origins['{}']);
   }})
 );""".format(domain, domain))
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -161,6 +161,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.fail("Options page not opened after clicking options button on popup")
 
+    @pbtest.repeat_if_failed(5)
     def test_trackers_link(self):
         """Ensure trackers link opens EFF website."""
 
@@ -356,6 +357,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.assertTrue(len(self.driver.find_elements_by_class_name('active')) == 0,
                 'error reporting should be closed again')
 
+    @pbtest.repeat_if_failed(5)
     def test_donate_button(self):
         """Ensure donate button opens EFF website."""
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -265,8 +265,10 @@ class PopupTest(pbtest.PBSeleniumTest):
             'div[data-origin="{}"] div.honeybadgerPowered'.format(DOMAIN)
         ).click()
 
-        # verify the domain is no longer user controlled
+        # get back to a valid window handle as the window just got closed
         self.driver.switch_to.window(self.driver.window_handles[0])
+
+        # verify the domain is no longer user controlled
         self.load_url(self.options_url, wait_on_site=1)
 
         # assert the action is not what we manually clicked
@@ -294,10 +296,16 @@ class PopupTest(pbtest.PBSeleniumTest):
         DISPLAYED_ERROR = " should not be displayed on popup"
         NOT_DISPLAYED_ERROR = " should be displayed on popup"
 
+        # need to preserve original window
+        # since enabling/disabling auto-closes popup
+        self.open_window()
         self.open_popup()
 
         self.get_disable_button().click()
 
+        # get back to a valid window handle as the window just got closed
+        self.driver.switch_to.window(self.driver.window_handles[0])
+        self.open_window()
         self.open_popup(close_overlay=False)
 
         # Check that popup state changed after disabling.
@@ -310,6 +318,8 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         enable_button.click()
 
+        self.driver.switch_to.window(self.driver.window_handles[0])
+        self.open_window()
         self.open_popup(close_overlay=False)
 
         # Check that popup state changed after re-enabling.

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -12,7 +12,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
-from window_utils import close_windows_with_url, switch_to_window_with_url
+from window_utils import switch_to_window_with_url
 
 
 class PopupTest(pbtest.PBSeleniumTest):
@@ -298,7 +298,6 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.get_disable_button().click()
 
-        close_windows_with_url(self.driver, self.popup_url)
         self.open_popup(close_overlay=False)
 
         # Check that popup state changed after disabling.
@@ -311,7 +310,6 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         enable_button.click()
 
-        close_windows_with_url(self.driver, self.popup_url)
         self.open_popup(close_overlay=False)
 
         # Check that popup state changed after re-enabling.

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -52,9 +52,17 @@ class PopupTest(pbtest.PBSeleniumTest):
         # for some test page like https://www.eff.org/files/badgertest.txt;
         # for example, see https://github.com/EFForg/privacybadger/issues/1634
         self.js("""getTab(function (tab) {
-  badger.recordFrame(tab.id, 0, -1, tab.url);
-  refreshPopup(tab.id);
-  window.DONE_REFRESHING = true;
+  chrome.runtime.sendMessage({
+    type: "getPopupData",
+    tabId: tab.id,
+    tabUrl: tab.url
+  }, (response) => {
+    response.noTabData = false;
+    response.origins = {};
+    setPopupData(response);
+    refreshPopup();
+    window.DONE_REFRESHING = true;
+  });
 });""")
         # wait until the async getTab function is done
         self.wait_for_script(

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -206,21 +206,36 @@ class PopupTest(pbtest.PBSeleniumTest):
         # "Other element would receive the click" Selenium limitation
         self.js("$('#block-{}').click()".format(DOMAIN_ID))
 
-        close_windows_with_url(self.driver, self.popup_url)
-
         # retrieve the new action
         self.load_url(self.options_url, wait_on_site=1)
-        origins = self.js("""return %s.reduce((memo, origin) => {
-memo[origin] = badger.storage.getBestAction(origin);
-return memo;
-}, {});""" % ([DOMAIN],))
+        label = self.driver.find_element_by_css_selector(
+            'input[name="{}"][checked] + label'.format(DOMAIN))
+        new_action = label.get_attribute('data-action')
 
-        self.open_popup(close_overlay=False, origins=origins)
+        self.assertEqual(new_action, "block",
+            "The domain should be blocked on options page.")
+
+        # test toggling some more
+        self.open_popup(close_overlay=False, origins={DOMAIN:"user_block"})
 
         self.assertTrue(
             self.driver.find_element_by_id("block-" + DOMAIN_ID).is_selected(),
-            "The domain should have gotten blocked."
+            "The domain should be shown as blocked in popup."
         )
+
+        # change to "cookieblock"
+        self.js("$('#cookieblock-{}').click()".format(DOMAIN_ID))
+        # change again to "block"
+        self.js("$('#block-{}').click()".format(DOMAIN_ID))
+
+        # retrieve the new action
+        self.load_url(self.options_url, wait_on_site=1)
+        label = self.driver.find_element_by_css_selector(
+            'input[name="{}"][checked] + label'.format(DOMAIN))
+        new_action = label.get_attribute('data-action')
+
+        self.assertEqual(new_action, "block",
+            "The domain should still be blocked on options page.")
 
     def test_disable_enable_buttons(self):
         """Ensure disable/enable buttons change popup state."""

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -6,7 +6,7 @@ import time
 import unittest
 import pbtest
 
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
@@ -78,10 +78,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         if close_overlay:
             # Click 'X' element to close overlay.
-            try:
-                close_element = self.driver.find_element_by_id("fittslaw")
-            except NoSuchElementException:
-                self.fail("Unable to find element to close popup overlay")
+            close_element = self.driver.find_element_by_id("fittslaw")
             close_element.click()
 
             # Element will fade out so wait for it to disappear.
@@ -94,27 +91,17 @@ class PopupTest(pbtest.PBSeleniumTest):
 
     def get_enable_button(self):
         """Get enable button on popup."""
-        try:
-            return self.driver.find_element_by_id("activate_site_btn")
-        except NoSuchElementException:
-            self.fail("Unable to find enable button on poup")
+        return self.driver.find_element_by_id("activate_site_btn")
 
     def get_disable_button(self):
         """Get disable button on popup."""
-        try:
-            return self.driver.find_element_by_id("deactivate_site_btn")
-        except NoSuchElementException:
-            self.fail("Unable to find disable buttons on popup")
+        return self.driver.find_element_by_id("deactivate_site_btn")
 
     def test_overlay(self):
         """Ensure overlay links to first run comic."""
         self.open_popup(close_overlay=False)
 
-        try:
-            comic_link = self.driver.find_element_by_id("firstRun")
-        except NoSuchElementException:
-            self.fail("Unable to find link to comic on popup overlay")
-        comic_link.click()
+        self.driver.find_element_by_id("firstRun").click()
 
         # Make sure first run comic not opened in same window.
         time.sleep(1)
@@ -133,11 +120,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         """Ensure first run page is opened when help button is clicked."""
         self.open_popup()
 
-        try:
-            help_button = self.driver.find_element_by_id("help")
-        except NoSuchElementException:
-            self.fail("Unable to find help button on popup")
-        help_button.click()
+        self.driver.find_element_by_id("help").click()
 
         # Make sure first run page not opened in same window.
         time.sleep(1)
@@ -156,11 +139,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         """Ensure options page is opened when button is clicked."""
         self.open_popup()
 
-        try:
-            options_button = self.driver.find_element_by_id("options")
-        except NoSuchElementException:
-            self.fail("Unable to find options button on popup")
-        options_button.click()
+        self.driver.find_element_by_id("options").click()
 
         # Make sure options page not opened in same window.
         time.sleep(1)
@@ -312,10 +291,7 @@ return memo;
 
         self.open_popup()
 
-        try:
-            donate_button = self.driver.find_element_by_id("donate")
-        except NoSuchElementException:
-            self.fail("Unable to find donate button on popup")
+        donate_button = self.driver.find_element_by_id("donate")
 
         donate_button.click()
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -10,7 +10,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
-from window_utils import switch_to_window_with_url
+from window_utils import close_windows_with_url, switch_to_window_with_url
 
 
 class PopupTest(pbtest.PBSeleniumTest):
@@ -209,6 +209,40 @@ class PopupTest(pbtest.PBSeleniumTest):
                     (By.CSS_SELECTOR, faq_selector)))
         except TimeoutException:
             self.fail("Unable to find expected element ({}) on EFF website".format(faq_selector))
+
+    def test_disable_enable_buttons(self):
+        """Ensure disable/enable buttons change popup state."""
+
+        DISPLAYED_ERROR = " should not be displayed on popup"
+        NOT_DISPLAYED_ERROR = " should be displayed on popup"
+
+        self.open_popup()
+
+        self.get_disable_button().click()
+
+        close_windows_with_url(self.driver, self.popup_url)
+        self.open_popup(close_overlay=False)
+
+        # Check that popup state changed after disabling.
+        disable_button = self.get_disable_button()
+        self.assertFalse(disable_button.is_displayed(),
+                         "Disable button" + DISPLAYED_ERROR)
+        enable_button = self.get_enable_button()
+        self.assertTrue(enable_button.is_displayed(),
+                        "Enable button" + NOT_DISPLAYED_ERROR)
+
+        enable_button.click()
+
+        close_windows_with_url(self.driver, self.popup_url)
+        self.open_popup(close_overlay=False)
+
+        # Check that popup state changed after re-enabling.
+        disable_button = self.get_disable_button()
+        self.assertTrue(disable_button.is_displayed(),
+                        "Disable button" + NOT_DISPLAYED_ERROR)
+        enable_button = self.get_enable_button()
+        self.assertFalse(enable_button.is_displayed(),
+                         "Enable button" + DISPLAYED_ERROR)
 
     def test_error_button(self):
         """Ensure error button opens report error overlay."""

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -15,6 +15,12 @@ from selenium.webdriver.support.ui import WebDriverWait
 from window_utils import switch_to_window_with_url
 
 
+def get_domain_slider_state(driver, domain):
+    label = driver.find_element_by_css_selector(
+        'input[name="{}"][checked] + label'.format(domain))
+    return label.get_attribute('data-action')
+
+
 class PopupTest(pbtest.PBSeleniumTest):
     """Make sure the popup works correctly."""
 
@@ -209,9 +215,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # retrieve the new action
         self.load_url(self.options_url, wait_on_site=1)
-        label = self.driver.find_element_by_css_selector(
-            'input[name="{}"][checked] + label'.format(DOMAIN))
-        new_action = label.get_attribute('data-action')
+        new_action = get_domain_slider_state(self.driver, DOMAIN)
 
         self.assertEqual(new_action, "block",
             "The domain should be blocked on options page.")
@@ -231,9 +235,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # retrieve the new action
         self.load_url(self.options_url, wait_on_site=1)
-        label = self.driver.find_element_by_css_selector(
-            'input[name="{}"][checked] + label'.format(DOMAIN))
-        new_action = label.get_attribute('data-action')
+        new_action = get_domain_slider_state(self.driver, DOMAIN)
 
         self.assertEqual(new_action, "block",
             "The domain should still be blocked on options page.")
@@ -272,13 +274,9 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.load_url(self.options_url, wait_on_site=1)
 
         # assert the action is not what we manually clicked
-        label = self.driver.find_element_by_css_selector(
-            'input[name="{}"][checked] + label'.format(DOMAIN))
-        self.assertEqual(
-            label.get_attribute('data-action'),
-            "cookieblock",
-            "Domain's action should have been restored."
-        )
+        action = get_domain_slider_state(self.driver, DOMAIN)
+        self.assertEqual(action, "cookieblock",
+            "Domain's action should have been restored.")
 
         # assert the undo arrow is not displayed
         self.driver.find_element_by_css_selector('a[href="#tab-tracking-domains"]').click()


### PR DESCRIPTION
Fixes #1060.

Fixes #1634 by properly calling `init()` in places where we test the popup. We'll probably always need to use workarounds to test the popup as there doesn't seem to be a way to open extension popups with Selenium.