### PR TITLE
fix for "clicking tabs makes window scroll down"

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -96,7 +96,7 @@ function loadOptions() {
     activate: function (event, ui) {
       // update options page URL fragment identifier
       // to preserve selected tab on page reload
-      history.pushState(null, null, "#" + ui.newPanel.attr('id'));
+      history.replaceState(null, null, "#" + ui.newPanel.attr('id'));
     }
   });
   $("button").button();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -97,6 +97,7 @@ function loadOptions() {
       // update options page URL fragment identifier
       // to preserve selected tab on page reload
       window.location.hash = ui.newPanel.attr('id');
+      window.scrollTo(0,0);
     }
   });
   $("button").button();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -96,8 +96,7 @@ function loadOptions() {
     activate: function (event, ui) {
       // update options page URL fragment identifier
       // to preserve selected tab on page reload
-      window.location.hash = ui.newPanel.attr('id');
-      window.scrollTo(0,0);
+      history.pushState(null, null, "#" + ui.newPanel.attr('id'));
     }
   });
   $("button").button();


### PR DESCRIPTION
Fixes #1918.

src/options.js, line 100. move window back to top of page