### PR TITLE
Make Soundcloud contentscript match more specific

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -90,7 +90,7 @@
         "SoundCloud": {
           "domain": "soundcloud.com",
           "buttonSelectors": [
-            "iframe[src*='api.soundcloud.com']"
+            "iframe[src^='https://w.soundcloud.com/player']"
           ],
           "replacementButton": {
             "details": "",

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -224,7 +224,8 @@ function replaceButtonWithHtmlCodeAndUnblockTracker(button, tracker, html) {
  * with executable scripts.
  */
 function replaceScriptsRecurse(node) {
-  if (node.getAttribute && node.getAttribute("type") == "text/javascript") {
+  if (node.nodeName && node.nodeName.toLowerCase() == 'script' &&
+      node.getAttribute && node.getAttribute("type") == "text/javascript") {
     var script = document.createElement("script");
     script.text = node.innerHTML;
     script.src = node.src;


### PR DESCRIPTION
Only match soundcloud script tags which begin with https://w.soundcloud.com, which will prevent javascript injection via widget replacement. Ensure that the node being replaced is a script.