### PR TITLE
Use i18n placeholders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,8 @@ upload:
 lint:
 	./node_modules/.bin/eslint .
 
-.PHONY: build travisbuild updatepsl zip crx todo logging lint
+tx:
+	tx pull -f
+	scripts/fix_placeholders.py
+
+.PHONY: build travisbuild updatepsl zip crx todo logging lint tx

--- a/scripts/fix_placeholders.py
+++ b/scripts/fix_placeholders.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import json
+
+from collections import OrderedDict
+from glob import glob
+
+SOURCE_LOCALE = 'src/_locales/en_US/messages.json'
+
+
+def fix_locale(locale, placeholder_keys):
+    # read in locale, preserving existing ordering
+    with open(locale, 'r') as f:
+        data = json.load(f, object_pairs_hook=OrderedDict)
+
+    # restore missing placeholders
+    for key in placeholder_keys:
+        if key in data and "placeholders" not in data[key]:
+            data[key]["placeholders"] = source_data[key]["placeholders"]
+
+    with open(locale, 'w') as f:
+        json.dump(data, f, ensure_ascii=False, indent=4)
+
+
+if __name__ == '__main__':
+    with open(SOURCE_LOCALE, 'r') as f:
+        source_data = json.load(f)
+
+    # get keys of locale messages with placeholders
+    placeholder_keys = []
+    for key in source_data:
+        if "placeholders" in source_data[key]:
+            placeholder_keys.append(key)
+
+    # fix all locales
+    for locale in glob('src/_locales/*/*.json'):
+        if locale == SOURCE_LOCALE:
+            continue
+
+        fix_locale(locale, placeholder_keys)

--- a/scripts/fix_placeholders.py
+++ b/scripts/fix_placeholders.py
@@ -24,7 +24,7 @@ def fix_locale(locale, placeholder_keys):
 
 if __name__ == '__main__':
     with open(SOURCE_LOCALE, 'r') as f:
-        source_data = json.load(f)
+        source_data = json.load(f, object_pairs_hook=OrderedDict)
 
     # get keys of locale messages with placeholders
     placeholder_keys = []

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Блокирах ",
-        "description": ""
+        "message": "Блокирах $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Невалиден JSON файл.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Няма преследвачи в ",
-        "description": ""
+        "message": "Няма преследвачи в $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Засега Privacy Badger проверява само дали трети страни ползват бисквитки, локалната памет на HTML5, или canvas fingerprinting, за да те следят. Някои от тези домейни може би използват други начини за следене, които Privacy Badger не може да засече.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Разреших ",
-        "description": ""
+        "message": "Разреших $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Какво е Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Блокирах бисквитки от ",
-        "description": ""
+        "message": "Блокирах бисквитки от $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Зареждам...",

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "потенциални <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>преследвачи</a> на тази страница. С тези плъзгачи можеш да контролираш как Privacy Badger се държи с всеки от тях. Не е необходимо да ги местиш, освен ако нещо не се е развалило.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger откри $COUNT$ потенциални $TRACKER_LINK_START$преследвачи$TRACKER_LINK_END$ на тази страница. С тези плъзгачи можеш да контролираш как Privacy Badger се държи с всеки от тях. Не е необходимо да ги местиш, освен ако нещо не се е развалило.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "блокирани",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger откри",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Един проект на Electronic Frontier Foundation",

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -208,10 +208,6 @@
         "message": "Настройки на Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger е открил",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Това ще изпрати следната информация автоматично на EFF: сайтът, който в момента посещаваш, версията на браузера ти, версията на Privacy Badger, и състоянието на всички плъзгачи за този сайт.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "потенциални <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>домейни-преследвачи</a> засега. С тези плъзгачи можеш да контролираш как Privacy Badger се държи с всеки от тях.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger е открил $COUNT$ потенциални $TRACKER_LINK_START$домейни-преследвачи$TRACKER_LINK_END$ засега. С тези плъзгачи можеш да контролираш как Privacy Badger се държи с всеки от тях.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger замени този ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger замени този $BUTTON$ бутон.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Блокирах ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger е открил",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " бутон.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Това ще изпрати следната информация автоматично на EFF: сайтът, който в момента посещаваш, версията на браузера ти, версията на Privacy Badger, и състоянието на всички плъзгачи за този сайт.",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger nahradil toto ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger nahradil toto $BUTTON$ tlačítko.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blokováno ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger do této doby detekoval",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " tlačítko.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Následující informace budou automaticky odeslány do EFF: stránka na které se nacházíte, verze vašeho prohlížeče, verze Privacy Badger a nastavení všech posuvníků pro tuto stránku.",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -208,10 +208,6 @@
         "message": "Nastavení Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger do této doby detekoval",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Následující informace budou automaticky odeslány do EFF: stránka na které se nacházíte, verze vašeho prohlížeče, verze Privacy Badger a nastavení všech posuvníků pro tuto stránku.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "možných <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>sledovacích prvků</a>. Tyto posuvníky umožňují nastavit, jak Privacy Badger naloží s jednotlivými sledovacími prvky.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger do této doby detekoval $COUNT$ možných $TRACKER_LINK_START$sledovacích prvků$TRACKER_LINK_END$. Tyto posuvníky umožňují nastavit, jak Privacy Badger naloží s jednotlivými sledovacími prvky.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blokováno ",
