### PR TITLE
Add img.purch.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -471,6 +471,7 @@ printfriendly.com
 providesupport.com
 psswrdbx.com
 publiekeomroep.nl
+img.purch.com
 qualtrics.com
 quotemedia.com
 api.razorpay.com


### PR DESCRIPTION
Fixes #2059.

Blocking `img.purch.com` breaks images on several prominent sites. `purch.com` is blocked in latest pre-trained data. I see cookie tracking from `privacy.purch.com` and canvas fingerprinting from `assets.purch.com`.

Error report counts by page domain and exact blocked subdomain:
```
+--------------------------+-----------------------------------------+-------+
| fqdn                     | blocked_fqdn                            | count |
+--------------------------+-----------------------------------------+-------+
| www.tomshardware.com     | assets.purch.com                        |   130 |
| www.tomshardware.com     | img.purch.com                           |   117 |
| www.space.com            | syndicate.purch.com                     |    61 |
| www.space.com            | img.purch.com                           |    60 |
| www.tomshardware.com     | ramp.purch.com                          |    58 |
| www.space.com            | ramp.purch.com                          |    50 |
| www.tomshardware.com     | t.purch.com                             |    46 |
| www.space.com            | assets.purch.com                        |    45 |
| www.livescience.com      | img.purch.com                           |    35 |
| www.tomshardware.com     | privacy.purch.com                       |    26 |
| www.livescience.com      | assets.purch.com                        |    25 |
| www.tomsguide.com        | img.purch.com                           |    21 |
| www.tomshardware.com     | qa.assets.purch.com                     |    21 |
| www.tomshardware.com     | syndicate.purch.com                     |    21 |
| www.livescience.com      | ramp.purch.com                          |    20 |
| www.tomsguide.com        | assets.purch.com                        |    19 |
| www.laptopmag.com        | assets.purch.com                        |    15 |
| www.laptopmag.com        | img.purch.com                           |    14 |
| www.space.com            | t.purch.com                             |    14 |
| www.laptopmag.com        | ramp.purch.com                          |    13 |
| www.tomsguide.com        | ramp.purch.com                          |    13 |
| www.space.com            | purch-match.dotomi.com                  |    12 |
| www.tomshardware.com     | purch-match.dotomi.com                  |    12 |
| www.space.com            | purch-sync.go.sonobi.com                |    12 |
| www.tomshardware.com     | purch-sync.go.sonobi.com                |    11 |
| www.livescience.com      | purch-match.dotomi.com                  |    10 |
| www.toptenreviews.com    | img.purch.com                           |     9 |
| www.toptenreviews.com    | ramp.purch.com                          |     9 |
...
```