### PR TITLE
Unwrap links on facebook.com

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -52,6 +52,11 @@ https://github.com/beaugunderson/javascript-ipv6
 Copyright 2011 Beau Gunderson
 Licensed MIT
 
+src/js/firstparties/facebook.js incorporates code from Facebook Tracking Removal
+https://github.com/mgziminsky/FacebookTrackingRemoval
+Copyright 2018 Michael Ziminsky
+Licensed GPL v3
+
 Incorporating code from ShareMeNot,
 https://sharemenot.cs.washington.edu
 Copyright © 2006-2014 University of Washington

--- a/LICENSE
+++ b/LICENSE
@@ -52,7 +52,8 @@ https://github.com/beaugunderson/javascript-ipv6
 Copyright 2011 Beau Gunderson
 Licensed MIT
 
-src/js/firstparties/facebook.js incorporates code from Facebook Tracking Removal
+src/js/firstparties/facebook.js incorporates code from Facebook™ Tracking & Ad
+Removal
 https://github.com/mgziminsky/FacebookTrackingRemoval
 Copyright 2018 Michael Ziminsky
 Licensed GPL v3

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -1,0 +1,68 @@
+// Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
+(function() {
+  let fb_shim_link = "a[onclick^='LinkshimAsyncLink.referrer_log']";
+  let fb_wrapped_link = "a[href*='facebook.com/l.php?'";
+
+  function findInAllFrames(query) {
+    let out = [];
+    document.querySelectorAll(query).forEach((node) => {
+      out.push(node);
+    });
+    Array.from(document.getElementsByTagName('iframe')).forEach((iframe) => {
+      try {
+        iframe.contentDocument.querySelectorAll(query).forEach((node) => {
+          out.push(node);
+        });
+      } catch (e) {
+        // pass on cross origin iframe errors
+      }
+    });
+    return out;
+  }
+
+  // remove all attributes from a link except for class and ARIA attributes
+  function cleanAttrs(elem) {
+    for (let i = elem.attributes.length - 1; i >= 0; --i) {
+      const attr = elem.attributes[i];
+      if (attr.name !== 'class' && !attr.name.startsWith('aria-')) {
+        elem.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  // Remove excessive attributes and event listeners from link a and replace
+  // its destination with href
+  function cleanLink(a, href) {
+    cleanAttrs(a);
+    a.href = href;
+    a.target = "_blank";
+    a.addEventListener("rlick", function (e) { e.stopPropagation(); }, true);
+    a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
+  }
+
+  function unwrapRedirects() {
+    console.log("Executing redirect unwrapping..."); 
+
+    // unwrap wrapped links
+    findInAllFrames(fb_wrapped_link).forEach((link) => {
+      const newHref = new URL(link.href).searchParams.get('u');
+      cleanLink(link, newHref);
+    });
+
+    // clean shim links
+    findInAllFrames(fb_shim_link).forEach((link) => {
+      console.log(link);
+      // extract the real link from the shim link's onmouseover attribute
+      let s = link.getAttribute("onmouseover"),
+        extHref = s.substring(s.indexOf('"') + 1,
+          s.lastIndexOf('"')).replace(/\\(.)/g, '$1');
+      console.log(extHref);
+      // replace the shim link with the real one
+      cleanLink(link, extHref);
+      console.log("Unwrapped shim link to " + extHref); 
+    });
+  }
+
+  unwrapRedirects();
+  setInterval(unwrapRedirects, 2000);
+}());

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -1,64 +1,63 @@
 // Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
 (function() {
-  let fb_shim_link = "a[onclick^='LinkshimAsyncLink.referrer_log']";
-  let fb_wrapped_link = "a[href*='facebook.com/l.php?'";
+let fb_wrapped_link = "a[href*='facebook.com/l.php?'";
 
-  function findInAllFrames(query) {
-    let out = [];
-    document.querySelectorAll(query).forEach((node) => {
-      out.push(node);
-    });
-    Array.from(document.getElementsByTagName('iframe')).forEach((iframe) => {
-      try {
-        iframe.contentDocument.querySelectorAll(query).forEach((node) => {
-          out.push(node);
-        });
-      } catch (e) {
-        // pass on cross origin iframe errors
-      }
-    });
-    return out;
-  }
+function findInAllFrames(query) {
+  let out = [];
+  document.querySelectorAll(query).forEach((node) => {
+    out.push(node);
+  });
+  Array.from(document.getElementsByTagName('iframe')).forEach((iframe) => {
+    try {
+      iframe.contentDocument.querySelectorAll(query).forEach((node) => {
+        out.push(node);
+      });
+    } catch (e) {
+      // pass on cross origin iframe errors
+    }
+  });
+  return out;
+}
 
-  // remove all attributes from a link except for class and ARIA attributes
-  function cleanAttrs(elem) {
-    for (let i = elem.attributes.length - 1; i >= 0; --i) {
-      const attr = elem.attributes[i];
-      if (attr.name !== 'class' && !attr.name.startsWith('aria-')) {
-        elem.removeAttribute(attr.name);
-      }
+// remove all attributes from a link except for class and ARIA attributes
+function cleanAttrs(elem) {
+  for (let i = elem.attributes.length - 1; i >= 0; --i) {
+    const attr = elem.attributes[i];
+    if (attr.name !== 'class' && !attr.name.startsWith('aria-')) {
+      elem.removeAttribute(attr.name);
     }
   }
+}
 
-  // Remove excessive attributes and event listeners from link a and replace
-  // its destination with href
-  function cleanLink(a) {
-    let href = new URL(a.href).searchParams.get('u');
-    cleanAttrs(a);
-    a.href = href;
-    a.target = "_blank";
-    a.addEventListener("click", function (e) { e.stopPropagation(); }, true);
-    a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
-    a.addEventListener("mouseup", function (e) { e.stopPropagation(); }, true);
-    a.addEventListener("mouseover", function (e) { e.stopPropagation(); }, true);
-    a.addEventListener("mousewheel", function (e) { e.stopPropagation(); }, true);
-  }
+// Remove excessive attributes and event listeners from link a and replace
+// its destination with href
+function cleanLink(a) {
+  let href = new URL(a.href).searchParams.get('u');
+  cleanAttrs(a);
+  a.href = href;
+  a.target = "_blank";
+  a.addEventListener("click", function (e) { e.stopPropagation(); }, true);
+  a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
+  a.addEventListener("mouseup", function (e) { e.stopPropagation(); }, true);
+  a.addEventListener("mouseover", function (e) { e.stopPropagation(); }, true);
+  a.addEventListener("mousewheel", function (e) { e.stopPropagation(); }, true);
+}
 
-  // unwrap wrapped links in the original page
-  findInAllFrames(fb_wrapped_link).forEach((link) => {
-    cleanLink(link);
-  });
+// unwrap wrapped links in the original page
+findInAllFrames(fb_wrapped_link).forEach((link) => {
+  cleanLink(link);
+});
 
-  // Execute redirect unwrapping each time new content is added to the page
-  new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
-      if (mutation.addedNodes.length) {
-        for (let node of mutation.addedNodes) {
-          node.querySelectorAll(fb_wrapped_link).forEach((link) => {
-            cleanLink(link);
-          });
-        }
+// Execute redirect unwrapping each time new content is added to the page
+new MutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    if (mutation.addedNodes.length) {
+      for (let node of mutation.addedNodes) {
+        node.querySelectorAll(fb_wrapped_link).forEach((link) => {
+          cleanLink(link);
+        });
       }
-    })
-  }).observe(document.body, {childList: true, subtree: true, attributes: false, characterData: false});
+    }
+  });
+}).observe(document.body, {childList: true, subtree: true, attributes: false, characterData: false});
 }());

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -44,6 +44,7 @@ function cleanLink(a) {
   cleanAttrs(a);
   a.href = href;
   a.rel = "noopener";
+  a.target = "_blank";
   a.addEventListener("click", function (e) { e.stopPropagation(); }, true);
   a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
   a.addEventListener("mouseup", function (e) { e.stopPropagation(); }, true);

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -33,14 +33,21 @@ function cleanAttrs(elem) {
 // its destination with href
 function cleanLink(a) {
   let href = new URL(a.href).searchParams.get('u');
+
+  // from https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
+  let url_regex = new RegExp(/[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi);
+  if (!href || !href.match(url_regex)) {
+    // If we can't extract a good URL, abort without breaking the links
+    return;
+  }
+
   cleanAttrs(a);
   a.href = href;
-  a.target = "_blank";
+  a.rel = "noopener";
   a.addEventListener("click", function (e) { e.stopPropagation(); }, true);
   a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
   a.addEventListener("mouseup", function (e) { e.stopPropagation(); }, true);
   a.addEventListener("mouseover", function (e) { e.stopPropagation(); }, true);
-  a.addEventListener("mousewheel", function (e) { e.stopPropagation(); }, true);
 }
 
 // unwrap wrapped links in the original page
@@ -56,6 +63,9 @@ new MutationObserver(function(mutations) {
         node.querySelectorAll(fb_wrapped_link).forEach((link) => {
           cleanLink(link);
         });
+        if (node.matches(fb_wrapped_link)) {
+          cleanLink(node);
+        }
       }
     }
   });

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -43,7 +43,7 @@ function cleanLink(a) {
 
   cleanAttrs(a);
   a.href = href;
-  a.rel = "noopener";
+  a.rel = "noreferrer";
   a.target = "_blank";
   a.addEventListener("click", function (e) { e.stopPropagation(); }, true);
   a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
@@ -53,14 +53,15 @@ function cleanLink(a) {
 
 // Check all new nodes added by a mutation for tracking links and unwrap them
 function cleanMutation(mutation) {
-  if (mutation.addedNodes.length) {
-    for (let node of mutation.addedNodes) {
-      node.querySelectorAll(fb_wrapped_link).forEach((link) => {
-        cleanLink(link);
-      });
-      if (node.matches(fb_wrapped_link)) {
-        cleanLink(node);
-      }
+  if (!mutation.addedNodes.length) {
+    return;
+  }
+  for (let node of mutation.addedNodes) {
+    node.querySelectorAll(fb_wrapped_link).forEach((link) => {
+      cleanLink(link);
+    });
+    if (node.matches(fb_wrapped_link)) {
+      cleanLink(node);
     }
   }
 }

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -50,6 +50,21 @@ function cleanLink(a) {
   a.addEventListener("mouseover", function (e) { e.stopPropagation(); }, true);
 }
 
+// Check all new nodes added by a mutation for tracking links and unwrap them
+function cleanMutation(mutation) {
+  if (mutation.addedNodes.length) {
+    for (let node of mutation.addedNodes) {
+      node.querySelectorAll(fb_wrapped_link).forEach((link) => {
+        cleanLink(link);
+      });
+      if (node.matches(fb_wrapped_link)) {
+        cleanLink(node);
+      }
+    }
+  }
+}
+
+
 // unwrap wrapped links in the original page
 findInAllFrames(fb_wrapped_link).forEach((link) => {
   cleanLink(link);
@@ -57,17 +72,6 @@ findInAllFrames(fb_wrapped_link).forEach((link) => {
 
 // Execute redirect unwrapping each time new content is added to the page
 new MutationObserver(function(mutations) {
-  mutations.forEach(function(mutation) {
-    if (mutation.addedNodes.length) {
-      for (let node of mutation.addedNodes) {
-        node.querySelectorAll(fb_wrapped_link).forEach((link) => {
-          cleanLink(link);
-        });
-        if (node.matches(fb_wrapped_link)) {
-          cleanLink(node);
-        }
-      }
-    }
-  });
+  mutations.forEach(cleanMutation);
 }).observe(document.body, {childList: true, subtree: true, attributes: false, characterData: false});
 }());

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -35,7 +35,7 @@ function cleanLink(a) {
   let href = new URL(a.href).searchParams.get('u');
 
   // from https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
-  let url_regex = new RegExp(/[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi);
+  let url_regex = new RegExp(/[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?/gi);
   if (!href || !href.match(url_regex)) {
     // If we can't extract a good URL, abort without breaking the links
     return;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -56,6 +56,16 @@
     },
     {
       "js": [
+        "js/firstparties/facebook.js"
+      ],
+      "matches": [
+        "https://*.facebook.com/*",
+        "http://*.facebook.com/*"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "js": [
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",
         "js/contentscripts/dnt.js",


### PR DESCRIPTION
Add a first-party script to unwrap and remove click handlers from outgoing links on facebook.com. Addresses part of #85.

This has been tested in Chrome and Firefox desktop browsers. For the most part, it seems to prevent Facebook from learning about which non-sponsored links you click in your newsfeed. 

It's not perfect. For some reason, in Firefox, middle-clicking (with the mouse wheel) on a link still triggers an XHR to https://www.facebook.com/ajax/bz with a tracking payload (with data like `click_ref:[..."https://url-you-clicked.com"]`). I'm not sure where this is happening, since the script should block all bubbling event handlers attached to each `<a>` element and I've checked all the capturing onclick handlers on a typical link's parent elements. I've decided to stop pursuing it for a bit, but maybe someone else can take a crack. 

For now, I think it's a good start, and a good excuse to raise awareness both about Privacy Badger and about Facebook's massive data collection apparatus. Feedback welcomed.