### PR TITLE
Add basic anti-tracking to google.com

### DIFF
--- a/src/js/firstparties/google.js
+++ b/src/js/firstparties/google.js
@@ -1,0 +1,40 @@
+(function() {
+let g_wrapped_link = "a[onmousedown^='return rwt(this,']";
+
+function findInAllFrames(query) {
+  let out = [];
+  document.querySelectorAll(query).forEach((node) => {
+    out.push(node);
+  });
+  Array.from(document.getElementsByTagName('iframe')).forEach((iframe) => {
+    try {
+      iframe.contentDocument.querySelectorAll(query).forEach((node) => {
+        out.push(node);
+      });
+    } catch (e) {
+      // pass on cross origin iframe errors
+    }
+  });
+  return out;
+}
+
+// Remove excessive attributes and event listeners from link a
+function cleanLink(a) {
+  // remove all attributes from a link except for href
+  for (let i = elem.attributes.length - 1; i >= 0; --i) {
+    const attr = elem.attributes[i];
+    if (attr.name !== 'href') {
+      elem.removeAttribute(attr.name);
+    }
+  }
+  a.rel = "noreferrer";
+  a.addEventListener("click", function (e) { e.stopImmediatePropagation(); }, true);
+  a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
+}
+
+// unwrap wrapped links in the original page
+findInAllFrames(g_wrapped_link).forEach((link) => {
+  cleanLink(link);
+});
+
+}());

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -66,6 +66,16 @@
     },
     {
       "js": [
+        "js/firstparties/google.js"
+      ],
+      "matches": [
+        "https://*.google.com/*",
+        "http://*.google.com/*"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "js": [
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",
         "js/contentscripts/dnt.js",


### PR DESCRIPTION
Remove click and mousedown event listeners from vanilla search links on google.com. Does not apply to localized domains, or to any google sites other than web search.

Not ready for merge!