### PR TITLE
Reset default WebRTC protection to browser setting

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -216,7 +216,7 @@
         "description": "Part of a reminder to visit the intro page. Shown in popup until the user clicks on the reminder link or browses through the intro page."
     },
     "options_webrtc_warning": {
-        "message": "* WebRTC can leak your local IP address. Privacy Badger's default setting helps protect you, but for added protection you may enable this option. Note that doing so may degrade performance on some tools like Google Hangouts.",
+        "message": "* WebRTC can leak your local IP address. Note that enabling this option may degrade performance on web conferencing apps like Google Hangouts.",
         "description": "Detailed explanation shown under checkboxes on the general settings page"
     },
     "options_general_settings": {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -55,7 +55,6 @@ function Badger() {
     } finally {
       self.initializeYellowlist();
       self.initializeDNT();
-      self.enableWebRTCProtection();
       if (!self.isIncognito) {self.showFirstRunPage();}
     }
 
@@ -258,33 +257,6 @@ Badger.prototype = {
 
     // set up periodic fetching of the yellowlist from eff.org
     setInterval(self.updateYellowlist.bind(self), utils.oneDay());
-  },
-
-  /**
-   * Change default WebRTC handling browser policy to more
-   * private setting that only shows public facing IP address.
-   *
-   * Only update if user does not have the strictest setting enabled.
-   */
-  enableWebRTCProtection: function () {
-    let self = this;
-
-    // Return early with non-supporting browsers
-    if (!self.webRTCAvailable) {
-      return;
-    }
-
-    var cpn = chrome.privacy.network;
-
-    cpn.webRTCIPHandlingPolicy.get({}, function(result) {
-      if (result.value == 'disable_non_proxied_udp') {
-        return;
-      }
-
-      cpn.webRTCIPHandlingPolicy.set({
-        value: 'default_public_interface_only'
-      });
-    });
   },
 
   /**
@@ -522,6 +494,7 @@ Badger.prototype = {
       Migrations.reapplyYellowlist,
       Migrations.forgetNontrackingDomains,
       Migrations.forgetMistakenlyBlockedDomains,
+      Migrations.resetWebRTCIPHandlingPolicy,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {
@@ -641,22 +614,6 @@ Badger.prototype = {
 
   isCheckingDNTPolicyEnabled: function() {
     return this.getSettings().getItem("checkForDNTPolicy");
-  },
-
-  /**
-   * Check if WebRTC IP leak protection is enabled.
-   *
-   * @param {Function} callback
-   */
-  isWebRTCIPProtectionEnabled: function (callback) {
-    // Return early with non-supporting browsers
-    if (!this.webRTCAvailable) {
-      return;
-    }
-
-    chrome.privacy.network.webRTCIPHandlingPolicy.get({}, function (result) {
-      callback(result);
-    });
   },
 
   /**

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -228,6 +228,22 @@ exports.Migrations= {
     }
   },
 
+  resetWebRTCIPHandlingPolicy: function (/*badger*/) {
+    console.log("Resetting webRTCIPHandlingPolicy ...");
+
+    const cpn = chrome.privacy.network;
+
+    cpn.webRTCIPHandlingPolicy.get({}, function (result) {
+      if (!result.levelOfControl.endsWith('_by_this_extension')) {
+        return;
+      }
+
+      if (result.value == 'default_public_interface_only') {
+        cpn.webRTCIPHandlingPolicy.clear({});
+      }
+    });
+  },
+
 };
 
 

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -228,8 +228,12 @@ exports.Migrations= {
     }
   },
 
-  resetWebRTCIPHandlingPolicy: function (/*badger*/) {
+  resetWebRTCIPHandlingPolicy: function (badger) {
     console.log("Resetting webRTCIPHandlingPolicy ...");
+
+    if (!badger.webRTCAvailable) {
+      return;
+    }
 
     const cpn = chrome.privacy.network;
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -120,15 +120,13 @@ function loadOptions() {
   if (badger.webRTCAvailable) {
     $("#toggle_webrtc_mode").on("click", toggleWebRTCIPProtection);
 
-    badger.isWebRTCIPProtectionEnabled(function (result) {
+    chrome.privacy.network.webRTCIPHandlingPolicy.get({}, result => {
       if (result.levelOfControl.endsWith("_by_this_extension")) {
         $("#toggle_webrtc_mode").attr("disabled", false);
       }
 
       $("#toggle_webrtc_mode").prop(
-        "checked",
-        result.value == "disable_non_proxied_udp"
-      );
+        "checked", result.value == "disable_non_proxied_udp");
     });
 
   } else {
@@ -635,9 +633,9 @@ function showTrackingDomains(domains) {
 /**
  * https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling-01#page-5
  *
- * Toggle WebRTC IP address leak protection setting. "False" value means
- * policy is set to Mode 3 (default_public_interface_only), whereas "true"
- * value means policy is set to Mode 4 (disable_non_proxied_udp).
+ * Toggle WebRTC IP address leak protection setting.
+ *
+ * When enabled, policy is set to Mode 4 (disable_non_proxied_udp).
  */
 function toggleWebRTCIPProtection() {
   // Return early with non-supporting browsers
@@ -648,16 +646,14 @@ function toggleWebRTCIPProtection() {
   let cpn = chrome.privacy.network;
 
   cpn.webRTCIPHandlingPolicy.get({}, function (result) {
-    let value;
-
     // Update new value to be opposite of current browser setting
-    if (result.value === 'disable_non_proxied_udp') {
-      value = 'default_public_interface_only';
+    if (result.value == 'disable_non_proxied_udp') {
+      cpn.webRTCIPHandlingPolicy.clear({});
     } else {
-      value = 'disable_non_proxied_udp';
+      cpn.webRTCIPHandlingPolicy.set({
+        value: 'disable_non_proxied_udp'
+      });
     }
-
-    cpn.webRTCIPHandlingPolicy.set({value});
   });
 }
 


### PR DESCRIPTION
Fixes #1099 by changing what happens when "Prevent WebRTC from leaking local IP address" is unchecked.

For descriptions of modes, see https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling-01#page-5.

Before:
- Unchecked (Badger default): Mode 3
- Checked: Mode 4

After:
- Unchecked (Badger default): Mode 1
- Checked: Mode 4

The problem with defaulting to Mode 3 is that it noticeably degrades video conferencing, causes unexpected breakage for less-robust WebRTC applications, and breaks user expectations with regard to unchecked settings.

This should match uBlock Origin's logic.