### PR TITLE
Fix user-set domains in error reports

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -207,9 +207,20 @@ function send_error(message) {
 
     for (let origin in origins) {
       let action = origins[origin];
+
       if (!action) {
         action = constants.NO_TRACKING;
       }
+
+      // adjust action names for error reporting
+      if (action == constants.USER_ALLOW) {
+        action = "usernoaction";
+      } else if (action == constants.USER_BLOCK) {
+        action = "userblock";
+      } else if (action == constants.USER_COOKIE_BLOCK) {
+        action = "usercookieblock";
+      }
+
       if (out[action]) {
         out[action] += ","+origin;
       } else {


### PR DESCRIPTION
Broken somewhere in the following range: https://github.com/EFForg/privacybadger/compare/chrome-2016.4.13...chrome-2016.5.16, when we switched from `"userblock"`, etc. to `constants.USER_BLOCK` / `"user_block"` action names. `2016.4.13` is the last version in error reports to have non-NULL "user" field values.