### PR TITLE
Fix XML document rendering in Firefox

### DIFF
--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -20,7 +20,6 @@
  * Communicates to webrequest.js to get orders if to delete cookies.
  */
 
-
 function insertCcScript(text) {
   var parent = document.documentElement,
     script = document.createElement('script');
@@ -30,6 +29,19 @@ function insertCcScript(text) {
 
   parent.insertBefore(script, parent.firstChild);
   parent.removeChild(script);
+}
+
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
 }
 
 // TODO race condition; fix waiting on https://crbug.com/478183
@@ -44,3 +56,5 @@ chrome.runtime.sendMessage({checkLocation:document.location.href}, function(bloc
   }
   return true;
 });
+
+}());

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -37,6 +37,19 @@ function insertClsScript(text) {
   parent.removeChild(script);
 }
 
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({checkLocation:document.location.href}, function(blocked) {
   if (blocked) {
@@ -58,3 +71,5 @@ chrome.runtime.sendMessage({checkLocation:document.location.href}, function(bloc
   }
   return true;
 });
+
+}());

--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -49,6 +49,19 @@ function insertPageScript(text) {
   parent.removeChild(script);
 }
 
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
   checkEnabled: true
@@ -57,3 +70,5 @@ chrome.runtime.sendMessage({
     insertPageScript(getPageScript());
   }
 });
+
+}());

--- a/src/js/contentscripts/fingerprinting.js
+++ b/src/js/contentscripts/fingerprinting.js
@@ -320,6 +320,20 @@ function insertFpScript(text, data) {
   parent.removeChild(script);
 }
 
+
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({checkEnabled: true},
   function (enabled) {
@@ -344,3 +358,5 @@ chrome.runtime.sendMessage({checkEnabled: true},
     });
   }
 );
+
+}());

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -327,6 +327,19 @@ function unblockTracker(buttonUrls, callback) {
   chrome.runtime.sendMessage(request, callback);
 }
 
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
 chrome.runtime.sendMessage({
   checkSocialWidgetReplacementEnabled: true
 }, function (checkSocialWidgetReplacementEnabled) {
@@ -335,3 +348,5 @@ chrome.runtime.sendMessage({
   }
   initialize();
 });
+
+}());

--- a/src/js/contentscripts/supercookie.js
+++ b/src/js/contentscripts/supercookie.js
@@ -110,6 +110,19 @@ function getScPageScript() {
 
 }
 
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
   checkEnabledAndThirdParty: true
@@ -134,3 +147,5 @@ chrome.runtime.sendMessage({
   });
 
 });
+
+}());


### PR DESCRIPTION
Fixes #1949.

This only seems to happen in Firefox. Does Chrome handle the checks we add in this PR internally?

Sample XML document: https://sourceforge.net/sitemap.xml
Sample XHTML document: http://tieba.baidu.com/mo/q---2799060AC2198378C599200012D229ED%3AFG%3D1--1-3-0--2--wapp_1440757687244_809/m?kw=%E9%9A%90%E6%9D%80&lp=1030

This seems like a good thing to have automated tests for, but I haven't yet figured out how to detect the difference between a pretty-rendered XML document in Firefox and a non-pretty-thanks-to-an-injected-script-tag version of the same with Selenium. The problem seems to be that Firefox handles its pretty rendering HTML specially; it's not part of the document (doesn't seem to be even inspectable by dev tools).
<details><summary>Here is my (non-working) test attempt:</summary>

```diff
diff --git a/tests/selenium/breakage_test.py b/tests/selenium/breakage_test.py
index 33a3743..db86fd8 100644
--- a/tests/selenium/breakage_test.py
+++ b/tests/selenium/breakage_test.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
+import os
 import unittest
+
 import pbtest
+
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-import re
 
 
-class Test(pbtest.PBSeleniumTest):
+class BreakageTest(pbtest.PBSeleniumTest):
     """Make sure the extension doesn't break common sites and use cases.
     e.g. we should be able to load a website, search on Google.
     TODO: Add tests to simulate most common web use cases:
@@ -27,5 +29,14 @@ class Test(pbtest.PBSeleniumTest):
         qry_el.submit()
         WebDriverWait(self.driver, 10).until(EC.title_contains("EFF"))
 
+    # https://github.com/EFForg/privacybadger/issues/1949
+    def test_xml_rendering(self):
+        xml_fixture_path = os.path.join(
+            pbtest.get_git_root(), 'tests', 'fixtures', 'xml_document.xml')
+        self.load_url('file://' + xml_fixture_path)
+        page_contents = self.js("return document.outerHTML;")
+        self.assertEqual(page_contents, '<root>Test</root>',
+            "XML document's contents should have been left alone.")
+
 if __name__ == "__main__":
     unittest.main()
```
```bash
$ cat tests/fixtures/xml_document.xml 
<root>Test</root>
```
</details>