### PR TITLE
Add rewardstyle.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -471,6 +471,7 @@ redditmedia.com
 redditstatic.com
 resellerratings.com
 resultspage.com
+rewardstyle.com
 rpxnow.com
 rssinclude.com
 salesforce.com


### PR DESCRIPTION
Fixes #1950.

I see a session cookie (#1545) and a `rs_lang=en_US` cookie (Privacy Badger doesn't recognize "en_US" as a language code yet).