### PR TITLE
Add two MailChimp domains to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -342,6 +342,7 @@ licensebuttons.net
 addon.lidl.de
 media.lidl.com
 linkwithin.com
+list-manage.com
 i.lithium.com
 messenger.live.com
 livechatinc.com
@@ -353,6 +354,7 @@ loggly.com
 logos.com
 lphbs.com
 mail.ru
+mailchimp.com
 mapbox.com
 mapquestapi.com
 marketo.com


### PR DESCRIPTION
Fixes #1539.

Error report counts by date and exact blocked `mailchimp.com` subdomain:
```
+---------+--------------------------+-------+
| ym      | blocked_fqdn             | count |
+---------+--------------------------+-------+
| 2018-04 | cdn-images.mailchimp.com |     6 |
| 2018-04 | downloads.mailchimp.com  |     1 |
| 2018-04 | gallery.mailchimp.com    |     1 |
| 2018-03 | cdn-images.mailchimp.com |     6 |
| 2018-03 | gallery.mailchimp.com    |     4 |
| 2018-02 | cdn-images.mailchimp.com |     9 |
| 2018-02 | downloads.mailchimp.com  |     1 |
| 2018-02 | gallery.mailchimp.com    |     4 |
| 2018-01 | cdn-images.mailchimp.com |     7 |
| 2018-01 | gallery.mailchimp.com    |     3 |
| 2018-01 | us6.admin.mailchimp.com  |     1 |
...
```

Error report counts by date and exact blocked `list-manage.com` subdomain:
```
+---------+------------------------------------------------+-------+
| ym      | blocked_fqdn                                   | count |
+---------+------------------------------------------------+-------+
| 2018-04 | delanceyplace.us5.list-manage.com              |     1 |
| 2018-04 | mc.us8.list-manage.com                         |     1 |
| 2018-04 | nyc.us10.list-manage.com                       |     1 |
| 2018-04 | patriotmemory.us7.list-manage.com              |     1 |
| 2018-04 | stanford.us6.list-manage.com                   |     1 |
| 2018-03 | homemadetools.us5.list-manage.com              |     1 |
| 2018-03 | kathimerini.us4.list-manage.com                |     1 |
| 2018-03 | nycskeptics.us1.list-manage.com                |     1 |
| 2018-03 | wikimediafoundation.us11.list-manage.com       |     1 |
| 2018-02 | mc.us11.list-manage.com                        |     1 |
| 2018-02 | mc.us8.list-manage.com                         |     1 |
| 2018-02 | neocities.us17.list-manage.com                 |     1 |
...
```