### PR TITLE
Update DNT policy checking checkbox label text

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -24,7 +24,7 @@
         "description": ""
     },
     "options_dnt_policy_setting": {
-        "message": "Check if sites comply with EFF's Do Not Track policy",
+        "message": "Check if external domains comply with <a target='_blank' href='https://www.eff.org/dnt-policy'>EFF's Do Not Track policy</a>",
         "description": "Checkbox label on the general settings page"
     },
     "intro_learns_paragraph": {
@@ -53,10 +53,6 @@
     },
     "dnt_tooltip": {
         "message": "This domain promises to not track you",
-        "description": ""
-    },
-    "options_dnt_policy_learn_more": {
-        "message": "Learn more",
         "description": ""
     },
     "next_section": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -24,7 +24,7 @@
         "description": ""
     },
     "options_dnt_policy_setting": {
-        "message": "Check if external domains comply with <a target='_blank' href='https://www.eff.org/dnt-policy'>EFF's Do Not Track policy</a>",
+        "message": "Check if <a target='_blank' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>third-party domains</a> comply with <a target='_blank' href='https://www.eff.org/dnt-policy'>EFF's Do Not Track policy</a>",
         "description": "Checkbox label on the general settings page"
     },
     "intro_learns_paragraph": {

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -161,7 +161,6 @@
           <input type="checkbox" id="check_dnt_policy_checkbox">
           <span class="i18n_options_dnt_policy_setting"></span>
         </label>
-        <a target="_blank" href="https://www.eff.org/dnt-policy"><span class="i18n_options_dnt_policy_learn_more"></span></a>
       </div>
       <div class="checkbox" id="webRTCToggle">
         <label>


### PR DESCRIPTION
Follows up on #2089.

Replaces "sites" with "external domains" for clarity.

Removes the "learn more" link and links the words directly for consistency.

Current text:
![screenshot from 2018-07-11 12 54 48](https://user-images.githubusercontent.com/794578/42587764-b95ee098-8509-11e8-9260-d5e0ddb5a07f.png)

Proposed update:
![screenshot from 2018-07-11 12 55 24](https://user-images.githubusercontent.com/794578/42587769-bc8180aa-8509-11e8-983b-bb84049e1c89.png)