### PR TITLE
Update Gap's MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -110,7 +110,6 @@ var multiDomainFirstPartiesArray = [
   ["autodesk.com", "tinkercad.com"],
   ["avon.com", "youravon.com"],
   ["baidu.com", "bdimg.com", "bdstatic.com"],
-  ["bananarepublic.com", "gap.com", "oldnavy.com", "piperlime.com"],
   ["bancomer.com", "bancomer.com.mx", "bbvanet.com.mx"],
   ["bankofamerica.com", "bofa.com", "mbna.com", "usecfo.com"],
   ["bank-yahav.co.il", "bankhapoalim.co.il"],
@@ -174,6 +173,28 @@ var multiDomainFirstPartiesArray = [
   ["facebook.com", "fbcdn.com", "fbcdn.net", "fbsbx.com", "facebook.net", "messenger.com"],
   ["firefox.com", "firefoxusercontent.com", "mozilla.org"],
   ["foxnews.com", "foxbusiness.com", "fncstatic.com"],
+  [
+    "gap.com",
+
+    "bananarepublic.com",
+    "gapfactory.com",
+    "gapinc.com",
+    "oldnavy.com",
+    "piperlime.com",
+
+    "bananarepublic.ca",
+    "bananarepublic.co.jp",
+    "bananarepublic.co.uk",
+    "bananarepublic.eu",
+    "gapcanada.ca",
+    "gap.co.jp",
+    "gap.co.uk",
+    "gap.eu",
+    "gap.hk",
+    "oldnavy.ca",
+
+    "assets-gap.com",
+  ],
   [
     "gettyimages.com",
 


### PR DESCRIPTION
Error report counts by page domain and exact blocked "assets-gap" subdomain:
```
+---------------------------------------------+----------------------+-------+
| fqdn                                        | blocked_fqdn         | count |
+---------------------------------------------+----------------------+-------+
| www.gap.com                                 | www1.assets-gap.com  |    20 |
| www.gap.com                                 | www3.assets-gap.com  |    20 |
| www.gap.com                                 | www4.assets-gap.com  |    19 |
| www.gap.com                                 | www2.assets-gap.com  |    18 |
| bananarepublic.gap.com                      | www3.assets-gap.com  |    18 |
| bananarepublic.gap.com                      | www1.assets-gap.com  |    17 |
| bananarepublic.gap.com                      | www2.assets-gap.com  |    17 |
| bananarepublic.gap.com                      | fonts.assets-gap.com |    16 |
| bananarepublic.gap.com                      | www4.assets-gap.com  |    16 |
| bananarepublicfactory.gapfactory.com        | www3.assets-gap.com  |    12 |
| bananarepublicfactory.gapfactory.com        | fonts.assets-gap.com |    11 |
| bananarepublicfactory.gapfactory.com        | www1.assets-gap.com  |    11 |
| bananarepublicfactory.gapfactory.com        | www2.assets-gap.com  |    11 |
| bananarepublicfactory.gapfactory.com        | www4.assets-gap.com  |    11 |
| athleta.gap.com                             | www3.assets-gap.com  |    10 |
| athleta.gap.com                             | www1.assets-gap.com  |     8 |
| athleta.gap.com                             | www2.assets-gap.com  |     8 |
| athleta.gap.com                             | www4.assets-gap.com  |     8 |
...
```

