### PR TITLE
Add wetter.com to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -720,6 +720,7 @@ var multiDomainFirstPartiesArray = [
   ["walmart.com", "wal.co", "walmartimages.com", "walmart.ca"],
   ["weebly.com", "editmysite.com"],
   ["wellsfargo.com", "wf.com"],
+  ["wetter.com", "tiempo.es", "wettercomassets.com"],
   ["wikia.com", "wikia.net", "nocookie.net"],
   ["wikipedia.org", "wikimedia.org", "wikimediafoundation.org", "wiktionary.org",
     "wikiquote.org", "wikibooks.org", "wikisource.org", "wikinews.org",


### PR DESCRIPTION
I don't see any reports outside of `wetter.com`, but I think Privacy Badger learns to block `wettercomassets.com` when Wetter.com-powered widgets are used on third-party websites. You can get examples from https://publicwww.com/websites/"wettercomassets.com"/.

Error report counts by page domain and exact blocked "wetter" subdomain:
```
+---------------------+----------------------------------+-------+
| fqdn                | blocked_fqdn                     | count |
+---------------------+----------------------------------+-------+
| www.wetter.com      | ls1.wettercomassets.com          |    24 |
| www.wetter.com      | m1.wettercomassets.com           |    21 |
| www.wetter.com      | ls2.wettercomassets.com          |    20 |
| www.wetter.com      | m2.wettercomassets.com           |    20 |
| www.wetter.com      | cs3.wettercomassets.com          |    16 |
| www.wetter.com      | cs4.wettercomassets.com          |    16 |
| www.wetter.com      | cs2.wettercomassets.com          |    12 |
| www.wetter.com      | cm3.wettercomassets.com          |     9 |
| www.wetter.com      | static-radar.wettercomassets.com |     7 |
| www.wetteronline.de | wetteronline-d.openx.net         |     7 |
| www.wetter.com      | cs1.wettercomassets.com          |     3 |
| www.wetter.com      | cv2.wettercomassets.com          |     2 |
| ch.wetter.com       | cm3.wettercomassets.com          |     1 |
| ch.wetter.com       | cs2.wettercomassets.com          |     1 |
| ch.wetter.com       | cs3.wettercomassets.com          |     1 |
| ch.wetter.com       | cs4.wettercomassets.com          |     1 |
| www.freenet.de      | ls1.wettercomassets.com          |     1 |
| ch.wetter.com       | wetter-ssl.wemfbox.ch            |     1 |
+---------------------+----------------------------------+-------+
```

We could follow this up with a yellowlist PR to fix widgets on third-party sites.