### PR TITLE
Improve Facebook link unwrapping

### DIFF
--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -57,6 +57,10 @@ function cleanMutation(mutation) {
     return;
   }
   for (let node of mutation.addedNodes) {
+    // only element nodes have querySelectorAll
+    if (node.nodeType != Node.ELEMENT_NODE) {
+      continue;
+    }
     node.querySelectorAll(fb_wrapped_link).forEach((link) => {
       cleanLink(link);
     });

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -1,6 +1,6 @@
 // Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
 (function() {
-let fb_wrapped_link = "a[href*='facebook.com/l.php?'";
+let fb_wrapped_link = `a[href*='${document.domain}/l.php?'`;
 
 function findInAllFrames(query) {
   let out = [];

--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -45,10 +45,10 @@ function cleanLink(a) {
   a.href = href;
   a.rel = "noreferrer";
   a.target = "_blank";
-  a.addEventListener("click", function (e) { e.stopPropagation(); }, true);
-  a.addEventListener("mousedown", function (e) { e.stopPropagation(); }, true);
-  a.addEventListener("mouseup", function (e) { e.stopPropagation(); }, true);
-  a.addEventListener("mouseover", function (e) { e.stopPropagation(); }, true);
+  a.addEventListener("click", function (e) { e.stopImmediatePropagation(); }, true);
+  a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
+  a.addEventListener("mouseup", function (e) { e.stopImmediatePropagation(); }, true);
+  a.addEventListener("mouseover", function (e) { e.stopImmediatePropagation(); }, true);
 }
 
 // Check all new nodes added by a mutation for tracking links and unwrap them

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -60,7 +60,8 @@
       ],
       "matches": [
         "https://*.facebook.com/*",
-        "http://*.facebook.com/*"
+        "http://*.facebook.com/*",
+        "*://*.facebookcorewwwi.onion/*"
       ],
       "run_at": "document_idle"
     },


### PR DESCRIPTION
This addresses a few issues that have come up since we merged the feature. Some of the issues are pulled from https://github.com/mgziminsky/FacebookTrackingRemoval.

- StopPropagation calls are replaced by StopImmediatePropagation
- Only nodes of type ELEMENT_NODE are "cleaned"
- The unwrapping script now runs on Facebook's .onion domain as well

Closes #2012, closes #2014, closes #2018.