### PR TITLE
Add all of openstreetmap.org to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -439,6 +439,7 @@ openload.co
 nominatim.openstreetmap.org
 tile.openstreetmap.fr
 tile.openstreetmap.org
+www.openstreetmap.org
 optimizely.com
 oregonlive.com
 outlook.com

--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -436,10 +436,8 @@ tile2.opencyclemap.org
 openlayers.org
 openlibrary.org
 openload.co
-nominatim.openstreetmap.org
 tile.openstreetmap.fr
-tile.openstreetmap.org
-www.openstreetmap.org
+openstreetmap.org
 optimizely.com
 oregonlive.com
 outlook.com


### PR DESCRIPTION
Prompted by https://github.com/EFForg/privacybadger/issues/2065#issuecomment-397050689.

Fixes #2090.

Error report counts by date and exact blocked "openstreetmap" subdomain:
```
+---------+-------------------------+-------------------------+-------+
| ym      | blocked_fqdn            | fqdn                    | count |
+---------+-------------------------+-------------------------+-------+
| 2018-06 | www.openstreetmap.org   | cccfr.de                |     1 |
| 2018-05 | www.openstreetmap.org   | garmin.openstreetmap.nl |     1 |
| 2018-04 | www.openstreetmap.org   | hdyc.neis-one.org       |     1 |
| 2018-03 | www.openstreetmap.org   | garmin.openstreetmap.nl |     1 |
| 2018-03 | www.openstreetmap.org   | www.openstreetcam.org   |     1 |
| 2018-02 | www.openstreetmap.org   | garmin.openstreetmap.nl |     1 |
| 2018-02 | www.openstreetmap.org   | hdyc.neis-one.org       |     1 |
| 2018-01 | www.openstreetmap.org   | db-ip.com               |     1 |
...
```