### PR TITLE
Ask about other extensions when reporting errors

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -407,10 +407,6 @@
         "message": "Privacy Badger hasn't detected any <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domains</a> yet. Keep browsing!",
         "description": "Shown on the Tracking Domains tab on the options page for new and recent installations."
     },
-    "report_input_label": {
-        "message": "Description",
-        "description": ""
-    },
     "non_tracker": {
         "message": "The domains below don't appear to be tracking you",
         "description": ""

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -100,8 +100,12 @@
         "description": "Intro page welcome paragraph."
     },
     "error_input": {
-        "message": "What's Wrong?",
-        "description": ""
+        "message": "What's wrong?",
+        "description": "Placeholder for an error reporting form input in the popup. This input is for briefly describing the problem."
+    },
+    "error_reporting_extensions_input": {
+        "message": "What other extensions do you use?",
+        "description": "Placeholder for an error reporting form input in the popup. This input is for letting us know of any other installed extensions."
     },
     "popup_instructions_no_trackers": {
         "message": "No <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> detected. Hooray for privacy!",

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -107,9 +107,9 @@ function init() {
     });
   });
 
-  var overlay = $('#overlay');
   $("#error").on("click", function() {
-    overlay.toggleClass('active');
+    $('#overlay').toggleClass('active');
+    $("#error_input").focus();
   });
   $("#report_cancel").on("click", function() {
     closeOverlay();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -117,7 +117,7 @@ function init() {
   $("#report_button").on("click", function() {
     $(this).prop("disabled", true);
     $("#report_cancel").prop("disabled", true);
-    send_error($("#error_input").val());
+    send_error();
   });
   $("#report_close").on("click", function() {
     closeOverlay();
@@ -180,11 +180,9 @@ function closeOverlay() {
 }
 
 /**
- * Send errors to PB error reporting server
- *
- * @param {String} message The message to send
+ * Sends errors to PB error reporting server.
  */
-function send_error(message) {
+function send_error() {
   // get the latest domain list from the background page
   chrome.runtime.sendMessage({
     type: "getPopupData",
@@ -200,10 +198,16 @@ function send_error(message) {
     let out = {
       browser: window.navigator.userAgent,
       fqdn: response.tabHost,
-      message: message,
+      message: $("#error_input").val(),
       url: response.tabUrl,
       version: chrome.runtime.getManifest().version
     };
+
+    // send "other extensions" with report if filled in
+    const other_extensions = $("#extensions_input").val().trim();
+    if (other_extensions) {
+      out.extensions = other_extensions;
+    }
 
     for (let origin in origins) {
       let action = origins[origin];

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -295,23 +295,30 @@ font-size: 16px;
   background: url("/skin/background.png");
   transition: opacity .1s ease;
 }
-  div#overlay.active {
+div#overlay.active {
     z-index: 31;
-    opacity: 1;}
-#error_input {
-  display: block;
-  width: 70%;}
+    opacity: 1;
+}
+#overlay textarea + textarea {
+    margin: 5px 0;
+}
+#error_input, #extensions_input {
+    display: block;
+    width: 95%;
+}
 #report_title {
-  display: inline-block;
-  padding: 0;
-  margin: 0; }
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+}
 #report_label {
-  display: block;
-  margin: 1% 0;
-  font-weight: bold;}
+    display: block;
+    margin: 1% 0;
+    font-weight: bold;
+}
 #report_button, #report_cancel {
-  cursor: pointer;
-  margin: 2% 2% 0 0;}
+    cursor: pointer;
+}
 #report_success {
   color: green;}
 #report_fail {

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -66,13 +66,13 @@
     <h1 id="report_title" class="i18n_report_title"></h1>
     <span id="report_close" class="i18n_report_close"></span>
     <p id="report_text" class="i18n_report_text"></p>
-    <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
+    <textarea id="error_input" name="error_input" rows="2" maxlength="300" placeholder="i18n_error_input"></textarea>
+    <textarea id="extensions_input" name="extensions_input" rows="2" maxlength="300" placeholder="i18n_error_reporting_extensions_input"></textarea>
+    <p id="report_terms" class="i18n_report_terms"></p>
     <button id="report_button" class="i18n_report_button"></button>
     <button id="report_cancel" class="i18n_report_cancel"></button>
     <span id="report_success" class="i18n_report_success hidden"></span>
     <span id="report_fail" class="i18n_report_fail hidden"></span>
-    <br><br>
-    <p id="report_terms" class="i18n_report_terms"></p>
   </div>
 
 <div id='privacyBadgerHeader'>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -66,7 +66,6 @@
     <h1 id="report_title" class="i18n_report_title"></h1>
     <span id="report_close" class="i18n_report_close"></span>
     <p id="report_text" class="i18n_report_text"></p>
-    <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
     <button id="report_button" class="i18n_report_button"></button>
     <button id="report_cancel" class="i18n_report_cancel"></button>


### PR DESCRIPTION
This adds another input to the error reporting form. The input's placeholder asks the user to share what other extensions they have installed. We already have an "extensions" column on the error reports table; it's just that it's always `NULL`.

This PR also sets focus on the problem description input upon error reporting overlay activation, as well as moves the "what else gets sent with your report" notice up above the submit button.

There are existing issues with form height (seemingly worse in Firefox). The height of the error form is affected by translations. The form can get taller than popup height, which will generate a scrollbar in Firefox, but not Chrome. The scrollbar is visible regardless of whether the form is active or not. If this PR doesn't make these problems worse, I'm fine leaving them unaddressed for now.