### PR TITLE
Add a couple of domains to NYPR's MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -422,7 +422,17 @@ var multiDomainFirstPartiesArray = [
   ],
   ["norsk-tipping.no", "buypass.no"],
   ["nymag.com", "vulture.com", "grubstreet.com"],
-  ["nypublicradio.org", "radiolab.org", "wnyc.org", "wqxr.org", "thegreenespace.org"],
+  [
+    "nypublicradio.org",
+
+    "newsounds.org",
+    "radiolab.org",
+    "thegreenespace.org",
+    "wnycstudios.org",
+    "wqxr.org",
+
+    "wnyc.org",
+  ],
   ["nytimes.com", "newyorktimes.com", "nyt.com"],
   ["onlineatnsb.com", "norwaysavingsbank.com"],
   ["paypal.com", "paypal-search.com"],


### PR DESCRIPTION
`wnycstudios.org` and `newsounds.org`.

Follows up on #1694 and https://github.com/EFForg/privacybadger/pull/1987#discussion_r184552450.

Error report counts by date and exact blocked `wnyc.org` subdomain:
```
+---------+----------------------+------------------------+-------+
| ym      | blocked_fqdn         | fqdn                   | count |
+---------+----------------------+------------------------+-------+
| 2018-04 | api.wnyc.org         | www.wnycstudios.org    |     7 |
| 2018-04 | media.wnyc.org       | www.wnycstudios.org    |     7 |
| 2018-03 | api.wnyc.org         | www.newsounds.org      |     1 |
| 2018-03 | api.wnyc.org         | www.propublica.org     |     1 |
| 2018-03 | api.wnyc.org         | www.wnycstudios.org    |     7 |
| 2018-03 | audio.wnyc.org       | www.wnycstudios.org    |     2 |
| 2018-03 | internal.wnyc.org    | www.newsounds.org      |     1 |
| 2018-03 | internal.wnyc.org    | www.propublica.org     |     1 |
| 2018-03 | media.wnyc.org       | www.newsounds.org      |     1 |
| 2018-03 | media.wnyc.org       | www.wnycstudios.org    |     8 |
| 2018-02 | api.wnyc.org         | www.wnycstudios.org    |     4 |
| 2018-02 | audio.wnyc.org       | freakonomics.com       |     1 |
| 2018-02 | internal.wnyc.org    | freakonomics.com       |     1 |
| 2018-02 | media.wnyc.org       | www.wnycstudios.org    |     4 |
| 2018-01 | api.wnyc.org         | www.wnycstudios.org    |     2 |
| 2018-01 | internal.wnyc.org    | www.wnycstudios.org    |     1 |
| 2018-01 | media.wnyc.org       | www.wnycstudios.org    |     2 |
| 2018-01 | www.wnyc.org         | www.wnycstudios.org    |     1 |
...
```