### PR TITLE
Add cdngeneral.rentcafe.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -489,6 +489,7 @@ recurly.com
 reddit.com
 redditmedia.com
 redditstatic.com
+cdngeneral.rentcafe.com
 resellerratings.com
 resultspage.com
 rewardstyle.com


### PR DESCRIPTION
To reproduce, first visit rentcafe.com to get a Google Analytics (#367) cookie set on `cdngeneral.rentcafe.com` and then visit three of the sites below.

Sample debug info:
```
**** ACTION_MAP for rentcafe.com debugger eval code:3:3
t.rentcafe.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 1535522741860
}
cdngeneral.rentcafe.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 1535427264771
}
rentcafe.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
}
**** SNITCH_MAP for rentcafe.com
rentcafe.com [
  "beaconviewapts.com",
  "shorehamapartments.com",
  "apertureon5th.com"
]
```

Error report counts by page domain and exact blocked subdomain:
```
+------------------------------------+--------------------------+-------+
| fqdn                               | blocked_fqdn             | count |
+------------------------------------+--------------------------+-------+
| www.coventryroseville.com          | cdngeneral.rentcafe.com  |     6 |
| www.coventryroseville.com          | t.rentcafe.com           |     6 |
| properties.steven-scott.com        | cdngeneral.rentcafe.com  |     2 |
| www.bridgesroseville.com           | cdngeneral.rentcafe.com  |     2 |
| properties.steven-scott.com        | t.rentcafe.com           |     2 |
| www.bridgesroseville.com           | t.rentcafe.com           |     2 |
| www.shorehamapartments.com         | api.rentcafe.com         |     1 |
| www.thevillagesgg.com              | api.rentcafe.com         |     1 |
| optimasignature.com                | cdn.rentcafe.com         |     1 |
| www.apertureon5th.com              | cdn.rentcafe.com         |     1 |
| www.beaconviewapts.com             | cdn.rentcafe.com         |     1 |
| www.domainhenderson.com            | cdn.rentcafe.com         |     1 |
| www.idahoterrace.com               | cdn.rentcafe.com         |     1 |
| www.nuestrasenoraapts.com          | cdn.rentcafe.com         |     1 |
| www.preserveatdeercreek-living.com | cdn.rentcafe.com         |     1 |
| www.resideliving.com               | cdn.rentcafe.com         |     1 |
| www.tributeproperties.com          | cdn.rentcafe.com         |     1 |
| www.v2apartments.com               | cdn.rentcafe.com         |     1 |
| 1333wabash.securecafe.com          | cdngeneral.rentcafe.com  |     1 |
| huntingtonlakes.securecafe.com     | cdngeneral.rentcafe.com  |     1 |
| www.1333wabash.com                 | cdngeneral.rentcafe.com  |     1 |
...
```

I don't see `cdn.rentcafe.com` being used at this time.