### PR TITLE
Add OSF and its preprint services

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -593,6 +593,7 @@ var multiDomainFirstPartiesArray = [
   ],
   ["onlineatnsb.com", "norwaysavingsbank.com"],
   ["openstreetmap.org", "osmfoundation.org"],
+  ["osf.io", "api.osf.io", "agrixiv.org", "arabixiv.org", "eartharxiv.org", "ecsarxiv.org", "engrxiv.org", "frenxiv.org", "marxiv.org", "mindrxiv.org", "paleorxiv.org", "psyarxiv.com", "thesiscommons.org"],
   ["paypal.com", "paypal-search.com"],
   ["pcworld.com", "staticworld.net", "idg.com", "idg.net", "infoworld.com", "macworld.com", "techhive.com", "idg.tv"],
   ["pepco.com", "pepcoholdings.com"],


### PR DESCRIPTION
This PR adds OSF and its associated preprint services to the list of MDFPs. 

I've added osf.io and api.osf.io separately, though perhaps api.osf.io is unnecessary because osf.io covers both? 

Also, please forgive me for not running ESLint - I'm not actually a developer, and I'm (embarrassingly) editing on github in the browser. But, I'm reasonably confident in this one ;)

Closes #2085