### PR TITLE
Remove unconditional waiting support from load_url

### DIFF
--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -2,6 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 import json
+import time
 import unittest
 
 import pbtest
@@ -176,6 +177,10 @@ class DNTTest(pbtest.PBSeleniumTest):
         # where X is the number of cookies it got
         # MEGAHACK: make sha1 of "cookies=0" a valid DNT hash
         self.load_url(self.bg_url)
+        # wait for DNT hash update to complete
+        # so that it doesn't overwrite our change below
+        # TODO wait conditionally
+        time.sleep(1)
         self.js("""badger.storage.updateDNTHashes(
 { "cookies=0 test policy": "f63ee614ebd77f8634b92633c6bb809a64b9a3d7" });""")
 

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -88,7 +88,7 @@ class DNTTest(pbtest.PBSeleniumTest):
 }}());""".format(DNT_DOMAIN)
 
         # mark a DNT-compliant domain for blocking
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
         self.js(BLOCK_DOMAIN_JS)
 
         # need to keep Badger's background page open for our changes to persist
@@ -152,7 +152,7 @@ class DNTTest(pbtest.PBSeleniumTest):
             "No cookies again")
 
         # perform a DNT policy check
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
         self.js(CHECK_FOR_DNT_POLICY_JS.format(TEST_DOMAIN))
         # wait until checkForDNTPolicy completed
         self.wait_for_script("return window.DNT_CHECK_RESULT === false")
@@ -175,7 +175,7 @@ class DNTTest(pbtest.PBSeleniumTest):
         # the DNT policy URL used by this test returns "cookies=X"
         # where X is the number of cookies it got
         # MEGAHACK: make sha1 of "cookies=0" a valid DNT hash
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
         self.js("""badger.storage.updateDNTHashes(
 { "cookies=0 test policy": "f63ee614ebd77f8634b92633c6bb809a64b9a3d7" });""")
 
@@ -197,7 +197,7 @@ class DNTTest(pbtest.PBSeleniumTest):
         NON_TRACKING_DOMAIN = "dnt-test.trackersimulator.org"
 
         # open Badger's background page
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
 
         # need to keep Badger's background page open to record what's happening
         # so, open and switch to a new window

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -45,7 +45,7 @@ return (
         FINGERPRINTING_DOMAIN = "cdn.jsdelivr.net"
 
         # open Badger's background page
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
 
         # need to keep Badger's background page open for tabData to persist
         # so, open and switch to a new window

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -36,6 +36,8 @@ return (
     map[tracker_origin].indexOf(site_origin) != -1
 );""".format(domain, page_url))
 
