### PR TITLE
Add dealerinspire.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -119,6 +119,7 @@ custhelp.com
 d3js.org
 dailymotion.com
 dealer.com
+dealerinspire.com
 delicious.com
 delvenetworks.com
 denverpost.com


### PR DESCRIPTION
Fixes #1500.

Sample sites:
- https://www.princetonlandrover.com
- https://www.landroveredison.com
- https://www.mbprinceton.com