### PR TITLE
Add dropboxusercontent.com to Dropbox's MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -146,7 +146,7 @@ var multiDomainFirstPartiesArray = [
   ["dictionary.com", "thesaurus.com", "sfdict.com"],
   ["discountbank.co.il", "telebank.co.il"],
   ["discover.com", "discovercard.com"],
-  ["dropbox.com", "dropboxstatic.com", "getdropbox.com"],
+  ["dropbox.com", "dropboxstatic.com", "dropboxusercontent.com", "getdropbox.com"],
   ["d.rip", "kickstarter.com"],
   ["ea.com", "origin.com", "play4free.com", "tiberiumalliance.com"],
   [


### PR DESCRIPTION
Got a few user error reports. Not clear why Badger learns to block it. Maybe people embed things from `dropboxusercontent.com` on their sites? Anyway, Dropbox is a big site and this domain belongs to it.