### PR TITLE
add www.twisto.cz to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -569,6 +569,9 @@ ttvnw.net
 tumblr.com
 turner.com
 twimg.com
+api.twisto.cz
+static.twisto.cz
+api.twisto.pl
 twitch.tv
 twitter.com
 platform.twitter.com


### PR DESCRIPTION
Twisto.cz is payment method like a Klarna, privacybadger currently block the JavaScript and completely break the payment functionality