### PR TITLE
Add akamaized.net to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -9,6 +9,7 @@ wwwimages.adobe.com
 xsdownload.adobe.com
 akamai.net
 akamaihd.net
+akamaized.net
 al.com
 alert60.com
 alexa.com


### PR DESCRIPTION
We're still getting quite a few error reports where Privacy Badger learned to block `akamaized.net` domains. We should try to reproduce tracking and generally figure out how this happens. Regardless, blocking `akamaized.net` breaks lots of sites.

Error report counts with blocked `akamaized.net` resources by date and site domain:
```
+---------+--------------------------+-------+
| ym      | fqdn                     | count |
+---------+--------------------------+-------+
| 2018-04 | www.msn.com              |    30 |
| 2018-04 | support.microsoft.com    |    18 |
| 2018-04 | www.microsoft.com        |    18 |
| 2018-04 | account.microsoft.com    |    15 |
| 2018-04 | answers.microsoft.com    |    15 |
| 2018-04 | support.office.com       |    14 |
| 2018-04 | products.office.com      |    13 |
| 2018-04 | www.themarysue.com       |    12 |
| 2018-04 | www.xbox.com             |    10 |
| 2018-04 | blogs.windows.com        |     9 |
| 2018-04 | na.op.gg                 |     9 |
| 2018-04 | worldofwarcraft.com      |     8 |
| 2018-04 | www.mediaite.com         |     8 |
| 2018-04 | onedrive.live.com        |     7 |
| 2018-04 | vimeo.com                |     7 |
| 2018-04 | www.freepik.com          |     7 |
| 2018-04 | www.standaard.be         |     7 |
| 2018-04 | cloudblogs.microsoft.com |     6 |
| 2018-04 | www.investing.com        |     6 |
| 2018-04 | www.olx.pl               |     6 |
| 2018-04 | www.sothebysrealty.com   |     6 |
| 2018-04 | www.twitch.tv            |     6 |
| 2018-04 | euw.op.gg                |     5 |
| 2018-04 | roosterteeth.com         |     5 |
| 2018-04 | account.live.com         |     4 |
| 2018-04 | urun.n11.com             |     4 |
| 2018-04 | www.office.com           |     4 |
| 2018-04 | www.olx.ro               |     4 |
| 2018-04 | www.op.gg                |     4 |
| 2018-04 | www.skype.com            |     4 |
| 2018-04 | www.visualstudio.com     |     4 |
| 2018-04 | msdn.microsoft.com       |     3 |
| 2018-04 | purchase.tickets.com     |     3 |
| 2018-04 | www.expressvpn.com       |     3 |
| 2018-04 | www.last.fm              |     3 |
| 2018-04 | www.limburger.nl         |     3 |
| 2018-04 | www.yesstyle.com         |     3 |
...
```

Previously: #1360.