### PR TITLE
Add selenium files to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 src/lib/vendor/
 src/tests/lib/vendor/
 node_modules/
+**/selenium/
+!tests/selenium/


### PR DESCRIPTION
On my machine, running "make lint" always prints a list of errors from javascript files in the Selenium directory in my virtualenv. This PR will ignore those files.