### PR TITLE
Work around broken Italian locale popup in Chrome

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -18,19 +18,22 @@
  /*csslint ids:ignore*/
 
 body {
-  margin: 0;
-  min-width: 430px; /* Chrome */
-  max-width: 100%;  /* FF android */
-  font-size: 12px;
+  box-sizing: border-box;
+
   background: #fefefe;
   color: #333;
   font-family: helvetica, arial, sans-serif;
-  padding: 8px 15px 0;
-  box-sizing: border-box;
+  font-size: 12px;
+
+  margin: 0;
+  padding: 7px 15px 0;
+
+  min-width: 430px; /* Chrome */
+  max-width: 100%;  /* FF android */
   min-height: 270px;
 }
 @media screen and (min--moz-device-pixel-ratio:0) {
-    body{
+    body {
         min-width: 200px; /* FF android */
         width: 430px;     /* FF desktop */
     }


### PR DESCRIPTION
By reverting the CSS padding change from bc231ec1d24afbba97d07cf898266e51b406b337.

Fixes #1977.

Could you please check Android is still OK?