### PR TITLE
Add libsyn.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -336,6 +336,7 @@ klarna.com
 klarnacdn.net
 klm.com
 kxcdn.com
+libsyn.com
 licdn.com
 licensebuttons.net
 addon.lidl.de


### PR DESCRIPTION
Fixes #1180.

More examples:
- https://www.stitcher.com/podcast/rncn/financial-gravity-with-john-pollock/e/53853435
- https://usa.streetsblog.org/2018/03/23/talking-headways-podcast-mobility-is-like-a-heavy-metal-band/
- https://overcast.fm/+HOFj9gH3g

I see session and day-long cookies (#1545):
![screenshot from 2018-04-02 17 14 48](https://user-images.githubusercontent.com/794578/38216638-67354852-3699-11e8-9f1c-cc9dbdfb5fa0.png)

Error report counts by date and exact blocked subdomain:
```
+---------+---------------------------+-------+
| ym      | blocked_fqdn              | count |
+---------+---------------------------+-------+
| 2018-03 | assets.libsyn.com         |     3 |
| 2018-03 | fightsgoneby.libsyn.com   |     1 |
| 2018-03 | html5-player.libsyn.com   |     2 |
| 2018-03 | hwcdn.libsyn.com          |     1 |
| 2018-03 | secure-hwcdn.libsyn.com   |     6 |
| 2018-03 | ssl-static.libsyn.com     |     1 |
| 2018-03 | static.libsyn.com         |     4 |
| 2018-03 | traffic.libsyn.com        |    11 |
| 2018-02 | assets.libsyn.com         |     7 |
| 2018-02 | html5-player.libsyn.com   |     6 |
| 2018-02 | hwcdn.libsyn.com          |     5 |
| 2018-02 | my.libsyn.com             |     3 |
| 2018-02 | secure-hwcdn.libsyn.com   |     7 |
| 2018-02 | ssl-static.libsyn.com     |     6 |
| 2018-02 | static.libsyn.com         |     8 |
| 2018-02 | stillbuffering.libsyn.com |     1 |
| 2018-02 | traffic.libsyn.com        |    13 |
| 2018-01 | assets.libsyn.com         |     1 |
| 2018-01 | html5-player.libsyn.com   |     3 |
| 2018-01 | hwcdn.libsyn.com          |     1 |
| 2018-01 | static.libsyn.com         |     1 |
| 2018-01 | traffic.libsyn.com        |     1 |
...
```