### PR TITLE
Add schibsted.com and schibsted.io to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -495,6 +495,9 @@ salsalabs.com
 sbnation.com
 schd.ws
 sched.org
+schibsted.com
+schibsted.io
+faast.schibsted.io
 scribd.com
 scribdassets.com
 securesuite.co.uk


### PR DESCRIPTION
As pointed out on the follow issue, requesting this two domains to be added to the yellowlist.

Fixes #2069.

schibsted.com
schibsted.io