-        "description": ""
+        "message": "Blokováno $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Neplatný soubor JSON.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Žádné sledovací prvky pro ",
-        "description": ""
+        "message": "Žádné sledovací prvky pro $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "V současnosti kontroluje Privacy Badger pouze soubory cookies třetích stran, lokální úložiště HTML5 a canvas fingerprinting, jestli nesledují vaše procházení. Některé domény mohou používat metody, které Privacy Badger prozatím nedokáže detekovat.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Povoleno ",
-        "description": ""
+        "message": "Povoleno $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Co je to Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blokovány soubory cookies od ",
-        "description": ""
+        "message": "Blokovány soubory cookies od $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Načítání...",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "možných <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>sledovacích prvků</a> na této webové stránce. Tyto posuvník umožňují nastavit, jak s nimi Privacy Badger naloží. Není nutné cokoliv měnit, jestliže je vše v pořádku.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger objevil $COUNT$ možných $TRACKER_LINK_START$sledovacích prvků$TRACKER_LINK_END$ na této webové stránce. Tyto posuvník umožňují nastavit, jak s nimi Privacy Badger naloží. Není nutné cokoliv měnit, jestliže je vše v pořádku.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "blokované",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger objevil",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Projekt Electronic Frontier Foundation",

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -208,10 +208,6 @@
         "message": "Privacy Badger Indstillinger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger har opdaget",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Dette vil automatisk sende følgende informationer til EFF: netstedet du besøger nu, din netlæsers version, Privacy Badgers version, og indstillingerne for alle skyderne for dette netsted.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potentielle <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>sporingsdomæner</a> indtil nu. Disse skydere lader dig styre hvordan Privacy Badger håndterer hver sporing.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger har opdaget $COUNT$ potentielle $TRACKER_LINK_START$sporingsdomæner$TRACKER_LINK_END$ indtil nu. Disse skydere lader dig styre hvordan Privacy Badger håndterer hver sporing.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potentielle <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>sporinger</a> på denne side. Disse skydere lader dig styre hvordan Privacy Badger håndterer hver især. Du burde ikke have nødigt at justere dem medmindre noget er i stykker.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger opdagede $COUNT$ potentielle $TRACKER_LINK_START$sporinger$TRACKER_LINK_END$ på denne side. Disse skydere lader dig styre hvordan Privacy Badger håndterer hver især. Du burde ikke have nødigt at justere dem medmindre noget er i stykker.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "blokeret",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger er deaktiveret på de følgende steder. Det betyder at Privacy Badger ikke vil blokere noget når du besøger stederne listet her. <br><br>Hvis du tror Privacy Badger ødelægger en side, kan du skrive sidens domæne i feltet nedenunder og klikke på knappen \"Tilføj domæne\".<br><br>Alternativt, når du allerede har sidens faneblad valgt, kan du blot klikke på Privacy Badgers knap i browserens værktøjslinje, og derefter klikke på knappen \"Deaktiver\".",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger opdagede",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Et projekt fra Electronic Frontier Foundation",

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger har erstattet denne ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger har erstattet denne $BUTTON$ knap.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blokerede ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger har opdaget",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " knap.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Dette vil automatisk sende følgende informationer til EFF: netstedet du besøger nu, din netlæsers version, Privacy Badgers version, og indstillingerne for alle skyderne for dette netsted.",

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blokerede ",
-        "description": ""
+        "message": "Blokerede $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Ugyldig JSON-fil.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Ingen sporing fra ",
-        "description": ""
+        "message": "Ingen sporing fra $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "I øjeblikket tjekker Privacy Badger kun om tredjeparter bruger cookies, HTML5 lokal lagring, eller kanvasfingeraftryk til at spore din netlæsning. Nogle af disse domæner kan bruge sporingsmetoder som Privacy Badger ikke kan opdage.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Tillod ",
-        "description": ""
+        "message": "Tillod $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Hvad er Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blokerede cookies fra ",
-        "description": ""
+        "message": "Blokerede cookies fra $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Indlæser...",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potenzielle <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>Tracker</a> auf dieser Seite erkannt. Mittels der Schieberegler können Sie steuern, wie Privacy Badger die einzelnen gefundenen Tracker handhabt. Sofern keine Probleme bei der Darstellung dieser Webseite aufgetreten sind, sollte es nicht nötig sein, die Schieberegler anzupassen.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger hat bisher $COUNT$ potenzielle $TRACKER_LINK_START$Tracker$TRACKER_LINK_END$ auf dieser Seite erkannt. Mittels der Schieberegler können Sie steuern, wie Privacy Badger die einzelnen gefundenen Tracker handhabt. Sofern keine Probleme bei der Darstellung dieser Webseite aufgetreten sind, sollte es nicht nötig sein, die Schieberegler anzupassen.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "geblockt",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger ist für die nachfolgenden Sites deaktiviert. Privacy Badger wird also nichts blocken, wenn Sie die hier aufgeführten Websites besuchen.<br><br>Falls Sie annehmen, dass aufgrund Privacy Badger eine Seite falsch dargestellt wird, so können Sie die Domain dieser Seite in dem Feld unten eingeben und auf die Schaltfläche »Domain hinzufügen« klicken.<br><br>Falls Sie den Tab der Seite bereits ausgewählt haben, so können Sie aber auch einfach auf Privacy Badgers Schaltfläche in der Browsersymbolleiste und dann dort auf die Schaltfäche »Deaktivieren« klicken.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger hat bisher",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Ein Projekt der Electronic Frontier Foundation",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Geblockt",
-        "description": ""
+        "message": "Geblockt $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Ungültige JSON-Datei.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Kein Tracking für",
-        "description": ""
+        "message": "Kein Tracking für $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Derzeit überprüft Privacy Badger nur, ob Drittparteien zum Verfolgen Ihres Surfverhaltens Cookies, lokalen HTML5-Speicher oder Canvas-Fingerprinting verwenden. Einige dieser Domains könnten allerdings Tracking-Methoden benutzen, die Privacy Badger nicht erkennen kann.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Erlaubt ",
-        "description": ""
+        "message": "Erlaubt $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Was ist Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Geblockte Cookies von ",
-        "description": ""
+        "message": "Geblockte Cookies von $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Lädt …",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -208,10 +208,6 @@
         "message": "Optionen von Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger hat bisher",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Dies wird folgende Informationen automatisch an die EFF senden: Die von Ihnen derzeit besuchte Website, Ihre Browserversion, die Version von Privacy Badger und den Status aller Schieberegler für diese Website.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potentielle <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>Tracking-Domains</a> erkannt. Diese Schieberegler lassen Sie steuern, wie Privacy Badger die jeweiligen Tracker handhabt.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger hat bisher $COUNT$ potentielle $TRACKER_LINK_START$Tracking-Domains$TRACKER_LINK_END$ erkannt. Diese Schieberegler lassen Sie steuern, wie Privacy Badger die jeweiligen Tracker handhabt.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger hat diese ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger hat diese $BUTTON$-Schaltfläche ersetzt.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Geblockt",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger hat bisher",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": "-Schaltfläche ersetzt.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Dies wird folgende Informationen automatisch an die EFF senden: Die von Ihnen derzeit besuchte Website, Ihre Browserversion, die Version von Privacy Badger und den Status aller Schieberegler für diese Website.",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blocked ",
-        "description": ""
+        "message": "Blocked $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Invalid JSON file.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "No tracking for ",
-        "description": ""
+        "message": "No tracking for $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Currently Privacy Badger only checks if third parties are using cookies, HTML5 local storage, or canvas fingerprinting to track your browsing. Some of these domains may be using tracking methods that Privacy Badger can't detect.",
@@ -142,8 +154,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Allowed ",
-        "description": ""
+        "message": "Allowed $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "What is Privacy Badger?",
@@ -230,8 +248,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blocked cookies from ",
-        "description": ""
+        "message": "Blocked cookies from $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Loading...",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger has replaced this ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger has replaced this $BUTTON$ button.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "content": "$1",
+                "example": "Facebook Like"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blocked ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger has detected",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " button.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "This will automatically send the following information to EFF: the site you're currently visiting, your browser version, the version of Privacy Badger, and the state of all of the sliders for this site.",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -191,10 +191,6 @@
         "message": "Privacy Badger Options",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger has detected",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "This will automatically send the following information to EFF: the site you're currently visiting, your browser version, the version of Privacy Badger, and the state of all of the sliders for this site.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potential <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domains</a> so far. These sliders let you control how Privacy Badger handles each tracker.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger has detected $COUNT$ potential $TRACKER_LINK_START$tracking domains$TRACKER_LINK_END$ so far. These sliders let you control how Privacy Badger handles each tracker.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -85,10 +85,6 @@
         "message": "Click here to block this domain from setting cookies",
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
-    "popup_instructions": {
-        "message": "potential <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
-        "description": "Continuation of the popup message that shows number of trackers"
-    },
     "options_domain_filter_block": {
         "message": "blocked",
         "description": "Dropdown control setting on the Tracking Domains options page tab."
@@ -333,9 +329,22 @@
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
     },
