### PR TITLE
Add radikal.ru to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -473,6 +473,7 @@ checkout.razorpay.com
 razorpay.com
 rackcdn.com
 rackspacecloud.com
+radikal.ru
 rambler.ru
 images.rapgenius.com
 readability.com


### PR DESCRIPTION
Seems to be an image host.

Sample pages:
- https://legal-alien.ru/akuly-iz-stali/glava-i/vova
- http://kinozal.tv/details.php?id=1382038
- https://rutracker.org/forum/viewtopic.php?t=2645033
- http://u-uk.ru
- http://rutor.info/torrent/453066/evangelion-novogo-pokolenija_shinseiki-evangelion-26-iz-26-1996-hdrip-720p-ot-sdincorporation-mc-entertainment