### PR TITLE
Add title as full URL atttribute for Twitter profile links

### DIFF
--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -14,7 +14,7 @@ function maybeAddNoreferrer(link) {
   link.rel = rel;
 }
 
-function getLinkAttribute(node, attribute) {
+function getLinkByAttribute(node, attribute) {
   let attr = node.getAttribute(attribute);
   if (attr && (attr.startsWith("https://") || attr.startsWith("http://"))) {
     return attr;
@@ -54,7 +54,7 @@ function findInAllFrames(query) {
 function unwrapTwitterURLsInTimeline() {
   // first iteration is needed to collect all links
   findInAllFrames(tcos_with_destination).forEach((link) => {
-    const attr = getLinkAttribute(link, full_url_attribute);
+    const attr = getLinkByAttribute(link, full_url_attribute);
     if (attr !== null) {
       fixes[link.href] = attr;
       // once we are here, we can also unwrap it directly, instead of iterating again later
@@ -73,7 +73,7 @@ function unwrapTwitterURLsInTimeline() {
 function unwrapSpecialTwitterURLs() {
   // unwrap profile links
   document.querySelectorAll(profile_links_tcos).forEach((link) => {
-    const attr = getLinkAttribute(link, full_url_attribute_profile);
+    const attr = getLinkByAttribute(link, full_url_attribute_profile);
     if (attr !== null) {
       unwrapTco(link, attr);
     }

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -1,8 +1,8 @@
-let query_param = 'data-expanded-url';
-let tcos_with_destination = getTCoSelectorWithDestination(query_param);
-let query_param_profile = "title";
-let profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(query_param_profile);
-let fixes = {};
+const query_param = 'data-expanded-url';
+const tcos_with_destination = getTCoSelectorWithDestination(query_param);
+const query_param_profile = "title";
+const profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(query_param_profile);
+const fixes = {};
 
 function getTCoSelectorWithDestination(attribute) {
   return "a[" + attribute + "][href^='https://t.co/'], a[" + attribute + "][href^='http://t.co/']";
@@ -54,7 +54,7 @@ function findInAllFrames(query) {
 function unwrapTwitterURLsInTimeline() {
   // first iteration is needed to collect all links
   findInAllFrames(tcos_with_destination).forEach((link) => {
-    let attr = getLinkAttribute(link, query_param);
+    const attr = getLinkAttribute(link, query_param);
     if (attr !== null) {
       fixes[link.href] = attr;
       // once we are here, we can also unwrap it directly, instead of iterating again later
@@ -73,7 +73,7 @@ function unwrapTwitterURLsInTimeline() {
 function unwrapSpecialTwitterURLs() {
   // unwrap profile links
   document.querySelectorAll(profile_links_tcos).forEach((link) => {
-    let attr = getLinkAttribute(link, query_param_profile);
+    const attr = getLinkAttribute(link, query_param_profile);
     if (attr !== null) {
       unwrapTco(link, attr);
     }

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -1,7 +1,7 @@
-const query_param = 'data-expanded-url';
-const tcos_with_destination = getTCoSelectorWithDestination(query_param);
-const query_param_profile = "title";
-const profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(query_param_profile);
+const full_url_attribute = 'data-expanded-url';
+const tcos_with_destination = getTCoSelectorWithDestination(full_url_attribute);
+const full_url_attribute_profile = "title";
+const profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(full_url_attribute_profile);
 const fixes = {};
 
 function getTCoSelectorWithDestination(attribute) {
@@ -54,7 +54,7 @@ function findInAllFrames(query) {
 function unwrapTwitterURLsInTimeline() {
   // first iteration is needed to collect all links
   findInAllFrames(tcos_with_destination).forEach((link) => {
-    const attr = getLinkAttribute(link, query_param);
+    const attr = getLinkAttribute(link, full_url_attribute);
     if (attr !== null) {
       fixes[link.href] = attr;
       // once we are here, we can also unwrap it directly, instead of iterating again later
@@ -73,7 +73,7 @@ function unwrapTwitterURLsInTimeline() {
 function unwrapSpecialTwitterURLs() {
   // unwrap profile links
   document.querySelectorAll(profile_links_tcos).forEach((link) => {
-    const attr = getLinkAttribute(link, query_param_profile);
+    const attr = getLinkAttribute(link, full_url_attribute_profile);
     if (attr !== null) {
       unwrapTco(link, attr);
     }

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -1,11 +1,26 @@
 let query_param = 'data-expanded-url';
-let tcos_with_destination = "a[" + query_param + "][href^='https://t.co/'], a[" + query_param + "][href^='http://t.co/']";
+let tcos_with_destination = getTCoSelectorWithDestination(query_param);
+let query_param_profile = "title";
+let profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(query_param_profile);
 let fixes = {};
+
+function getTCoSelectorWithDestination(attribute) {
+  return "a[" + attribute + "][href^='https://t.co/'], a[" + attribute + "][href^='http://t.co/']";
+}
 
 function maybeAddNoreferrer(link) {
   let rel = link.rel ? link.rel : "";
   if (!rel.includes("noreferrer")) {rel += " noreferrer";}
   link.rel = rel;
+}
+
+function getLinkAttribute(node, attribute) {
+  let attr = node.getAttribute(attribute);
+  if (attr && (attr.startsWith("https://") || attr.startsWith("http://"))) {
+    return attr;
+  }
+
+  return null;
 }
 
 function unwrapTco(tco, destination) {
@@ -36,14 +51,18 @@ function findInAllFrames(query) {
   return out;
 }
 
-function unwrapTwitterURLs() {
+function unwrapTwitterURLsInTimeline() {
+  // first iteration is needed to collect all links
   findInAllFrames(tcos_with_destination).forEach((link) => {
-    let attr = link.getAttribute(query_param);
-    if (attr && (attr.startsWith("https://") || attr.startsWith("http://"))) {
+    let attr = getLinkAttribute(link, query_param);
+    if (attr !== null) {
       fixes[link.href] = attr;
+      // once we are here, we can also unwrap it directly, instead of iterating again later
       unwrapTco(link, attr);
     }
   });
+
+  // iterate another time to actually replace the link (of Twitter cards, e.g.)
   findInAllFrames("a[href^='https://t.co/'], a[href^='http://t.co/'").forEach((link) => {
     if (fixes.hasOwnProperty(link.href)) {
       unwrapTco(link, fixes[link.href]);
@@ -51,5 +70,16 @@ function unwrapTwitterURLs() {
   });
 }
 
-unwrapTwitterURLs();
-setInterval(unwrapTwitterURLs, 2000);
+function unwrapSpecialTwitterURLs() {
+  // unwrap profile links
+  document.querySelectorAll(profile_links_tcos).forEach((link) => {
+    let attr = getLinkAttribute(link, query_param_profile);
+    if (attr !== null) {
+      unwrapTco(link, attr);
+    }
+  });
+}
+
+unwrapSpecialTwitterURLs();
+unwrapTwitterURLsInTimeline();
+setInterval(unwrapTwitterURLsInTimeline, 2000);


### PR DESCRIPTION
Fixes https://github.com/EFForg/privacybadger/issues/1426

![twitterprofile](https://user-images.githubusercontent.com/11966684/39880070-e65486c4-547c-11e8-8219-6abfc54ba389.png)

Some things I noticed as for the current implementation:
* I don't understand why you need two loops
* Also why is the selector query so specific if you filter out the elements later anyway?
* The above combined, this could easily be simplified into only one loop for all t.co elements
* Why does the query include **http**://t.co links? Does Twitter use them anywhere, anyway? AFAIK they are HTTPS-only for some time already, are not they?
   **Edit:** Saw https://github.com/EFForg/privacybadger/pull/1392#issuecomment-304400706, but don't know whether that is valid for profile links. Anyway, who cares… 

I read https://github.com/EFForg/privacybadger/pull/1392#issuecomment-307234848 and saw that you want to avoid `title` due to XSS issues. (Unfortunately I read it a bit late but huh… 😇)

So my implementation always prefers the expanded data thing attribute, and only falls back to the `title` if that is not possible (as in the twitter profile), and as it has been the case before, it checks that it is a valid HTTP/HTTPS URL, so I see no direct attack/XSS vector here.

As for this PR:
* I did not test it works when an URL is mentioned in the Twitter bio. Should I? (if so an example link would be nice – I want to avoid changing my bio because of that :laughing:)
* If the above XSS thing does not convince you, I could of course make it more specific to only target the "website" part in the bio, where hopefully Twitter verifies that users cannot put bad things into the `title` tag. (this change would of course be contrary to the previous point, so mhh… only one thing possible here)

BTW I plan to also do https://github.com/EFForg/privacybadger/issues/1886. If I've got nothing to do I could have a look at https://github.com/EFForg/privacybadger/issues/1651, but I'd need to signup on Tweetdeck for that and I also see that a PR is open anyway for that (but abandoned, as it seems).

/cc @cowlicks, @ghostwords 