+    # TODO can fail because our content script runs too late: https://crbug.com/478183
+    @pbtest.repeat_if_failed(3)
     def test_canvas_fingerprinting_detection(self):
         PAGE_URL = (
             "https://cdn.rawgit.com/ghostwords"

--- a/tests/selenium/localstorage_test.py
+++ b/tests/selenium/localstorage_test.py
@@ -41,20 +41,20 @@ class LocalStorageTest(pbtest.PBSeleniumTest):
             self.assertEqual(PB_POLICY_HASH_LEN, len(policy_hash))
 
     def test_should_init_local_storage_entries(self):
-        self.load_url(self.bg_url, wait_on_site=3)
-        js = self.js
+        self.load_url(self.bg_url)
+
         self.check_policy_download()
-        self.assertEqual(js("return constants.YELLOWLIST_URL"),
+        self.assertEqual(self.js("return constants.YELLOWLIST_URL"),
                          "https://www.eff.org/files/cookieblocklist_new.txt")
 
         get_disabled_sites = "return (badger.storage.getBadgerStorageObject("\
             "'settings_map').getItem('disabledSites'))"
-        disabled_sites = js(get_disabled_sites)
+        disabled_sites = self.js(get_disabled_sites)
 
         self.assertFalse(len(disabled_sites),
                          "Shouldn't have any disabledSites after installation")
         
-        self.assertTrue(js("return (badger.storage.getBadgerStorageObject("\
+        self.assertTrue(self.js("return (badger.storage.getBadgerStorageObject("\
             "'settings_map').getItem('checkForDNTPolicy'))"),
             "Should start with DNT policy enabled")
         # TODO: do we expect currentVersion to be present after the first run?

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -31,8 +31,7 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
             pass
 
     def load_options_page(self):
-        self.load_url(self.bg_url)  # load a dummy page
-        self.load_url(self.options_url, wait_on_site=1)
+        self.load_url(self.options_url)
 
     def add_test_origin(self, origin, action):
         """Add given origin to backend storage."""

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -297,7 +297,7 @@ class PBSeleniumTest(unittest.TestCase):
         self.js('window.open()')
         self.driver.switch_to.window(self.driver.window_handles[-1])
 
-    def load_url(self, url, wait_on_site=0, wait_for_body_text=False, retries=5):
+    def load_url(self, url, wait_for_body_text=False, retries=5):
         """Load a URL and wait before returning."""
         for i in range(retries):
             try:
@@ -320,8 +320,6 @@ class PBSeleniumTest(unittest.TestCase):
                 lambda: self.driver.find_element_by_tag_name('body').text,
                 msg="Waiting for document.body.textContent to get populated ..."
             )
-
-        time.sleep(wait_on_site)
 
     def txt_by_css(self, css_selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         """Find an element by CSS selector and return its text."""

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -52,6 +52,8 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.open_window()
 
         self.load_url(self.popup_url)
+        # TODO replace with conditional, poll-based wait for popup being fully displayed
+        time.sleep(1)
 
         # hack to get tabData populated for the popup's tab
         # to get the popup shown for regular pages

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -51,7 +51,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         # Chrome where popup.js will keep thinking it is on popup.html.
         self.open_window()
 
-        self.load_url(self.popup_url, wait_on_site=1)
+        self.load_url(self.popup_url)
 
         # hack to get tabData populated for the popup's tab
         # to get the popup shown for regular pages
@@ -215,7 +215,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.js("$('#block-{}').click()".format(DOMAIN_ID))
 
         # retrieve the new action
-        self.load_url(self.options_url, wait_on_site=1)
+        self.load_url(self.options_url)
         new_action = get_domain_slider_state(self.driver, DOMAIN)
 
         self.assertEqual(new_action, "block",
@@ -235,7 +235,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.js("$('#block-{}').click()".format(DOMAIN_ID))
 
         # retrieve the new action
-        self.load_url(self.options_url, wait_on_site=1)
+        self.load_url(self.options_url)
         new_action = get_domain_slider_state(self.driver, DOMAIN)
 
         self.assertEqual(new_action, "block",
@@ -248,7 +248,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         DOMAIN_ID = DOMAIN.replace(".", "-")
 
         # record the domain as cookieblocked by Badger
-        self.load_url(self.options_url, wait_on_site=1)
+        self.load_url(self.options_url)
         self.js("badger.storage.setupHeuristicAction('{}', '{}');".format(
             DOMAIN, "cookieblock"))
 
@@ -272,7 +272,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.driver.switch_to.window(self.driver.window_handles[0])
 
         # verify the domain is no longer user controlled
-        self.load_url(self.options_url, wait_on_site=1)
+        self.load_url(self.options_url)
 
         # assert the action is not what we manually clicked
         action = get_domain_slider_state(self.driver, DOMAIN)

--- a/tests/selenium/qunit_test.py
+++ b/tests/selenium/qunit_test.py
@@ -2,18 +2,15 @@
 # -*- coding: UTF-8 -*-
 
 import unittest
+
 import pbtest
+
 from selenium.common.exceptions import TimeoutException
 
 
 class Test(pbtest.PBSeleniumTest):
 
     def test_run_qunit_tests(self):
-        # First load a dummy URL to make sure the extension is activated.
-        # Otherwise, we ran into a race condition where Qunit runs (& fails)
-        # while chrome.extension is undefined.
-        # Probably related to Chromium bugs 129181 & 132148
-        self.load_url(self.bg_url)
         self.load_url(self.test_url)
 
         try:

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -13,7 +13,7 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
     """Make sure we detect potential supercookies. """
 
     def detected_tracking_by(self, origin):
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
 
         CHECK_SNITCH_MAP_JS = """return (
   badger.storage.getBadgerStorageObject('snitch_map')
@@ -58,8 +58,7 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
 
         Perhaps related to: https://github.com/ghostwords/chameleon/issues/5
         """
-        self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html",  # noqa
-                      wait_on_site=1)
+        self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html")
         self.driver.refresh()
         time.sleep(1)
         self.assertTrue(self.detected_tracking_by("githack.com"))
@@ -68,14 +67,16 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         self.load_url(
             "https://gistcdn.githack.com/gunesacar"
             "/6f0c39fb728a218ccd91215bfefbd4e0/raw/f438eb4e5ce10dc8623a8834b1298fd4a846c6fa"
-            "/low_entropy_localstorage_from_third_party_script.html",
-            wait_on_site=2)
-
+            "/low_entropy_localstorage_from_third_party_script.html"
+        )
+        self.driver.refresh()
+        time.sleep(3)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_first_party_ls(self):
-        self.load_url("https://gistcdn.githack.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html",  # noqa
-                      wait_on_site=2)
+        self.load_url("https://gistcdn.githack.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html")
+        self.driver.refresh()
+        time.sleep(3)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_ls_of_third_party_script(self):
@@ -83,8 +84,10 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         self.load_url(
             "https://rawgit.com/gunesacar"
             "/b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11"
-            "/localstorage_from_third_party_script.html",
-            wait_on_site=2)
+            "/localstorage_from_third_party_script.html"
+        )
+        self.driver.refresh()
+        time.sleep(3)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
 

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -49,19 +49,18 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
         self.assertFalse(self.detected_tracking_by("raw.githubusercontent.com"),
             msg="Image is not a tracker but was flagged as one.")
 
-    @pbtest.repeat_if_failed(5)
     def test_should_detect_ls_of_third_party_frame(self):
-        """We get some intermittent failures for this test.
+        # TODO We get some intermittent failures for this test.
 
-        It seems we sometimes miss the setting of localStorage items,
-        perhaps because the script runs before we start intercepting the calls.
+        # It seems we sometimes miss the setting of localStorage items,
+        # perhaps because the script runs before we start intercepting the calls.
 
-        Perhaps related to: https://github.com/ghostwords/chameleon/issues/5
-        """
+        # Perhaps related to: https://github.com/ghostwords/chameleon/issues/5
         self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html")
-        self.driver.refresh()
+        # TODO might also be related to https://github.com/EFForg/privacybadger/pull/1522
         time.sleep(1)
-        self.assertTrue(self.detected_tracking_by("githack.com"))
+        self.assertTrue(pbtest.retry_until(
+            partial(self.detected_tracking_by, "githack.com"), times=2))
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):
         self.load_url(
@@ -69,14 +68,12 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
             "/6f0c39fb728a218ccd91215bfefbd4e0/raw/f438eb4e5ce10dc8623a8834b1298fd4a846c6fa"
             "/low_entropy_localstorage_from_third_party_script.html"
         )
-        self.driver.refresh()
-        time.sleep(3)
+        time.sleep(4)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_first_party_ls(self):
         self.load_url("https://gistcdn.githack.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html")
-        self.driver.refresh()
-        time.sleep(3)
+        time.sleep(4)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_ls_of_third_party_script(self):
@@ -86,8 +83,7 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
             "/b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11"
             "/localstorage_from_third_party_script.html"
         )
-        self.driver.refresh()
-        time.sleep(3)
+        time.sleep(4)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
 

--- a/tests/selenium/surrogates_test.py
+++ b/tests/selenium/surrogates_test.py
@@ -33,7 +33,7 @@ class Test(pbtest.PBSeleniumTest):
 
     def test_ga_js_surrogate(self):
         # open the background page
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
 
         # verify the surrogate is present
         self.assertTrue(self.js(
@@ -48,7 +48,7 @@ class Test(pbtest.PBSeleniumTest):
         )
 
         # block ga.js (known to break the site)
-        self.load_url(self.bg_url, wait_on_site=1)
+        self.load_url(self.bg_url)
         # also back up the surrogate definition before removing it
         ga_backup = self.js(
             "badger.heuristicBlocking.blacklistOrigin('www.google-analytics.com', 'google-analytics.com');"


### PR DESCRIPTION
Should be replaced as necessary with conditional, poll-based waits for specific requirements (an element is visible, a JavaScript statement evals to true, ...).

Closes #2073.