### PR TITLE
Add tradingview.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -532,6 +532,7 @@ tmsbuyatoyota.com
 torbit.com
 townnews.com
 cookieblock.trackersimulate.org
+tradingview.com
 trb.com
 trbimg.com
 tripadvisor.com


### PR DESCRIPTION
Fixes display of various chart/price quote widgets from TradingView.

Besides cookies and localStorage, I see "database storage" (#1557):

![screenshot from 2018-03-23 16 51 24](https://user-images.githubusercontent.com/794578/37852819-71a05e3a-2eba-11e8-8d74-b1f2921b2709.png)

Examples:
- https://seekingalpha.com/symbol/AAPL/chart
- https://cryptoking.org
- https://cryptosignals.trade/markets-live/
- https://prices.org/ethereum/
- http://www.pmbull.com/gold-price/