### PR TITLE
Add Glassdoor to MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -181,6 +181,19 @@ var multiDomainFirstPartiesArray = [
   ["github.com", "githubapp.com"],
   ["gizmodo.com", "kinja-img.com", "kinja-static.com", "deadspin.com", "lifehacker.com",
     "technoratimedia.com", "kinja.com", "jalopnik.com", "jezebel.com"],
+  [
+    "glassdoor.com",
+
+    "glassdoor.be",
+    "glassdoor.ca",
+    "glassdoor.co.in",
+    "glassdoor.com.au",
+    "glassdoor.co.uk",
+    "glassdoor.de",
+    "glassdoor.fr",
+    "glassdoor.ie",
+    "glassdoor.nl",
+  ],
   ["gogoair.com", "gogoinflight.com"],
   [
     "google.com",


### PR DESCRIPTION
You might have to log in first in order to reproduce Privacy Badger learning to block `glassdoor.com`. 

Sample regional pages:
- https://www.glassdoor.ca/Job/vancouver-embedded-software-developer-jobs-SRCH_IL.0,9_IC2278756_KO10,37.htm
- https://www.glassdoor.com.au/Job/rockdale-jobs-SRCH_IL.0,8_IC2243547.htm
- https://www.glassdoor.ie/Salary/FireEye-Dublin-Salaries-EI_IE235161.0,7_IL.8,14_IM1052.htm

Error report counts by page domain and exact blocked subdomain:
```
+----------------------+-----------------------+-------+
| fqdn                 | blocked_fqdn          | count |
+----------------------+-----------------------+-------+
| www.glassdoor.ca     | static.glassdoor.com  |    15 |
| www.glassdoor.ca     | media.glassdoor.com   |    10 |
| www.glassdoor.ca     | www.glassdoor.com     |     6 |
| www.glassdoor.co.uk  | static.glassdoor.com  |     5 |
| www.glassdoor.ca     | static2.glassdoor.com |     5 |
| www.glassdoor.co.in  | static.glassdoor.com  |     4 |
| www.glassdoor.ca     | static4.glassdoor.com |     4 |
| www.glassdoor.ca     | static5.glassdoor.com |     4 |
| www.glassdoor.co.in  | media.glassdoor.com   |     3 |
| www.glassdoor.ca     | static3.glassdoor.com |     3 |
| www.glassdoor.co.in  | static3.glassdoor.com |     3 |
| www.glassdoor.co.uk  | www.glassdoor.com     |     3 |
| www.glassdoor.co.uk  | media.glassdoor.com   |     2 |
| www.glassdoor.ie     | media.glassdoor.com   |     2 |
| www.glassdoor.nl     | static.glassdoor.com  |     2 |
| www.glassdoor.ca     | static1.glassdoor.com |     2 |
| www.glassdoor.co.in  | static2.glassdoor.com |     2 |
| www.glassdoor.nl     | static2.glassdoor.com |     2 |
| www.glassdoor.co.uk  | static3.glassdoor.com |     2 |
| www.glassdoor.co.in  | static5.glassdoor.com |     2 |
| www.glassdoor.ca     | ads.glassdoor.com     |     1 |
| nl.glassdoor.be      | media.glassdoor.com   |     1 |
...
```
Error report counts by date and exact blocked subdomain:
```
+---------+-----------------------+-------+
| ym      | blocked_fqdn          | count |
+---------+-----------------------+-------+
| 2018-03 | media.glassdoor.com   |     2 |
| 2018-03 | static.glassdoor.com  |     3 |
| 2018-03 | www.glassdoor.com     |     3 |
| 2018-02 | ads.glassdoor.com     |     1 |
| 2018-02 | media.glassdoor.com   |     7 |
| 2018-02 | static.glassdoor.com  |     6 |
| 2018-02 | www.glassdoor.com     |     9 |
| 2018-01 | www.glassdoor.com     |     1 |
...
```