### PR TITLE
Ignore storage update errors unrelated to Privacy Badger

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -519,7 +519,9 @@ var _syncStorage = (function () {
   function cb() {
     if (chrome.runtime.lastError) {
       let err = chrome.runtime.lastError.message;
-      badger.criticalError = err;
+      if (!err.startsWith("IO error:") && !err.startsWith("Corruption:")) {
+        badger.criticalError = err;
+      }
       console.error("Error writing to chrome.storage.local:", err);
     }
   }


### PR DESCRIPTION
Fixes #1866. Supersedes #1913.

Here are the errors we've seen so far:
- `QUOTA_BYTES` #1717
- `FILE_ERROR_NO_SPACE` #1866 
- "Could not perform read" #1952
- "Corruption: block checksum mismatch" #1963

Looks like there are many different corruption scenarios: https://chromium.googlesource.com/chromium/src/+/2a9a8201b8c0b213aa41b6a390e9324113176f15/third_party/leveldatabase/env_chromium.cc#658