-    "pb_detected": {
-        "message": "Privacy Badger detected",
-        "description": "Beginning of popup message that shows the number of trackers."
+    "popup_instructions": {
+        "message": "Privacy Badger detected $COUNT$ potential $TRACKER_LINK_START$trackers$TRACKER_LINK_END$ on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "intro_by_eff": {
         "message": "A project of the Electronic Frontier Foundation",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blokita",
-        "description": ""
+        "message": "Blokita $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Malĝusta dosiero JSON.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Ne spuras por",
-        "description": ""
+        "message": "Ne spuras por $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Nune Privata Melo nur kontrolas ĉu eksteraj liverantoj uzas kuketojn, lokan konservejon HTML5 aŭ kanvasan fingrospuron por spuri vian retumadon. Iuj de tiuj nomregnoj povas uzi aliajn spurajn rimedojn, kiujn Privata Melo ne povas malkovri.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Permesata",
-        "description": ""
+        "message": "Permesata $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Kio la Privata Melo estas?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blokitaj kuketoj el",
-        "description": ""
+        "message": "Blokitaj kuketoj el $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Ŝargado…",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privata Melo anstataŭigis tiun ĉi butonon de ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privata Melo anstataŭigis tiun ĉi butonon de $BUTTON$.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blokita",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privata Melo malkovris",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": ".",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Tio ĉi aŭtomate sendos la jenajn datumojn al EFF: la nune vizitatan retpaĝon, version de via retumilo, version de Privata Melo kaj staton de ĉiuj ŝovilojn ĉe tiu ĉi retejo.",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "eblajn <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>spurilojn</a> sur tiu ĉi retpaĝo. Tiuj ĉi ŝoviloj ebligas al vi agordi kiel Privata Melo procedas pri ili. Vi ne devus ŝanĝi ilin escepte se io malfunkcias.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privata Melo malkovris $COUNT$ eblajn $TRACKER_LINK_START$spurilojn$TRACKER_LINK_END$ sur tiu ĉi retpaĝo. Tiuj ĉi ŝoviloj ebligas al vi agordi kiel Privata Melo procedas pri ili. Vi ne devus ŝanĝi ilin escepte se io malfunkcias.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "blokitaj",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privata Melo estas malaktivigita por la subaj nomregnoj. Tio ĉi signifas, ke Privata Melo blokos nenion, kiam vi vizitos la jenajn retejojn.<br><br>Se viaopinie Privata Melo difektas iun retpaĝon, vi povas entajpi ĝian nomregnon en la kampon sube kaj klaku “aldoni nomregnon”.<br><br>Alimaniere, se langeto de difektita paĝo estas malfermita, klaku la piktogramon de Privata Melo sur la folumila ilarstrio kaj klaku la butonon “malaktivigi”.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privata Melo malkovris",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Projekto de Electronic Frontier Foundation",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -208,10 +208,6 @@
         "message": "Agordoj de Privata Melo",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privata Melo malkovris",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Tio ĉi aŭtomate sendos la jenajn datumojn al EFF: la nune vizitatan retpaĝon, version de via retumilo, version de Privata Melo kaj staton de ĉiuj ŝovilojn ĉe tiu ĉi retejo.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "eblajn <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>spurantajn nomregnojn</a> ĝis nun. Tiuj ĉi ŝoviloj ebligas al vi agordi kiel Privata Melo procedas pri ĉiu spurilo.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privata Melo malkovris $COUNT$ eblajn $TRACKER_LINK_START$spurantajn nomregnojn$TRACKER_LINK_END$ ĝis nun. Tiuj ĉi ŝoviloj ebligas al vi agordi kiel Privata Melo procedas pri ĉiu spurilo.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privata Melo",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Este rastreador está BLOQUEADO, desliza para desbloquear el rastreador o bloquear las cookies.",
-        "description": ""
+        "message": "Blocked $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Archivo JSON invalido.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Sin rastreo de ",
-        "description": ""
+        "message": "Sin rastreo de $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Actualmente Privacy Badger sólo comprueba si terceras partes utilizan cookies, almacenamiento local HTML5, o huella digital del escritorio para rastrear tu navegador. Algunos de estos dominios pueden estar usando métodos de rastreo que Privacy Badger no puede detectar.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Este dominio está desbloqueado, desliza para bloquearlo completamento o bloquear las cookies.",
-        "description": ""
+        "message": "Allowed $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "¿Qué es Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Las cookies de este rastreador están bloqueadas, desliza para bloquear o desbloquear el rastreador.",
-        "description": ""
+        "message": "Blocked cookies from $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Cargando...",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": " potenciales <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>rastreadores</a> en esta página. Estas barras te permiten controlar como Privacy Badger maneja cada uno. No deberías de necesitar modificar estas opciones a menos que Privacy Badger cree problemas con esa página.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger detectado $COUNT$ potenciales $TRACKER_LINK_START$rastreadores$TRACKER_LINK_END$ en esta página. Estas barras te permiten controlar como Privacy Badger maneja cada uno. No deberías de necesitar modificar estas opciones a menos que Privacy Badger cree problemas con esa página.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "bloqueado",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger detectado",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Un proyecto de Electronic Frontier Foundation",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -208,10 +208,6 @@
         "message": "Opciones de Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger ha detectado",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Esto enviará automáticamente la siguiente información a la EFF: el sitio que estás visitando actualmente, tu versión del navegador, la versión de Privacy Badger, y el estado de los controles deslizantes para este sitio.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": " <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>dominios rastreadores</a> potenciales al momento. Las barras te permiten controlar lo que Privacy Badger hace con cada uno.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger ha detectado $COUNT$ $TRACKER_LINK_START$dominios rastreadores$TRACKER_LINK_END$ potenciales al momento. Las barras te permiten controlar lo que Privacy Badger hace con cada uno.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger ha sustituido este botón de ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger ha sustituido este botón de $BUTTON$.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Este rastreador está BLOQUEADO, desliza para desbloquear el rastreador o bloquear las cookies.",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger ha detectado",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": ".",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Esto enviará automáticamente la siguiente información a la EFF: el sitio que estás visitando actualmente, tu versión del navegador, la versión de Privacy Badger, y el estado de los controles deslizantes para este sitio.",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>traceurs</a> potentiels sur cette page. Ces curseurs vous permettent de modifier la façon dont ils sont gérés. Vous ne devriez pas avoir besoin de les modifier à moins d'un site non fonctionnel.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger a détecté $COUNT$ $TRACKER_LINK_START$traceurs$TRACKER_LINK_END$ potentiels sur cette page. Ces curseurs vous permettent de modifier la façon dont ils sont gérés. Vous ne devriez pas avoir besoin de les modifier à moins d'un site non fonctionnel.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "bloqués",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger a détecté",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Un projet de l'Electronic Frontier Foundation",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -208,10 +208,6 @@
         "message": "Options de Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger a detecté",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Le nom du site problématique, le réglage des curseurs associés, la version de votre navigateur et de Privacy Badger seront automatiquement transmis à l'EFF.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "<a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>domaines traceurs</a> jusqu'à présent. Les curseurs vous permettent de définir la façon dont l'application les gère.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger a detecté $COUNT$ $TRACKER_LINK_START$domaines traceurs$TRACKER_LINK_END$ jusqu'à présent. Les curseurs vous permettent de définir la façon dont l'application les gère.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger a remplacé ce bouton ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger a remplacé ce bouton $BUTTON$.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blocage de ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger a detecté",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": ".",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Le nom du site problématique, le réglage des curseurs associés, la version de votre navigateur et de Privacy Badger seront automatiquement transmis à l'EFF.",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blocage de ",
-        "description": ""
+        "message": "Blocage de $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Fichier JSON invalide.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Pas de traçage de la part de ",
-        "description": ""
+        "message": "Pas de traçage de la part de $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "À ce jour, Privacy Badger vérifie seulement si un tiers se sert de cookies, du stockage HTML5 local ou de l'empreinte par canvas pour épier votre navigation. Il se peut que d'autres méthodes non détectées soient utilisées.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Autorisation de ",
-        "description": ""
+        "message": "Autorisation de $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Qu'est-ce que Privacy Badger ?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blocage des cookies de ",
-        "description": ""
+        "message": "Blocage des cookies de $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Chargement...",

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potenziali <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracker</a> in questa pagina. Con questi pulsanti puoi controllare come Privacy Badger tratta ogni tracker. Non dovresti averne bisogno a meno che qualcosa non funzioni correttamente.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger ha rilevato $COUNT$ potenziali $TRACKER_LINK_START$tracker$TRACKER_LINK_END$ in questa pagina. Con questi pulsanti puoi controllare come Privacy Badger tratta ogni tracker. Non dovresti averne bisogno a meno che qualcosa non funzioni correttamente.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "bloccati",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger ha rilevato",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Un progetto della Electronic Frontier Foundation",

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Bloccato ",
-        "description": ""
+        "message": "Bloccato $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "File JSON non valido.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Nessun tracciamento da ",
-        "description": ""
+        "message": "Nessun tracciamento da $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Al momento Privacy Badger sta controllando esclusivamente se terze parti stanno usando dei cookie, local storage HTML5 o il canvas fingerprinting per tracciare la navigazione. Alcuni di questi domini potrebbero utilizzare metodi di tracciamento che Privacy Badger non è in grado rilevare.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Permesso ",
-        "description": ""
+        "message": "Permesso $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Cos'è Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Cookie bloccati da ",
-        "description": ""
+        "message": "Cookie bloccati da $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Caricamento...",

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger ha sostituito questo ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger ha sostituito questo $BUTTON$ pulsante.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Bloccato ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Sono stati rilevati",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " pulsante.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Verranno inviate automaticamente le seguenti informazioni alla EFF: il sito che stai visitando, la versione del browser, la versione di Privacy Badger e lo stato di tutti i pulsanti per questo sito.",

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -208,10 +208,6 @@
         "message": "Opzioni di Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Sono stati rilevati",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Verranno inviate automaticamente le seguenti informazioni alla EFF: il sito che stai visitando, la versione del browser, la versione di Privacy Badger e lo stato di tutti i pulsanti per questo sito.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potenziali <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>domini traccianti</a> finora. Con questi pulsanti puoi controllare come Privacy Badger tratta ogni tracker.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Sono stati rilevati $COUNT$ potenziali $TRACKER_LINK_START$domini traccianti$TRACKER_LINK_END$ finora. Con questi pulsanti puoi controllare come Privacy Badger tratta ogni tracker.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger has replaced this ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger has replaced this $BUTTON$ button.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blokkert ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Personvernsgrevlingen har oppdaget",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " button.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Dette vil automatisk sende følgende informasjon til EFF: Siden du besøker, nettleserversjon, versjonen av Personvernsgrevlingen du bruker, samt alle glidebryterinnstillingene for denne siden.",

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blokkert ",
-        "description": ""
+        "message": "Blokkert $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Ugyldig JSON-fil.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "No tracking for ",
-        "description": ""
+        "message": "No tracking for $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Personvernsgrevlingen sjekker for tiden bare om tredjeparter bruker kaker, lokal lagring i HTML5, eller lerret-fingeravtrykk for å spore din nettleserhistorikk. Det kan hende noen av disse domenene gjør bruk av metoder som ikke  oppdages av Personvernsgrevlingen.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Tillatt ",
-        "description": ""
+        "message": "Tillatt $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Hva er Personvernsgrevlingen?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blokkerte kaker fra ",
-        "description": ""
+        "message": "Blokkerte kaker fra $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Laster inn…",

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -208,10 +208,6 @@
         "message": "Valg for Personvernsgrevlingen",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Personvernsgrevlingen har oppdaget",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Dette vil automatisk sende følgende informasjon til EFF: Siden du besøker, nettleserversjon, versjonen av Personvernsgrevlingen du bruker, samt alle glidebryterinnstillingene for denne siden.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potential <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domains</a> so far. These sliders let you control how Privacy Badger handles each tracker.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger has detected $COUNT$ potential $TRACKER_LINK_START$tracking domains$TRACKER_LINK_END$ so far. These sliders let you control how Privacy Badger handles each tracker.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Personvernsgrevlingen",

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potential <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger detected $COUNT$ potential $TRACKER_LINK_START$trackers$TRACKER_LINK_END$ on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "blocked",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Personvernsgrevling oppdaget",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Et av Electronic Frontier Foundations prosjekter",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -208,10 +208,6 @@
         "message": "Privacy Badger-opties",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger heeft",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "De volgende informatie wordt automatisch naar EFF verzonden: de huidige webpagina, de versie van uw browser, de versie van Privacy Badger en de stand van de schuifbalkjes voor de huidige webpagina.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "mogelijke <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackingdomeinen</a> gedetecteerd. Met deze schuifbalkjes kunt u bepalen hoe Privacy Badger met elke tracker omgaat.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger heeft $COUNT$ mogelijke $TRACKER_LINK_START$trackingdomeinen$TRACKER_LINK_END$ gedetecteerd. Met deze schuifbalkjes kunt u bepalen hoe Privacy Badger met elke tracker omgaat.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger heeft deze ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger heeft deze $BUTTON$-knop vervangen.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Geblokkeerd ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger heeft",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": "-knop vervangen.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "De volgende informatie wordt automatisch naar EFF verzonden: de huidige webpagina, de versie van uw browser, de versie van Privacy Badger en de stand van de schuifbalkjes voor de huidige webpagina.",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Geblokkeerd ",
-        "description": ""
+        "message": "Geblokkeerd $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Ongeldig JSON-bestand.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Geen tracking voor ",
-        "description": ""
+        "message": "Geen tracking voor $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Momenteel controleert Privacy Badger alleen of derde partijen cookies, HTML5 lokale opslag of canvas fingerprinting gebruiken om uw surfgedrag te volgen. Sommige van deze domeinen gebruiken wellicht trackingmethoden die Privacy Badger (nog) niet detecteert.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Toegestaan ",
-        "description": ""
+        "message": "Toegestaan $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Wat is Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Cookies geblokkeerd van ",
-        "description": ""
+        "message": "Cookies geblokkeerd van $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Laden...",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "mogelijke <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> gedetecteerd op deze webpagina. Met deze schuifbalkjes kunt u bepalen hoe Privacy Badger met elke tracker omgaat. U hoeft de schuifbalkjes alleen aan te passen als er iets niet meer werkt.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger heeft $COUNT$ mogelijke $TRACKER_LINK_START$trackers$TRACKER_LINK_END$ gedetecteerd op deze webpagina. Met deze schuifbalkjes kunt u bepalen hoe Privacy Badger met elke tracker omgaat. U hoeft de schuifbalkjes alleen aan te passen als er iets niet meer werkt.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "geblokkeerd",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger heeft",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Een project van de Electronic Frontier Foundation",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger zastąpił ten przycisk ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger zastąpił ten przycisk $BUTTON$.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Zablokowany",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger wykrył",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": ".",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Następujące informacje zostaną automatycznie wysłane do EFF: odwiedzana strona, wersja przeglądarki, wersja Privacy Badgera i stan wszystkich suwaków na tej stronie.",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -208,10 +208,6 @@
         "message": "Ustawienia Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger wykrył",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Następujące informacje zostaną automatycznie wysłane do EFF: odwiedzana strona, wersja przeglądarki, wersja Privacy Badgera i stan wszystkich suwaków na tej stronie.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potencjalnych <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>szpiegujących domen</a>. Te suwaki pozwolą Ci kontrolować jak Privacy Badger ma postępować z każdym śledzikiem.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger wykrył $COUNT$ potencjalnych $TRACKER_LINK_START$szpiegujących domen$TRACKER_LINK_END$. Te suwaki pozwolą Ci kontrolować jak Privacy Badger ma postępować z każdym śledzikiem.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Zablokowany",
-        "description": ""
+        "message": "Zablokowany $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Nieprawidłowy plik JSON.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Nie szpieguje",
-        "description": ""
+        "message": "Nie szpieguje $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Obecnie Privacy Badger sprawdza tylko czy strony trzecie używają ciasteczek, pamięci podręcznej HTML5 lub odcisku palca canvas, aby śledzić Twoją historię przeglądania. Niektóre z tych domen mogą śledzić metodami, których Privacy Badger nie potrafi wykryć.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Odblokowany",
-        "description": ""
+        "message": "Odblokowany $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Czym jest Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Zablokowano ciasteczka z",
-        "description": ""
+        "message": "Zablokowano ciasteczka z $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Ładowanie…",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potencjalnych <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>szpiegów</a> na tej stronie. Te suwaki pozwolą Ci kontrolować jak ma z nimi postępować Privacy Badger. Nie powinieneś nimi kręcić, jeżeli wszystko działa.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger wykrył $COUNT$ potencjalnych $TRACKER_LINK_START$szpiegów$TRACKER_LINK_END$ na tej stronie. Te suwaki pozwolą Ci kontrolować jak ma z nimi postępować Privacy Badger. Nie powinieneś nimi kręcić, jeżeli wszystko działa.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "zablokowane",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger jest wyłączony dla następujących domen. Oznacza to, że nic będzie blokowane podczas wizyty na stronach wpisanych poniżej.<br><br>Jeżeli uważasz, że Privacy Badger psuje jakąś stronę, wpisz domenę tej strony w pole poniżej i kliknij w przycisk „dodaj domenę”.<br><br>Inny sposób: mając otwartą kartę ze stroną, kliknij w ikonę Privacy Badgera na pasku narzędzi przeglądarki, a następnie kliknij „wyłącz.”",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger wykrył",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Projekt Electronic Frontier Foundation",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Заблокирован ",
-        "description": ""
+        "message": "Заблокирован $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Неверный файл JSON.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Нет отслеживающей активности на",
-        "description": ""
+        "message": "Нет отслеживающей активности на $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "На данный момент Privacy Badger проверяет только использование сторонних файлов cookie, локального хранилища HTML5 или метода canvas fingerprinting для отслеживания вашей сетевой активности. Некоторые домены могут использовать методы отслеживания, которые Privacy Badger не может обнаружить.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Разрешен ",
-        "description": ""
+        "message": "Разрешен $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Что такое Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Заблокированы файлы cookie домена ",
-        "description": ""
+        "message": "Заблокированы файлы cookie от $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Загрузка...",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "потенциальных <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>трекеров</a> на этой странице. С помощью этих переключателей вы можете выбрать, какое действие Privacy Badger выполнит с каждым из них. Переключателей нужно регулировать только в случае проблем с работой сайта.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger обнаружил $COUNT$ потенциальных $TRACKER_LINK_START$трекеров$TRACKER_LINK_END$ на этой странице. С помощью этих переключателей вы можете выбрать, какое действие Privacy Badger выполнит с каждым из них. Переключателей нужно регулировать только в случае проблем с работой сайта.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "заблокированные",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger обнаружил",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Проект Electronic Frontier Foundation",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -208,10 +208,6 @@
         "message": "Настройки Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger обнаружил",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Это действие автоматически отправит в EFF следующую информацию: адрес сайта, на котором вы находитесь в данный момент, версию вашего браузера, версию Privacy Badger и состояние всех переключателей, установленных для этого сайта.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "потенциальных <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>трекеров</a> на данный момент. С помощью этих переключателей вы сможете выбрать, какое действие Privacy Badger будет выполнять с каждым трекером.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger обнаружил $COUNT$ потенциальных $TRACKER_LINK_START$трекеров$TRACKER_LINK_END$ на данный момент. С помощью этих переключателей вы сможете выбрать, какое действие Privacy Badger будет выполнять с каждым трекером.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger заменил кнопку ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger заменил кнопку $BUTTON$.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Заблокирован ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger обнаружил",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": ".",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Это действие автоматически отправит в EFF следующую информацию: адрес сайта, на котором вы находитесь в данный момент, версию вашего браузера, версию Privacy Badger и состояние всех переключателей, установленных для этого сайта.",

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Блокирано ",
-        "description": ""
+        "message": "Блокирано $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Неважећа JSON датотека.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "No tracking for ",
-        "description": ""
+        "message": "No tracking for $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Тренутно Privacy Badger проверава само да ли треће стране користе колачиће, HTML5 локално складиште, или метод canvas fingerprinting за праћење вашег прегледања. Неки од ових домена могу користити методе праћења које Privacy Badger не може открити.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Дозвољено ",
-        "description": ""
+        "message": "Дозвољено $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Шта је Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Блокирани колачићи са ",
-        "description": ""
+        "message": "Блокирани колачићи са $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Учитавање...",

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -208,10 +208,6 @@
         "message": "Privacy Badger - Опције",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger је открио",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Ово ће аутоматски послати следеће информације на EFF: сајт који тренутно прегледате, верзија прегледача, верзија Privacy Badger проширења и стање свих клизача за сајт.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potential <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domains</a> so far. These sliders let you control how Privacy Badger handles each tracker.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger has detected $COUNT$ potential $TRACKER_LINK_START$tracking domains$TRACKER_LINK_END$ so far. These sliders let you control how Privacy Badger handles each tracker.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger has replaced this ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger has replaced this $BUTTON$ button.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Блокирано ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger је открио",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " button.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Ово ће аутоматски послати следеће информације на EFF: сајт који тренутно прегледате, верзија прегледача, верзија Privacy Badger проширења и стање свих клизача за сајт.",

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potential <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>trackers</a> on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger detected $COUNT$ potential $TRACKER_LINK_START$trackers$TRACKER_LINK_END$ on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "blocked",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger је откривен",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Пројекат Electronic Frontier Foundation",

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Blockerade ",
-        "description": ""
+        "message": "Blockerade $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Ogiltig JSON-fil.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Ingen spejare för ",
-        "description": ""
+        "message": "Ingen spejare för $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "För närvarande kontrollerar Privacy Badger endast om tredjeparter använder kakor, HTML5-lagring eller canvas fingeravtryck för att speja på din surfning. Vissa av domänerna kan använda spejarmetoder som Privacy Badger inte kan upptäcka.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Tillät ",
-        "description": ""
+        "message": "Tillät $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Vad är Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Blockerade kakor från ",
-        "description": ""
+        "message": "Blockerade kakor från $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Laddar...",

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -208,10 +208,6 @@
         "message": "Privacy Badger alternativ",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger har upptäckt",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Detta skickar automatiskt följande information till EFF: den webbplats du besöker för tillfället, din webbläsareversion, versionen av Privacy Badger och läget för alla skjutreglaget för den här webbplatsen.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "potentiella <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>spejardomäner</a> hittills. Med dessa reglage kan du styra hur Privacy Badger hanterar varje spejare.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger har upptäckt $COUNT$ potentiella $TRACKER_LINK_START$spejardomäner$TRACKER_LINK_END$ hittills. Med dessa reglage kan du styra hur Privacy Badger hanterar varje spejare.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger har ersatt den här ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger har ersatt den här $BUTTON$ knappen.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Blockerade ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger har upptäckt",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " knappen.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Detta skickar automatiskt följande information till EFF: den webbplats du besöker för tillfället, din webbläsareversion, versionen av Privacy Badger och läget för alla skjutreglaget för den här webbplatsen.",

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "potentiella <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>spejare</a> på denna sida. Dessa reglage låter dig styra hur Privacy Badger hanterar var och en. Du behöver inte justera reglagen om inte något är trasigt.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger upptäckte $COUNT$ potentiella $TRACKER_LINK_START$spejare$TRACKER_LINK_END$ på denna sida. Dessa reglage låter dig styra hur Privacy Badger hanterar var och en. Du behöver inte justera reglagen om inte något är trasigt.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "blockerad",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger upptäckte",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Ett projekt av Electronic Frontier Foundation",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -208,10 +208,6 @@
         "message": "Privacy Badger Seçenekleri",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger şu ana dek ",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Bu EFF'ye otomatik olarak şu bilgileri gönderecek: şu an ziyaret ettiğin site, tarayıcı sürümün, Privacy Badger versiyonun, ve bu site için bütün kaydırıcıların durumu.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "tane potansiyel <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>takipçi adres</a> buldu. Bu kaydırıcılar Privacy Badger'in her biriyle nasıl başa çıkacağını ayarlamanızı sağlar.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger şu ana dek $COUNT$ tane potansiyel $TRACKER_LINK_START$takipçi adres$TRACKER_LINK_END$ buldu. Bu kaydırıcılar Privacy Badger'in her biriyle nasıl başa çıkacağını ayarlamanızı sağlar.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Engellendi ",
-        "description": ""
+        "message": "Engellendi $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Geçersiz JSON dosyası.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Takip yok ",
-        "description": ""
+        "message": "Takip yok $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "Şu an Privacy Badger sadece 3. partilerin çerez, yerel HTML5 depolaması, veya tuval parmak izi kullanarak taramanızı takip edip etmediğini kontrol ediyor. Bazı adresler Privacy Badger tarafından algılanmayan yöntemler kullanıyor olabilir.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Şuna izin verildi: ",
-        "description": ""
+        "message": "Şuna izin verildi: $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Privacy Badger nedir?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Şuradan çerezler engellendi: ",
-        "description": ""
+        "message": "Şuradan çerezler engellendi: $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Yükleniyor...",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger bu ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger bu $BUTTON$ butonunu değiştirdi.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Engellendi ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger şu ana dek ",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " butonunu değiştirdi.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Bu EFF'ye otomatik olarak şu bilgileri gönderecek: şu an ziyaret ettiğin site, tarayıcı sürümün, Privacy Badger versiyonun, ve bu site için bütün kaydırıcıların durumu.",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "tane potansiyel <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>takipçi</a> buldu. Bu kaydırıcılar Privacy Badger'in her biriyle nasıl başa çıkacağını ayarlamanızı sağlar. Ters giden birşey yoksa kaydırıcıları ayarlamanız gerekmez.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "\"Privacy Badger $COUNT$ tane potansiyel $TRACKER_LINK_START$takipçi$TRACKER_LINK_END$ buldu. Bu kaydırıcılar Privacy Badger'in her biriyle nasıl başa çıkacağını ayarlamanızı sağlar. Ters giden birşey yoksa kaydırıcıları ayarlamanız gerekmez.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "engellenmiş",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger aşağıdaki sitelerde devre dışıdır. Bunun anlamı, Privacy Badger bu sitelerdeki hiçbir şeyi engellemez.<br><br>Eğer Privacy Badger'ın bir sayfayı bozduğunu düşünüyorsanız, sayfanın adresini aşağıdaki kutucuğa yazıp \"Adres Ekle\" butonuna tıklayabilirsiniz.<br><br>Alternatif olarak, sayfanın sekmesi seçiliyken tarayıcı araç çubuğundan Privacy Badger'a tıklayıp \"Devre Dışı Bırak\" butonuna tıklayabilirsiniz.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger ",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Bir Electronic Frontier Foundation projesi",

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger змінив цю ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger змінив цю $BUTTON$ кнопку.",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "Заблоковано ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "Privacy Badger виявив",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " кнопку.",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "Ця дія призведе до автоматичного надсилання наступної інформації до EFF: поточний сайт, версія браузера, версія Privacy Badger, а також положення всіх перемикачів для цього сайту.",

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "можливих <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>елементів стеження</a> на цій сторінці. Перемикачі дозволяють контролювати обробку кожного з них. Не варто їх регулювати, якщо все працює як слід.",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger виявив $COUNT$ можливих $TRACKER_LINK_START$елементів стеження$TRACKER_LINK_END$ на цій сторінці. Перемикачі дозволяють контролювати обробку кожного з них. Не варто їх регулювати, якщо все працює як слід.",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "заблоковані",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger виявив",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "Проект Electronic Frontier Foundation",

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -208,10 +208,6 @@
         "message": "Налаштування Privacy Badger",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "Privacy Badger виявив",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "Ця дія призведе до автоматичного надсилання наступної інформації до EFF: поточний сайт, версія браузера, версія Privacy Badger, а також положення всіх перемикачів для цього сайту.",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "можливих <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>доменів стеження</a> на цей час. Ці перемикачі дозволяють вам контролювати обробку кожного з них.",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "Privacy Badger виявив $COUNT$ можливих $TRACKER_LINK_START$доменів стеження$TRACKER_LINK_END$ на цей час. Ці перемикачі дозволяють вам контролювати обробку кожного з них.",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "Заблоковано ",
-        "description": ""
+        "message": "Заблоковано $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "Неправильний файл JSON.",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "Немає стеження для",
-        "description": ""
+        "message": "Немає стеження для $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "В даний момент Privacy Badger лише перевіряє, чи сторонні елементи не використовують куки, локальне сховище HTML5, або відбиток canvas для стеження за вашим переглядом. Деякі з цих доменів можуть використовувати способи стеження, які Privacy Badger не в змозі виявити.",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "Дозволено ",
-        "description": ""
+        "message": "Дозволено $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Що таке Privacy Badger?",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "Заблоковано куки з ",
-        "description": ""
+        "message": "Заблоковано куки з $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "Завантаження...",

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "屏蔽 ",
-        "description": ""
+        "message": "屏蔽 $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "无效的 JSON 文件。",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "没有追踪 ",
-        "description": ""
+        "message": "没有追踪 $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "目前隐私獾只检查跟踪浏览情况的第三方 Cookies，HTML5 local storage，和画布指纹（canvas fingerprinting）。 有些域名可能使用了隐私獾无法检测的跟踪方式。",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "允许 ",
-        "description": ""
+        "message": "允许 $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "什么是隐私獾？",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "屏蔽此网站的 cookies ",
-        "description": ""
+        "message": "屏蔽此网站的 cookies $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "加载中…",

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "隐私獾已经替换了这个 ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "隐私獾已经替换了这个 $BUTTON$ 按钮。",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "屏蔽 ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "隐私獾发现了",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " 按钮。",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "这会自动把以下的信息报告给电子前哨基金会：你现在访问的网站，浏览器版本，隐私獾版本和这个网站所有滑块的状态。",

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -208,10 +208,6 @@
         "message": "隐私獾设置",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "隐私獾发现了",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "这会自动把以下的信息报告给电子前哨基金会：你现在访问的网站，浏览器版本，隐私獾版本和这个网站所有滑块的状态。",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "至今为止潜在的<a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>追踪域名</a>。这些滑块使你控制隐私獾如何处理这些追踪器。",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "隐私獾发现了 $COUNT$ 至今为止潜在的$TRACKER_LINK_START$追踪域名$TRACKER_LINK_END$。这些滑块使你控制隐私獾如何处理这些追踪器。",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "隐私獾",

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "这个页面上的潜在的<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>追踪器</a>。这些滑块使你控制隐私獾如何控制每个。除非一些东西破损，你应该不需要调节它。",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "隐私獾检测到 $COUNT$ 这个页面上的潜在的$TRACKER_LINK_START$追踪器$TRACKER_LINK_END$。这些滑块使你控制隐私獾如何控制每个。除非一些东西破损，你应该不需要调节它。",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "已屏蔽",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.<br><br>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.<br><br>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "隐私獾检测到",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "电子前哨基金会一个的项目",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -1,7 +1,13 @@
 {
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger 已經取代了 ",
-        "description": "Beginning of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
+        "message": "Privacy Badger 已經取代了 $BUTTON$ 按鈕。",
+        "description": "Tooltip shown over a replaced social button.",
+        "placeholders": {
+            "button": {
+                "example": "Facebook Like",
+                "content": "$1"
+            }
+        }
     },
     "badger_status_block": {
         "message": "封鎖 ",
@@ -174,10 +180,6 @@
     "options_pb_has_detected": {
         "message": "目前為止，Privacy Badger 偵測到",
         "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
-    "social_tooltip_button": {
-        "message": " 按鈕。",
-        "description": "Continuation of tooltip shown over a replaced social button, e.g [Privacy Badger has replaced this ]Facebook[ button]."
     },
     "report_terms": {
         "message": "將會自動回報下列資訊給 EFF 電子前鋒基金會: 您目前造訪的網站、瀏覽器版本、 Privacy Badger 版本，以及此網站所有滾動條的狀態。",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -10,8 +10,14 @@
         }
     },
     "badger_status_block": {
-        "message": "封鎖 ",
-        "description": ""
+        "message": "封鎖 $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "invalid_json": {
         "message": "無效的 JSON 檔案。",
@@ -22,8 +28,14 @@
         "description": ""
     },
     "badger_status_noaction": {
-        "message": "沒有追蹤 ",
-        "description": ""
+        "message": "沒有追蹤 $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "non_tracker_tip": {
         "message": "目前 Privacy Badger 只檢查透過第三方 cookie、HTML5 Local Storage、Canvas 指紋來追蹤您瀏覽網頁的情況。有些網域可能使用了 Privacy Badger 無法偵測的追蹤方式。",
@@ -159,8 +171,14 @@
         "description": ""
     },
     "badger_status_allow": {
-        "message": "允許 ",
-        "description": ""
+        "message": "允許 $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "privacy_badger_what_is": {
         "message": "Privacy Badger 是什麼？",
@@ -247,8 +265,14 @@
         "description": ""
     },
     "badger_status_cookieblock": {
-        "message": "封鎖此網站的 cookie ",
-        "description": ""
+        "message": "封鎖此網站的 cookie $DOMAIN$",
+        "description": "",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_loading": {
         "message": "載入中…",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -4,8 +4,8 @@
         "description": "Tooltip shown over a replaced social button.",
         "placeholders": {
             "button": {
-                "example": "Facebook Like",
-                "content": "$1"
+                "content": "$1",
+                "example": "Facebook Like"
             }
         }
     },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -208,10 +208,6 @@
         "message": "Privacy Badger 設定",
         "description": ""
     },
-    "options_pb_has_detected": {
-        "message": "目前為止，Privacy Badger 偵測到",
-        "description": "Beginning of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
-    },
     "report_terms": {
         "message": "將會自動回報下列資訊給 EFF 電子前鋒基金會: 您目前造訪的網站、瀏覽器版本、 Privacy Badger 版本，以及此網站所有滾動條的狀態。",
         "description": ""
@@ -403,8 +399,21 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "個潛在<a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>追蹤網域</a>。滑桿讓您可以控制 Privacy Badger 如何控制處理它。",
-        "description": "Continuation of message on the Tracking Domains options page tab that shows the total number of trackers detected so far."
+        "message": "目前為止，Privacy Badger 偵測到 $COUNT$ 個潛在$TRACKER_LINK_START$追蹤網域$TRACKER_LINK_END$。滑桿讓您可以控制 Privacy Badger 如何控制處理它。",
+        "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "900"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "name": {
         "message": "Privacy Badger",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -86,8 +86,21 @@
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "popup_instructions": {
-        "message": "在此頁面上的潛在<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>追蹤器</a>。這些滑桿讓您可以控制 Privacy Badger 如何處理每個追蹤器。除非有某些東西壞掉了，否則您應該不需要調整這些滑桿。",
-        "description": "Continuation of the popup message that shows number of trackers"
+        "message": "Privacy Badger 偵測到這個網站上有 $COUNT$ 在此頁面上的潛在$TRACKER_LINK_START$追蹤器$TRACKER_LINK_END$。這些滑桿讓您可以控制 Privacy Badger 如何處理每個追蹤器。除非有某些東西壞掉了，否則您應該不需要調整這些滑桿。",
+        "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "15"
+            },
+            "tracker_link_start": {
+                "content": "$2",
+                "example": "<a title='What is a tracker?' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+            },
+            "tracker_link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "options_domain_filter_block": {
         "message": "已阻擋",
@@ -332,10 +345,6 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger 已在下列的網站中停用。這代表了 Privacy Badger 將不會在您造訪在這裡列出來的網站時阻擋任何東西。<br><br>若您覺得 Privacy Badger 把頁面弄壞了，您可以透過在下方的輸入框中輸入網域並點按「新增網域」按鈕來新增網域。<br><br>或者是當您已經選取了網頁的分頁，您也可以點選在瀏覽器工具列中的 Privacy Badger 按鈕並點選「停用」按鈕。",
         "description": ""
-    },
-    "pb_detected": {
-        "message": "Privacy Badger 偵測到這個網站上有",
-        "description": "Beginning of popup message that shows the number of trackers."
     },
     "intro_by_eff": {
         "message": "EFF 電子前鋒基金會的專案",

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -48,8 +48,6 @@
  */
 let trackerInfo;
 
-let i18n = chrome.i18n;
-
 
 /**
  * Initializes the content script.
@@ -115,8 +113,10 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
   var details = buttonData.details;
 
   button.setAttribute("src", buttonUrl);
-  button.setAttribute("title", i18n.getMessage("social_tooltip_pb_has_replaced") +
-                            tracker.name + i18n.getMessage("social_tooltip_button"));
+  button.setAttribute(
+    "title",
+    chrome.i18n.getMessage("social_tooltip_pb_has_replaced", tracker.name)
+  );
   button.setAttribute(
     "style",
     "border: none !important; cursor: pointer !important; height: auto !important; width: auto !important;"

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -70,22 +70,25 @@ var htmlUtils = exports.htmlUtils = {
    * @returns {String} Localized action description with origin.
    */
   getActionDescription: (function () {
-    var actionDescriptions = {
-      block: i18n.getMessage('badger_status_block'),
-      cookieblock: i18n.getMessage('badger_status_cookieblock'),
-      noaction: i18n.getMessage('badger_status_noaction'),
-      allow: i18n.getMessage('badger_status_allow'),
+    const messages = {
+      block: i18n.getMessage('badger_status_block', "XXX"),
+      cookieblock: i18n.getMessage('badger_status_cookieblock', "XXX"),
+      noaction: i18n.getMessage('badger_status_noaction', "XXX"),
+      allow: i18n.getMessage('badger_status_allow', "XXX"),
       dntTooltip: i18n.getMessage('dnt_tooltip')
     };
-    return function (action, origin, isWhitelisted) {
-      var rv_action = actionDescriptions[action];
-      if (typeof(isWhitelisted) !== 'undefined' && isWhitelisted) {
-        return actionDescriptions.dntTooltip;
-      } else if (typeof(rv_action) == 'undefined') {
-        return origin;
-      } else {
-        return rv_action + origin;
+    return function (action, origin, is_whitelisted) {
+      if (is_whitelisted) {
+        return messages.dntTooltip;
       }
+
+      const rv_action = messages[action];
+
+      if (!rv_action) {
+        return origin;
+      }
+
+      return rv_action.replace("XXX", origin);
     };
   }()),
   /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -459,8 +459,6 @@ function reloadTrackingDomainsTab() {
   var allTrackingDomains = getOriginsArray(originCache);
   if (!allTrackingDomains || allTrackingDomains.length === 0) {
     // leave out number of trackers and slider instructions message if no sliders will be displayed
-    $("#pb_has_detected").hide();
-    $("#count").hide();
     $("#options_domain_list_trackers").hide();
     $("#options_domain_list_one_tracker").hide();
 
@@ -480,18 +478,19 @@ function reloadTrackingDomainsTab() {
   $("#tracking-domains-div").show();
 
   // Update messages according to tracking domain count.
-  if (allTrackingDomains.length === 1) {
+  if (allTrackingDomains.length == 1) {
     // leave out messages about multiple trackers
-    $("#pb_has_detected").hide();
-    $("#count").hide();
     $("#options_domain_list_trackers").hide();
 
     // show singular "tracker" message
     $("#options_domain_list_one_tracker").show();
   } else {
-    $("#pb_has_detected").show();
-    $("#count").text(allTrackingDomains.length).show();
-    $("#options_domain_list_trackers").show();
+    $("#options_domain_list_trackers").html(i18n.getMessage(
+      "options_domain_list_trackers", [
+        allTrackingDomains.length,
+        "<a target='_blank' title='" + _.escape(i18n.getMessage("what_is_a_tracker")) + "' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+      ]
+    )).show();
   }
 
   // Get containing HTML for domain list along with toggle legend icons.

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -449,7 +449,7 @@ function refreshPopup() {
   $('#instructions-many-trackers').html(chrome.i18n.getMessage(
     "popup_instructions", [
       num_trackers,
-      "<a target='_blank' title='" + chrome.i18n.getMessage("what_is_a_tracker") + "' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+      "<a target='_blank' title='" + _.escape(chrome.i18n.getMessage("what_is_a_tracker")) + "' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
     ]
   ));
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -21,8 +21,6 @@ var constants = require("constants");
 var FirefoxAndroid = require("firefoxandroid");
 var htmlUtils = require("htmlutils").htmlUtils;
 
-var i18n = chrome.i18n;
-
 let POPUP_DATA = {};
 
 // TODO hack: disable Tooltipster tooltips on Firefox
@@ -125,7 +123,7 @@ function init() {
   $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
   $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
 
-  var version = i18n.getMessage("version") + " " + chrome.runtime.getManifest().version;
+  var version = chrome.i18n.getMessage("version") + " " + chrome.runtime.getManifest().version;
   $("#version").text(version);
 
   if (POPUP_DATA.isPrivateWindow) {
@@ -386,13 +384,11 @@ function refreshPopup() {
 
   if (!originsArr.length) {
     // leave out number of trackers and slider instructions message if no sliders will be displayed
-    $("#pb_detected").hide();
-    $("#number_trackers").hide();
-    $("#sliders_explanation").hide();
+    $("#instructions-many-trackers").hide();
 
     // show "no trackers" message
     $("#instructions_no_trackers").show();
-    $("#blockedResources").html(i18n.getMessage("popup_blocked"));
+    $("#blockedResources").html(chrome.i18n.getMessage("popup_blocked"));
 
     // activate tooltips
     $('.tooltip').tooltipster();
@@ -409,7 +405,7 @@ function refreshPopup() {
   var printable = [];
   var nonTracking = [];
   originsArr = htmlUtils.sortDomains(originsArr);
-  var trackerCount = 0;
+  var num_trackers = 0;
 
   for (let i=0; i < originsArr.length; i++) {
     var origin = originsArr[i];
@@ -421,15 +417,15 @@ function refreshPopup() {
     }
 
     if (action != constants.DNT) {
-      trackerCount++;
+      num_trackers++;
     }
     printable.push(
       htmlUtils.getOriginHtml(origin, action, action == constants.DNT)
     );
   }
 
-  var nonTrackerText = i18n.getMessage("non_tracker");
-  var nonTrackerTooltip = i18n.getMessage("non_tracker_tip");
+  var nonTrackerText = chrome.i18n.getMessage("non_tracker");
+  var nonTrackerTooltip = chrome.i18n.getMessage("non_tracker_tip");
 
   if (nonTracking.length > 0) {
     printable.push(
@@ -442,17 +438,20 @@ function refreshPopup() {
     }
   }
 
-  if (trackerCount === 1) {
+  if (num_trackers == 1) {
     // leave out messages about multiple trackers
-    $("#pb_detected").hide();
-    $("#number_trackers").hide();
-    $("#sliders_explanation").hide();
+    $("#instructions-many-trackers").hide();
 
     // show singular "tracker" message
     $("#instructions_one_tracker").show();
   }
 
-  $('#number_trackers').text(trackerCount);
+  $('#instructions-many-trackers').html(chrome.i18n.getMessage(
+    "popup_instructions", [
+      num_trackers,
+      "<a target='_blank' title='" + chrome.i18n.getMessage("what_is_a_tracker") + "' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>"
+    ]
+  ));
 
   function renderDomains() {
     const CHUNK = 1;

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -70,7 +70,7 @@
     </div>
     <div id="blockedResourcesContainer">
       <p id="pbInstructions">
-        <span id="pb_has_detected" class="i18n_options_pb_has_detected"></span> <span id='count'>0</span> <span id="options_domain_list_trackers" class="i18n_options_domain_list_trackers"></span>
+        <span id="options_domain_list_trackers"></span>
         <span id="options_domain_list_one_tracker" class="i18n_options_domain_list_one_tracker" style="display:none"></span>
         <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" style="display:none"></span>
       </p>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -91,7 +91,7 @@
 
 <div id="blockedResourcesContainer">
   <p id="pbInstructions">
-    <span id="pb_detected" class="i18n_pb_detected"></span> <span id='number_trackers'></span> <span id="sliders_explanation" class="i18n_popup_instructions"></span>
+    <span id="instructions-many-trackers"></span>
     <span id="instructions_one_tracker" class="i18n_popup_instructions_one_tracker" style="display:none"></span>
     <span id="instructions_no_trackers" class="i18n_popup_instructions_no_trackers" style="display:none"></span>
   </p>

--- a/src/tests/tests/htmlutils.js
+++ b/src/tests/tests/htmlutils.js
@@ -36,17 +36,17 @@
       {
         action: "block",
         origin,
-        expectedResult: getMessage('badger_status_block') + origin,
+        expectedResult: getMessage('badger_status_block', origin)
       },
       {
         action: "cookieblock",
         origin,
-        expectedResult: getMessage('badger_status_cookieblock') + origin,
+        expectedResult: getMessage('badger_status_cookieblock', origin)
       },
       {
         action: "allow",
         origin,
-        expectedResult: getMessage('badger_status_allow') + origin,
+        expectedResult: getMessage('badger_status_allow', origin)
       },
     ];
 

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -99,10 +99,6 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
         self.assertFalse(
             self.driver.find_element_by_id("options_domain_list_no_trackers").is_displayed(), error_message)
         self.assertFalse(
-            self.driver.find_element_by_id("pb_has_detected").is_displayed(), error_message)
-        self.assertFalse(
-            self.driver.find_element_by_id("count").is_displayed(), error_message)
-        self.assertFalse(
             self.driver.find_element_by_id("options_domain_list_trackers").is_displayed(), error_message)
 
         # Check that origin is displayed.
@@ -127,20 +123,18 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
 
         error_message = "Only the 'multiple tracker' messages should be displayed after adding 2 origins"
         self.assertTrue(
-            self.driver.find_element_by_id("pb_has_detected").is_displayed(), error_message)
-        self.assertTrue(
-            self.driver.find_element_by_id("count").is_displayed(), error_message)
-        self.assertTrue(
             self.driver.find_element_by_id("options_domain_list_trackers").is_displayed(), error_message)
         self.assertFalse(
             self.driver.find_element_by_id("options_domain_list_one_tracker").is_displayed(), error_message)
         self.assertFalse(
             self.driver.find_element_by_id("options_domain_list_no_trackers").is_displayed(), error_message)
 
-        # Check tracker count.
-        error_message = "Origin tracker count should be 2 after adding origin"
+        # check tracker count
         self.assertEqual(
-            self.driver.find_element_by_id("count").text, "2", error_message)
+            self.driver.find_element_by_id("options_domain_list_trackers").text,
+            "Privacy Badger has detected 2 potential tracking domains so far. These sliders let you control how Privacy Badger handles each tracker.",
+            "Origin tracker count should be 2 after adding origin"
+        )
 
         # Check those origins are displayed.
         origins = self.driver.find_element_by_id("blockedResourcesInner")
@@ -190,10 +184,6 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
         error_message = "Only the 'no trackers' message should be displayed before adding an origin"
         self.assertFalse(
             self.driver.find_element_by_id("options_domain_list_one_tracker").is_displayed(), error_message)
-        self.assertFalse(
-            self.driver.find_element_by_id("pb_has_detected").is_displayed(), error_message)
-        self.assertFalse(
-            self.driver.find_element_by_id("count").is_displayed(), error_message)
         self.assertFalse(
             self.driver.find_element_by_id("options_domain_list_trackers").is_displayed(), error_message)
 


### PR DESCRIPTION
Fixes #1329.

We are about to get a Persian locale, which is a right-to-left script (support added in f0f4f53245446305e8ee8bfb1071b6189ef40150). Some of our messages are formed by concatenating multiple locale strings in the code, which I think tips the scales in favor of using placeholders.