### PR TITLE
Add pandacommerce.net to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -421,6 +421,7 @@ tile.openstreetmap.org
 optimizely.com
 oregonlive.com
 outlook.com
+pandacommerce.net
 passwordbox.com
 paypal.com
 paypalobjects.com


### PR DESCRIPTION
Fixes #1910.

To reproduce Privacy Badger learning to block `pandacommerce.net` resources, visit a PandaCommerce-powered shop, add an item to your cart and proceed to checkout to get tracking cookies (looks like Google Analytics: `_ga` and `_gid`) on the `pandacommerce.net` domain. (There are also some cookies and localStorage on `checkout.pandacommerce.net`.) Visiting any other PandaCommerce shops at this point will send those cookies, so visiting two more shops should teach Privacy Badger to start blocking `pandacommerce.net` domains.

Example shops:
- http://www.marelimedical.com/
- https://www.sexleksakeroutlet.se/
- https://www.andromedaslust.se/