### PR TITLE
Add JSON error handling and retrying to DNT header tests

### DIFF
--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -226,7 +226,7 @@ class DNTTest(pbtest.PBSeleniumTest):
     def test_first_party_dnt_header(self):
         TEST_URL = "https://httpbin.org/get"
         headers = retry_until(partial(self.get_first_party_headers, TEST_URL))
-        self.assertTrue(headers, "It seems we failed to get DNT headers")
+        self.assertTrue(headers is not None, "It seems we failed to get DNT headers")
         self.assertIn('Dnt', headers, "DNT header should have been present")
         self.assertEqual(headers['Dnt'], "1",
             'DNT header should have been set to "1"')
@@ -235,7 +235,7 @@ class DNTTest(pbtest.PBSeleniumTest):
         TEST_URL = "https://httpbin.org/get"
         self.disable_badger_on_site(TEST_URL)
         headers = retry_until(partial(self.get_first_party_headers, TEST_URL))
-        self.assertTrue(headers, "It seems we failed to get DNT headers")
+        self.assertTrue(headers is not None, "It seems we failed to get DNT headers")
         self.assertNotIn('Dnt', headers, "DNT header should have been missing")
 
     def test_navigator_object(self):

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -104,7 +104,7 @@ class DNTTest(pbtest.PBSeleniumTest):
         # verify that the domain is allowed
         was_blocked = retry_until(
             partial(self.domain_was_blocked, DNT_DOMAIN),
-            cond=False,
+            tester=lambda x: not x,
             msg="Waiting a bit for DNT check to complete and retrying ...")
 
         self.assertFalse(was_blocked, msg="DNT-compliant resource should have gotten unblocked.")

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -40,7 +40,7 @@ class DNTTest(pbtest.PBSeleniumTest):
             headers = json.loads(text)['headers']
         except ValueError:
             print("\nFailed to parse JSON from {}".format(repr(text)))
-            return False
+            return None
 
         return headers
 
@@ -226,6 +226,7 @@ class DNTTest(pbtest.PBSeleniumTest):
     def test_first_party_dnt_header(self):
         TEST_URL = "https://httpbin.org/get"
         headers = retry_until(partial(self.get_first_party_headers, TEST_URL))
+        self.assertTrue(headers, "It seems we failed to get DNT headers")
         self.assertIn('Dnt', headers, "DNT header should have been present")
         self.assertEqual(headers['Dnt'], "1",
             'DNT header should have been set to "1"')
@@ -234,6 +235,7 @@ class DNTTest(pbtest.PBSeleniumTest):
         TEST_URL = "https://httpbin.org/get"
         self.disable_badger_on_site(TEST_URL)
         headers = retry_until(partial(self.get_first_party_headers, TEST_URL))
+        self.assertTrue(headers, "It seems we failed to get DNT headers")
         self.assertNotIn('Dnt', headers, "DNT header should have been missing")
 
     def test_navigator_object(self):

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -31,6 +31,19 @@ class DNTTest(pbtest.PBSeleniumTest):
         #"privacy-badger-navigator-donottrack-fixture.html"
     )
 
+    def get_first_party_headers(self, url):
+        self.load_url(url)
+
+        text = self.driver.find_element_by_tag_name('body').text
+
+        try:
+            headers = json.loads(text)['headers']
+        except ValueError:
+            print("\nFailed to parse JSON from {}".format(repr(text)))
+            return False
+
+        return headers
+
     def disable_badger_on_site(self, url):
         self.load_url(self.options_url)
         self.driver.find_element_by_css_selector(
@@ -212,28 +225,15 @@ class DNTTest(pbtest.PBSeleniumTest):
 
     def test_first_party_dnt_header(self):
         TEST_URL = "https://httpbin.org/get"
-
-        self.load_url(TEST_URL)
-
-        headers = json.loads(
-            self.driver.find_element_by_tag_name('body').text
-        )['headers']
-
+        headers = retry_until(partial(self.get_first_party_headers, TEST_URL))
         self.assertIn('Dnt', headers, "DNT header should have been present")
         self.assertEqual(headers['Dnt'], "1",
             'DNT header should have been set to "1"')
 
     def test_no_dnt_header_when_disabled(self):
         TEST_URL = "https://httpbin.org/get"
-
         self.disable_badger_on_site(TEST_URL)
-
-        self.load_url(TEST_URL)
-
-        headers = json.loads(
-            self.driver.find_element_by_tag_name('body').text
-        )['headers']
-
+        headers = retry_until(partial(self.get_first_party_headers, TEST_URL))
         self.assertNotIn('Dnt', headers, "DNT header should have been missing")
 
     def test_navigator_object(self):

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -201,14 +201,17 @@ def if_firefox(wrapper):
     return test_catcher
 
 
-def retry_until(fun, cond=True, times=5, msg="Waiting a bit and retrying ..."):
+def retry_until(fun, tester=None, times=5, msg="Waiting a bit and retrying ..."):
     """
-    Execute function `fun` until either its return equals `cond`,
+    Execute function `fun` until either its return is truthy
+    (or if `tester` is set, until the result of calling `tester` with `fun`'s return is truthy),
     or it gets executed X times, where X = `times` + 1.
     """
     for i in range(times):
         result = fun()
-        if result == cond:
+        if tester is not None and tester(result):
+            break
+        elif result:
             break
         elif i == 0:
             print("")
@@ -308,7 +311,7 @@ class PBSeleniumTest(unittest.TestCase):
 
         if wait_for_body_text:
             retry_until(
-                lambda: bool(self.driver.find_element_by_tag_name('body').text),
+                lambda: self.driver.find_element_by_tag_name('body').text,
                 msg="Waiting for document.body.textContent to get populated ..."
             )
 


### PR DESCRIPTION
This follows up on this failed job: https://travis-ci.org/EFForg/privacybadger/jobs/359621950.

It's not clear why we got what doesn't appear to be JSON from the httpbin page (see below), but this PR should handle invalid JSON scenarios and retry the test where it happened.

```python
'JSON\nRaw Data\nHeaders\nSave\nCopy\nargs {}\nheaders\nAccept "text/html,application/xhtml+xml,application/xml;q=0.9,.../5.0 (X11; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0"\norigin "35.184.226.236"\nurl "https://httpbin.org/get"'
```