### PR TITLE
Improve notification of FILE_ERROR_NO_SPACE errors

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -51,6 +51,10 @@
         "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
         "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
     },
+    "extension_error_no_space": {
+        "message": "Your disk seems to be low on space:",
+        "description": "Shown in the popup when the browser produces a FILE_ERROR_NO_SPACE error when Privacy Badger tries to save its state."
+    },
     "data_settings": {
         "message": "Manage Data",
         "description": "This is an options page tab heading."

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -43,14 +43,14 @@ function showNagMaybe() {
   var outer = $("#instruction-outer");
   var firstRunUrl = chrome.extension.getURL("/skin/firstRun.html");
 
-  function _setSeenComic() {
+  function _acknowledgeNag() {
     chrome.runtime.sendMessage({
-      type: "seenComic"
+      type: "acknowledgeNag"
     });
   }
 
   function _hideNag() {
-    _setSeenComic();
+    _acknowledgeNag();
     nag.fadeOut();
     outer.fadeOut();
   }
@@ -85,6 +85,7 @@ function showNagMaybe() {
         _showNag();
       }
     });
+
   } else if (POPUP_DATA.criticalError) {
     $('#instruction-text').hide();
     $('#error-text').show().find('a').attr('id', 'firstRun').css('padding', '5px');

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -88,8 +88,18 @@ function showNagMaybe() {
 
   } else if (POPUP_DATA.criticalError) {
     $('#instruction-text').hide();
-    $('#error-text').show().find('a').attr('id', 'firstRun').css('padding', '5px');
-    $('#error-message').text(POPUP_DATA.criticalError);
+
+    if (POPUP_DATA.criticalError.indexOf("FILE_ERROR_NO_SPACE") != -1) {
+      // disk low on space
+      $('#error-text').show();
+      $('#error-header').text(i18n.getMessage("extension_error_no_space"));
+      $('#error-message').text(POPUP_DATA.criticalError);
+    } else {
+      // some other error
+      $('#error-text').show().find('a').attr('id', 'firstRun').css('padding', '5px');
+      $('#error-message').text(POPUP_DATA.criticalError);
+    }
+
     _showNag();
   }
 }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -716,8 +716,9 @@ function dispatcher(request, sender, sendResponse) {
       tabUrl: tab_url
     });
 
-  } else if (request.type == "seenComic") {
+  } else if (request.type == "acknowledgeNag") {
     badger.getSettings().setItem("seenComic", true);
+    delete badger.criticalError;
 
   } else if (request.type == "activateOnSite") {
     badger.enablePrivacyBadgerForOrigin(request.tabHost);

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -58,7 +58,7 @@
         </div>
     </div>
     <div id="error-text" style="display:none">
-        <p><span class="i18n_extension_error_text"></span></p>
+        <p id="error-header"><span class="i18n_extension_error_text"></span></p>
         <p style="color:#cc0000" id="error-message"></p>
     </div>
   </div>


### PR DESCRIPTION
Fixes #1866.

This doesn't address the badge not getting immediately updated upon `badger.criticalError` getting set or cleared (existing issue, can probably wait).

Acknowledging either the first run nag or an error notification clears both as having been done, which is probably fine for now.