### PR TITLE
Add mpsnare.iesnare.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -284,6 +284,7 @@ hypothes.is
 ibsys.com
 ibtimes.com
 icbdr.com
+mpsnare.iesnare.com
 imagecorn.com
 imageg.net
 imagehost123.com


### PR DESCRIPTION
Fixes #1782.

Error report counts by date and exact blocked subdomain:
```
+---------+---------------------+-------+
| ym      | blocked_fqdn        | count |
+---------+---------------------+-------+
| 2018-04 | mpsnare.iesnare.com |    20 |
| 2018-03 | mpsnare.iesnare.com |    20 |
| 2018-02 | mpsnare.iesnare.com |    17 |
| 2018-01 | mpsnare.iesnare.com |    17 |
| 2017-12 | mpsnare.iesnare.com |    14 |
...
```

Error report counts by page domain and exact blocked subdomain:
```
+---------------------------------------------------+---------------------+-------+
| fqdn                                              | blocked_fqdn        | count |
+---------------------------------------------------+---------------------+-------+
| citiretailservices.citibankonline.com             | mpsnare.iesnare.com |    61 |
| online.citi.com                                   | mpsnare.iesnare.com |    25 |
| www.united.com                                    | mpsnare.iesnare.com |    19 |
| www.westernunion.com                              | mpsnare.iesnare.com |    14 |
| www.rei.com                                       | mpsnare.iesnare.com |    11 |
| store.starbucks.com                               | mpsnare.iesnare.com |    10 |
| pp.hm.com                                         | mpsnare.iesnare.com |     8 |
| www.macys.com                                     | mpsnare.iesnare.com |     8 |
| www.ups.com                                       | mpsnare.iesnare.com |     7 |
| www.starbucks.com                                 | mpsnare.iesnare.com |     6 |
| dashboard.stripe.com                              | mpsnare.iesnare.com |     5 |
| search.swagbucks.com                              | mpsnare.iesnare.com |     4 |
| shop.lenovo.com                                   | mpsnare.iesnare.com |     4 |
| www.betfair.com                                   | mpsnare.iesnare.com |     4 |
| www.stitcher.com                                  | mpsnare.iesnare.com |     4 |
| www.trekbikes.com                                 | mpsnare.iesnare.com |     4 |
...
```