### PR TITLE
Fix DNT checking in Private Browsing/Incognito

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -219,10 +219,6 @@ function onBeforeSendHeaders(details) {
     };
     chrome.tabs.sendMessage(tab_id, msg);
 
-    window.setTimeout(function () {
-      badger.checkForDNTPolicy(requestDomain);
-    }, 10);
-
     if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
       return {
         redirectUrl: 'about:blank'

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -118,7 +118,7 @@ function onBeforeRequest(details) {
   chrome.tabs.sendMessage(tab_id, msg);
 
   // if this is a heuristically- (not user-) blocked domain
-  if (requestAction == constants.BLOCK) {
+  if (requestAction == constants.BLOCK && incognito.learningEnabled(tab_id)) {
     // check for DNT policy
     window.setTimeout(function () {
       badger.checkForDNTPolicy(requestDomain);


### PR DESCRIPTION
Fixes #1929 (and follows up on #1642).

One way to reproduce the bug is to import an older Privacy Badger data file that knows to block a good number of domains that are ready to have their DNT policies rechecked (old-enough `nextUpdateTime` timestamps in `action_map`), and visit some news site (lots of tracking domains) in Private Browsing or Incognito. Since DNT requests contact remote servers and modify local data, you should not see any DNT requests go out, but you will see some for domains on the page that Privacy Badger previously learned to block.

