### PR TITLE
MDFP for TechMedia sites

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -306,7 +306,7 @@ var multiDomainFirstPartiesArray = [
   ],
   ["gotomeeting.com", "citrixonline.com"],
   ["guardian.co.uk", "guim.co.uk", "guardianapps.co.uk", "theguardian.com", "gu-web.net"],
-  ["habrahabr.ru", "geektimes.ru", "dr.habracdn.net", "hsto.org", "habrastorage.org"],
+  ["habrahabr.ru", "geektimes.ru", "habracdn.net", "hsto.org", "habrastorage.org"],
   ["healthfusion.com", "healthfusionclaims.com"],
   ["hvfcu.org", "hvfcuonline.org"],
   ["logmein.com", "logme.in"],

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -306,6 +306,7 @@ var multiDomainFirstPartiesArray = [
   ],
   ["gotomeeting.com", "citrixonline.com"],
   ["guardian.co.uk", "guim.co.uk", "guardianapps.co.uk", "theguardian.com", "gu-web.net"],
+  ["habrahabr.ru", "geektimes.ru", "dr.habracdn.net", "hsto.org", "habrastorage.org"],
   ["healthfusion.com", "healthfusionclaims.com"],
   ["hvfcu.org", "hvfcuonline.org"],
   ["logmein.com", "logme.in"],


### PR DESCRIPTION
TechMedia operates two a few websites, the most prominent being habahabr.ru and geektimes.ru (think slashdot with some local quirks).

Both sites use dr.habracdn.net to serve CSS&JS and hsto.org to serve images.  habrastorage.org seems to only ever return 302 302 Moved Temporarily and redirect to hsto.org.

Currently, Privacy Badger blocks dr.habracdn.net and hsto.org, requiring manual yellowlisting. 