### PR TITLE
Add Salesforce domains to MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -388,6 +388,14 @@ var multiDomainFirstPartiesArray = [
   ["railnation.ru", "railnation.de", "rail-nation.com", "railnation.gr", "railnation.us", "trucknation.de", "traviangames.com"],
   ["rakuten.com", "buy.com"],
   ["reddit.com", "redditmedia.com", "redditstatic.com", "redd.it", "redditenhancementsuite.com", "reddituploads.com", "imgur.com"],
+  [
+    "salesforce.com",
+
+    "einstein.com",
+    "force.com",
+    "pardot.com",
+    "salesforceliveagent.com",
+  ],
   ["sanguosha.com", "bianfeng.com"],
   ["schwab.com", "schwabplan.com"],
   ["sears.com", "shld.net"],


### PR DESCRIPTION
Fixes #1931. I noticed `pardot.com` as another Salesforce-owned domain from error reports.