### PR TITLE
Add assets-cdk.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -40,6 +40,7 @@ cdn.arstechnica.net
 aspnetcdn.com
 c64.assets-yammer.com
 assetfiles.com
+assets-cdk.com
 authorize.net
 autoforums.com
 azureedge.net


### PR DESCRIPTION
Error report counts by page domain and exact blocked subdomain:
```
+----------------------------------+------------------------------+-------+
| fqdn                             | blocked_fqdn                 | count |
+----------------------------------+------------------------------+-------+
| www.chevynorthridge.com          | fo-static.assets-cdk.com     |     1 |
| www.cornerstonechevrolet.com     | fo-static.assets-cdk.com     |     1 |
| www.covertcadillac.com           | fo-static.assets-cdk.com     |     1 |
| www.foxgm.com                    | fo-static.assets-cdk.com     |     1 |
| www.grossingerchevycadillac.com  | fo-static.assets-cdk.com     |     1 |
| www.hilltopchevy.com             | fo-static.assets-cdk.com     |     1 |
| www.jimkerasmemphis.com          | fo-static.assets-cdk.com     |     1 |
| www.josephchevrolet.com          | fo-static.assets-cdk.com     |     1 |
| www.lexusofdayton.com            | fo-static.assets-cdk.com     |     1 |
| www.medinagmautomall.com         | fo-static.assets-cdk.com     |     1 |
| www.modernchevrolet.com          | fo-static.assets-cdk.com     |     1 |
| www.redriverchevy.com            | fo-static.assets-cdk.com     |     1 |
| www.sheehancadillac.com          | fo-static.assets-cdk.com     |     1 |
| www.sunchevy.com                 | fo-static.assets-cdk.com     |     1 |
| www.winkelly.com                 | fo-static.assets-cdk.com     |     1 |
| www.bergstromauto.com            | inventory-dmg.assets-cdk.com |     1 |
| www.boardwalkchevrolet.com       | inventory-dmg.assets-cdk.com |     1 |
| www.columbiachev.com             | inventory-dmg.assets-cdk.com |     1 |
| www.covertcadillac.com           | inventory-dmg.assets-cdk.com |     1 |
| www.josephchevrolet.com          | inventory-dmg.assets-cdk.com |     1 |
| www.johnsonmotorsales.com        | media-cf.assets-cdk.com      |     1 |
| www.bergstromauto.com            | media-dmg.assets-cdk.com     |     1 |
| www.bobbrownchevy.com            | media-dmg.assets-cdk.com     |     1 |
| www.bobhook.com                  | media-dmg.assets-cdk.com     |     1 |
| www.chevyiowa.com                | media-dmg.assets-cdk.com     |     1 |
| www.chevynorthridge.com          | media-dmg.assets-cdk.com     |     1 |
| www.cornerstonechevrolet.com     | media-dmg.assets-cdk.com     |     1 |
| www.covertcadillac.com           | media-dmg.assets-cdk.com     |     1 |
| www.foxgm.com                    | media-dmg.assets-cdk.com     |     1 |
| www.grossingerchevycadillac.com  | media-dmg.assets-cdk.com     |     1 |
| www.hilltopchevy.com             | media-dmg.assets-cdk.com     |     1 |
...
```

Error report counts by date and exact blocked subdomain:
```
+---------+------------------------------+-------+
| ym      | blocked_fqdn                 | count |
+---------+------------------------------+-------+
| 2018-03 | fo-static.assets-cdk.com     |     8 |
| 2018-03 | inventory-dmg.assets-cdk.com |     3 |
| 2018-03 | media-dmg.assets-cdk.com     |     9 |
| 2018-02 | fo-static.assets-cdk.com     |     5 |
| 2018-02 | media-dmg.assets-cdk.com     |     5 |
| 2018-01 | fo-static.assets-cdk.com     |     2 |
| 2018-01 | media-cf.assets-cdk.com      |     1 |
| 2018-01 | media-dmg.assets-cdk.com     |     3 |
...
```