### PR TITLE
Unwrap links at Twitter PWA

### DIFF
--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -2,7 +2,7 @@ const tcos_all = getTCoSelectorWithDestination();
 const timeline_refresh_interval = 2000;
 
 // twitter.com
-const full_url_attribute = 'data-expanded-url';
+const full_url_attribute = 'title';
 const tcos_with_destination = getTCoSelectorWithDestination(full_url_attribute);
 const full_url_attribute_profile = "title";
 const profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(full_url_attribute_profile);
@@ -91,6 +91,12 @@ function unwrapTwitterPwaURLsInTimeline() {
       unwrapTco(link, fixes[link.href]);
       return;
     }
+    
+    // use title, if possible
+    if (fixes.hasOwnProperty(link.href)) {
+      unwrapTco(link, fixes[link.href]);
+      return;
+    }
 
     // find span element with link text in it
     const allSpans = link.getElementsByTagName("span");
@@ -144,14 +150,9 @@ function unwrapSpecialTwitterPwaURLs() {
   }
 }
 
-if (window.location.hostname == "mobile.twitter.com") {
-  unwrapSpecialTwitterPwaURLs();
-  unwrapTwitterPwaURLsInTimeline();
+unwrapTwitterURLsInTimeline();
+unwrapSpecialTwitterPwaURLs();
+unwrapTwitterPwaURLsInTimeline();
 
-  setInterval(unwrapTwitterPwaURLsInTimeline, timeline_refresh_interval);
-} else {
-  unwrapTwitterURLsInTimeline();
-  unwrapSpecialTwitterURLs();
-
-  setInterval(unwrapTwitterURLsInTimeline, timeline_refresh_interval);
-}
+setInterval(unwrapTwitterURLsInTimeline, timeline_refresh_interval);
+setInterval(unwrapTwitterPwaURLsInTimeline, timeline_refresh_interval);

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -129,14 +129,9 @@ function unwrapSpecialTwitterURLs() {
 }
 
 function unwrapSpecialTwitterPwaURLs() {
-  // profile URL can be found in JSON of page
-  if (!window.wrappedJSObject) {
-    return;
-  }
-
   try {
     // iterate users object (usually should only be one, with some random ID?)
-    for (const entityKey of Object.keys(window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities)) {
+    for (const entityKey of Object.keys(window.__INITIAL_STATE__.entities.users.entities)) {
       const entityValue = window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities[entityKey];
       // iterate url array (usually only one)
       for (const url of entityValue.entities.url.urls) {
@@ -151,8 +146,9 @@ function unwrapSpecialTwitterPwaURLs() {
 }
 
 unwrapTwitterURLsInTimeline();
-unwrapSpecialTwitterPwaURLs();
 unwrapTwitterPwaURLsInTimeline();
 
+// only works at initial load if you directly load a profile
+unwrapSpecialTwitterPwaURLs();
+
 setInterval(unwrapTwitterURLsInTimeline, timeline_refresh_interval);
-setInterval(unwrapTwitterPwaURLsInTimeline, timeline_refresh_interval);

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -83,41 +83,6 @@ function unwrapTwitterURLsInTimeline() {
   });
 }
 
-function unwrapTwitterPwaURLsInTimeline() {
-  // unwrap profile links
-  document.querySelectorAll(tcos_all).forEach((link) => {
-    // use cached value if possible
-    if (fixes.hasOwnProperty(link.href)) {
-      unwrapTco(link, fixes[link.href]);
-      return;
-    }
-    
-    // use title, if possible
-    if (fixes.hasOwnProperty(link.href)) {
-      unwrapTco(link, fixes[link.href]);
-      return;
-    }
-
-    // find span element with link text in it
-    const allSpans = link.getElementsByTagName("span");
-    if (!allSpans.length) {
-      return;
-    }
-
-    const linkElement = allSpans[0];
-    const elements = link_reg_ex.exec(linkElement.textContent);
-    if (elements === null) {
-      return;
-    }
-
-    const url = elements[1];
-    if (url) {
-      fixes[link.href] = url;
-      unwrapTco(link, url);
-    }
-  });
-}
-
 function unwrapSpecialTwitterURLs() {
   // unwrap profile links
   document.querySelectorAll(profile_links_tcos).forEach((link) => {
@@ -146,7 +111,6 @@ function unwrapSpecialTwitterPwaURLs() {
 }
 
 unwrapTwitterURLsInTimeline();
-unwrapTwitterPwaURLsInTimeline();
 
 // only works at initial load if you directly load a profile
 unwrapSpecialTwitterPwaURLs();

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -4,11 +4,6 @@ const timeline_refresh_interval = 2000;
 // twitter.com
 const full_url_attribute = 'title';
 const tcos_with_destination = getTCoSelectorWithDestination(full_url_attribute);
-const full_url_attribute_profile = "title";
-const profile_links_tcos = ".ProfileHeaderCard " + getTCoSelectorWithDestination(full_url_attribute_profile);
-
-// mobile.twitter.com
-const link_reg_ex = /\(link: (https?:\/\/.+)\)/;
 
 const fixes = {};
 
@@ -83,20 +78,10 @@ function unwrapTwitterURLsInTimeline() {
   });
 }
 
-function unwrapSpecialTwitterURLs() {
-  // unwrap profile links
-  document.querySelectorAll(profile_links_tcos).forEach((link) => {
-    const attr = getLinkByAttribute(link, full_url_attribute_profile);
-    if (attr !== null) {
-      unwrapTco(link, attr);
-    }
-  });
-}
-
 function unwrapSpecialTwitterPwaURLs() {
   try {
     // iterate users object (usually should only be one, with some random ID?)
-    for (const entityKey of Object.keys(window.__INITIAL_STATE__.entities.users.entities)) {
+    for (const entityKey of Object.keys(window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities)) {
       const entityValue = window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities[entityKey];
       // iterate url array (usually only one)
       for (const url of entityValue.entities.url.urls) {

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -94,11 +94,11 @@ function unwrapTwitterPwaURLsInTimeline() {
 
     // find span element with link text in it
     const allSpans = link.getElementsByTagName("span");
-    if (!allSpans) {
+    if (!allSpans.length) {
       return;
     }
 
-    const linkElement = link.getElementsByTagName("span")[0];
+    const linkElement = allSpans[0];
     const elements = link_reg_ex.exec(linkElement.textContent);
     if (elements === null) {
       return;
@@ -124,6 +124,9 @@ function unwrapSpecialTwitterURLs() {
 
 function unwrapSpecialTwitterPwaURLs() {
   // profile URL can be found in JSON of page
+  if (!window.wrappedJSObject) {
+    return;
+  }
 
   try {
     // iterate users object (usually should only be one, with some random ID?)

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -1,5 +1,5 @@
 const tcos_all = getTCoSelectorWithDestination();
-const timeline_refresh_intervall = 2000;
+const timeline_refresh_interval = 2000;
 
 // twitter.com
 const full_url_attribute = 'data-expanded-url';
@@ -93,6 +93,11 @@ function unwrapTwitterPwaURLsInTimeline() {
     }
 
     // find span element with link text in it
+    const allSpans = link.getElementsByTagName("span");
+    if (!allSpans) {
+      return;
+    }
+
     const linkElement = link.getElementsByTagName("span")[0];
     const elements = link_reg_ex.exec(linkElement.textContent);
     if (elements === null) {
@@ -120,14 +125,19 @@ function unwrapSpecialTwitterURLs() {
 function unwrapSpecialTwitterPwaURLs() {
   // profile URL can be found in JSON of page
 
-  // iterate users object (usually should only be one, with some random ID?)
-  for (const entityKey of Object.keys(window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities)) {
-    const entityValue = window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities[entityKey];
-    // iterate url array (usually only one)
-    for (const url of entityValue.entities.url.urls) {
-      // save for later use (will be unwrapped later)
-      fixes[url.url] = url.expanded_url;
+  try {
+    // iterate users object (usually should only be one, with some random ID?)
+    for (const entityKey of Object.keys(window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities)) {
+      const entityValue = window.wrappedJSObject.__INITIAL_STATE__.entities.users.entities[entityKey];
+      // iterate url array (usually only one)
+      for (const url of entityValue.entities.url.urls) {
+        // save for later use (will be unwrapped later)
+        fixes[url.url] = url.expanded_url;
+      }
     }
+  } catch (e) {
+    // ignore errors and only log them when the JSON of Twitter should change
+    console.error(e);
   }
 }
 
@@ -135,10 +145,10 @@ if (window.location.hostname == "mobile.twitter.com") {
   unwrapSpecialTwitterPwaURLs();
   unwrapTwitterPwaURLsInTimeline();
 
-  setInterval(unwrapTwitterPwaURLsInTimeline, timeline_refresh_intervall);
+  setInterval(unwrapTwitterPwaURLsInTimeline, timeline_refresh_interval);
 } else {
   unwrapTwitterURLsInTimeline();
   unwrapSpecialTwitterURLs();
 
-  setInterval(unwrapTwitterURLsInTimeline, timeline_refresh_intervall);
+  setInterval(unwrapTwitterURLsInTimeline, timeline_refresh_interval);
 }

--- a/src/js/firstparties/twitter.js
+++ b/src/js/firstparties/twitter.js
@@ -92,8 +92,8 @@ function unwrapTwitterPwaURLsInTimeline() {
       return;
     }
 
-    // spans seem to be used for usual links, divs for links in Twitter Bio
-    const linkElement = link.getElementsByTagName("span")[0] || link.getElementsByTagName("div")[0];
+    // find span element with link text in it
+    const linkElement = link.getElementsByTagName("span")[0];
     const elements = link_reg_ex.exec(linkElement.textContent);
     if (elements === null) {
       return;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -50,7 +50,9 @@
       ],
       "matches": [
         "https://twitter.com/*",
-        "http://twitter.com/*"
+        "http://twitter.com/*",
+        "https://mobile.twitter.com/*",
+        "http://mobile.twitter.com/*"
       ],
       "run_at": "document_idle"
     },


### PR DESCRIPTION
Fixes https://github.com/EFForg/privacybadger/issues/1886

It expands links in the timeline and user bio/profile.

Does not include support for Twitter cards, because I just could not find the URL anywhere in the page. (At least not in the HTML part.)

It may only expand twitter cards, if the link has been used on some other part of the page, but that is not very likely.