### PR TITLE
Error text stays when user clicks away

### DIFF
--- a/src/js/contentscripts/fingerprinting.js
+++ b/src/js/contentscripts/fingerprinting.js
@@ -80,7 +80,7 @@ function getFpPageScript() {
           detail: messages
         }));
 
-        // clear the queue 
+        // clear the queue
         messages = [];
       }, 100);
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -110,6 +110,17 @@ function init() {
   var overlay = $('#overlay');
   $("#error").on("click", function() {
     overlay.toggleClass('active');
+
+    $('#error_input').bind('input propertychange', function() {
+
+      // No easy way of sending message on popup close, send message for every change
+      chrome.runtime.sendMessage({
+        type: 'saveErrorText',
+        tabId: POPUP_DATA.tabId,
+        errorText: $("#error_input").val()
+      });
+    });
+
   });
   $("#report_cancel").on("click", function() {
     closeOverlay();
@@ -177,6 +188,11 @@ function closeOverlay() {
   $("#report_success").toggleClass("hidden", true);
   $("#report_fail").toggleClass("hidden", true);
   $("#error_input").val("");
+
+  chrome.runtime.sendMessage({
+    type: 'removeErrorText',
+    tabId: POPUP_DATA.tabId
+  });
 }
 
 /**
@@ -346,6 +362,12 @@ function registerToggleHandlers() {
  * @param {Integer} tabId The id of the tab
  */
 function refreshPopup() {
+  
+  //If there is any saved error text, fill the error input with it.
+  if (POPUP_DATA.hasOwnProperty('errorText')) {
+    $("#error_input").val(POPUP_DATA.errorText);
+  }
+
   // must be a special browser page,
   // or a page that loaded everything before our most recent initialization
   if (POPUP_DATA.noTabData) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -362,7 +362,7 @@ function registerToggleHandlers() {
  * @param {Integer} tabId The id of the tab
  */
 function refreshPopup() {
-  
+
   //If there is any saved error text, fill the error input with it.
   if (POPUP_DATA.hasOwnProperty('errorText')) {
     $("#error_input").val(POPUP_DATA.errorText);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -701,7 +701,14 @@ function dispatcher(request, sender, sendResponse) {
     let tab_id = request.tabId,
       tab_url = request.tabUrl,
       tab_host = window.extractHostFromURL(tab_url),
-      has_tab_data = badger.tabData.hasOwnProperty(tab_id);
+      has_tab_data = badger.tabData.hasOwnProperty(tab_id),
+      errorText = null;
+
+      if (has_tab_data) {
+        if (badger.tabData[tab_id].hasOwnProperty('errorText')) {
+          errorText = badger.tabData[tab_id].errorText;
+        }
+      }
 
     sendResponse({
       criticalError: badger.criticalError,
@@ -712,7 +719,8 @@ function dispatcher(request, sender, sendResponse) {
       tabHost: tab_host,
       tabId: tab_id,
       isPrivateWindow: incognito.tabIsIncognito(tab_id),
-      tabUrl: tab_url
+      tabUrl: tab_url,
+      errorText: errorText
     });
 
   } else if (request.type == "seenComic") {
@@ -776,6 +784,16 @@ function dispatcher(request, sender, sendResponse) {
     badger.storage.getBadgerStorageObject("action_map").deleteItem(request.origin);
 
     sendResponse();
+  } else if (request.type == "saveErrorText") {
+    let activeTab = badger.tabData[request.tabId];
+    activeTab.errorText = request.errorText;
+
+    sendResponse();
+  } else if (request.type == "removeErrorText") {
+    let activeTab = badger.tabData[request.tabId];
+    delete activeTab.errorText;
+
+    // sendResponse();
   }
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -704,11 +704,11 @@ function dispatcher(request, sender, sendResponse) {
       has_tab_data = badger.tabData.hasOwnProperty(tab_id),
       errorText = null;
 
-      if (has_tab_data) {
-        if (badger.tabData[tab_id].hasOwnProperty('errorText')) {
-          errorText = badger.tabData[tab_id].errorText;
-        }
+    if (has_tab_data) {
+      if (badger.tabData[tab_id].hasOwnProperty('errorText')) {
+        errorText = badger.tabData[tab_id].errorText;
       }
+    }
 
     sendResponse({
       criticalError: badger.criticalError,


### PR DESCRIPTION
This PR fixes https://github.com/EFForg/privacybadger/issues/1965 . I am however unable to create a successful selenium test and emulate the "clicking away" action with the test framework. 

Refreshing the window or closing & reopening creates new **window** and thus destroying the previous state apparently