### PR TITLE
Update TechMedia MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -307,8 +307,11 @@ var multiDomainFirstPartiesArray = [
   ["gotomeeting.com", "citrixonline.com"],
   ["guardian.co.uk", "guim.co.uk", "guardianapps.co.uk", "theguardian.com", "gu-web.net"],
   [
+    "habr.com",
+    "habr.ru",
     "habrahabr.ru",
     "freelansim.ru",
+    "geektimes.com",
     "geektimes.ru",
     "moikrug.ru",
     "toster.ru",


### PR DESCRIPTION
TechMedia announced they are moving primary domains for Habrababr and Geektimes to `habr.com` and `geektimes.com`, the announcements are https://habrahabr.ru/company/tm/blog/93946/ and https://geektimes.ru/company/tm/blog/300291/ (both in Russian). As of now, both `.ru` domains redirect to '.com' ones. Whois org information for all the four domains is

```
organisation: ORG-HL168-RIPE
org-name: Habr LLC
org-type: OTHER
address: Spartakovsky lane 2, bld. 1
address: Moscow 105082
address: RUSSIAN FEDERATION
phone: +7 499 653-59-61
```

`habr.ru` is an older redirect mentioned in the 1st announcement. Whois org information is different for this one (last modified in 2015), but it uses the same nameservers `ns{1,2,3}.habradns.net.` All in all I think it is safe to consider it a first-party domain as well.

The rest of TechMedia projects seem to stay in `.ru` zone for now.