### PR TITLE
Add more cnetcontent.com domains to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -98,7 +98,9 @@ gr-assets.com
 guardian.co.uk
 media-imdb.com
 mediaworks.co.nz
+cc.cnetcontent.com
 cdn.cnetcontent.com
+ws.cnetcontent.com
 com.com
 complex.com
 convio.net


### PR DESCRIPTION
Follows up on #1730.

Sample pages:
- http://www.argos.co.uk/product/4136774
- http://www.compumail.dk/vare-oversigt.php?varenummer=990144106
- https://www.newegg.ca/Product/Product.aspx?Item=N82E16820233970&cm_sp=Homepage_FDD-_-P1_20-233-970-_-03232018

The "Overview" tab becomes missing in that last link.