### PR TITLE
Add US government sites to the MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -433,6 +433,7 @@ var multiDomainFirstPartiesArray = [
   ["twitch.tv", "ttvnw.net", "jtvnw.net"],
   ["twitter.com", "twimg.com", "t.co"],
   ["ua2go.com", "ual.com", "united.com", "unitedwifi.com"],
+  ["usa.gov", "usembassy.gov", "dhs.gov", "transportation.gov"],
   ["verizon.com", "verizon.net"],
   ["vk.com", "vk.me", "vkontakte.ru"],
   ["volkskrant.nl", "persgroep.net", "persgroep.nl", "parool.nl"],


### PR DESCRIPTION
Add sites "[usa.gov](url)," "[usembassy.gov](url)," "[dhs.gov](url)," and "[transportation.gov](url)" to the MDFP list. These were discovered by the crawler script in development.

To reproduce, visit [usa.gov](url) followed by the other three sites in any order. For some reason, visiting any of the other sites before visiting [usa.gov](url) does not cause privacy badger to detect it as a tracker.