### PR TITLE
Add Reuters domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -626,6 +626,31 @@ var multiDomainFirstPartiesArray = [
   ],
   ["reddit.com", "redditmedia.com", "redditstatic.com", "redd.it", "redditenhancementsuite.com", "reddituploads.com", "imgur.com"],
   [
+    "reuters.com",
+    "reuters.tv",
+    "reutersmedia.net",
+    "thomsonreuters.com",
+
+    "reutersagency.cn",
+
+    "thomsonreuters.ca",
+    "thomsonreuters.cn",
+    "thomsonreuters.co.jp",
+    "thomsonreuters.co.kr",
+    "thomsonreuters.com.ar",
+    "thomsonreuters.com.au",
+    "thomsonreuters.com.br",
+    "thomsonreuters.com.hk",
+    "thomsonreuters.com.my",
+    "thomsonreuters.com.pe",
+    "thomsonreuters.com.sg",
+    "thomsonreuters.com.tr",
+    "thomsonreuters.co.uk",
+    "thomsonreuters.es",
+    "thomsonreuters.in",
+    "thomsonreuters.ru",
+  ],
+  [
     "s-kanava.fi",
 
     "abcasemat.fi",


### PR DESCRIPTION
Error report counts by page domain and exact blocked "reuters" subdomain:
```
+-------------------------------------+-----------------------------+-------+
| fqdn                                | blocked_fqdn                | count |
+-------------------------------------+-----------------------------+-------+
| www.reuters.com                     | reuters-d.openx.net         |    16 |
| www.reuters.com                     | s2.reutersmedia.net         |    12 |
| www.reuters.com                     | s3.reutersmedia.net         |    12 |
| www.reuters.com                     | s4.reutersmedia.net         |    12 |
| www.reuters.com                     | s1.reutersmedia.net         |     8 |
| www.reuters.com                     | reuters.demdex.net          |     6 |
| www.reuters.com                     | reuters.us.intellitxt.com   |     5 |
| www.reuters.com                     | queso-cdn.prod.reuters.tv   |     3 |
| www.reuters.com                     | sope.prod.reuters.tv        |     3 |
| www.reuters.com                     | cdnstatic.reuters.tv        |     2 |
| www.reuters.com                     | fast.reuters.demdex.net     |     2 |
| www.reuters.com                     | queso.prod.reuters.tv       |     2 |
| uk.reuters.com                      | reuters.demdex.net          |     2 |
| uk.reuters.com                      | s2.reutersmedia.net         |     2 |
| uk.reuters.com                      | s3.reutersmedia.net         |     2 |
| uk.reuters.com                      | s4.reutersmedia.net         |     2 |
| phx.corporate-ir.net                | charts.reuters.com          |     1 |
| www.reuters.com                     | graphics.thomsonreuters.com |     1 |
| uk.reuters.com                      | queso-cdn.prod.reuters.tv   |     1 |
| uk.reuters.com                      | sope.prod.reuters.tv        |     1 |
| uk.reuters.com                      | static.reutersmedia.net     |     1 |
| www.reuters.com                     | static.reutersmedia.net     |     1 |
+-------------------------------------+-----------------------------+-------+
```