### PR TITLE
Add "guildwars2.com" to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -275,6 +275,7 @@ gravatar.com
 greenhouse.io
 gscdn.nl
 gstatic.com
+guildwars2.com
 hackerone-user-content.com
 helium.com
 hellobar.com


### PR DESCRIPTION
Privacybadger is blocking access to `api.guildwars2.com` which is the [official public API for the MMORPG Guild Wars 2](https://api.guildwars2.com/v2). It can only be used to read personal data off an account if the user previously generated and provided a valid API key (see "Authentication" section at the bottom), which makes this opt-in.

(Probably?) since all sites making use of that API are hosted on different domains, and most of the sites access the API from the client side, Privacybadger blocks the access to this API, regularly causing questions like [this](https://www.reddit.com/r/Guildwars2/comments/53zunu/gw2efficiency_account_values_statistics_update/d7xvuzk/?context=3) or [this](https://www.reddit.com/r/Guildwars2/comments/91j9lh/best_conversion_rates_for_zephyrite_supply_boxes/e300s4o/?context=2).