### PR TITLE
Fix for Issue #1896: script and docs for functional tests locally on MacOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ node_modules
 
 tests/.cache
 tests/.pytest_cache
+.pytest_cache
 
 *.xpi
 .chrome-profile

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -47,6 +47,9 @@ The `BROWSER` environment variable must be set. It must be one of:
 * `BROWSER=/path/to/a/browser`
 * the name of a browser executable that can be found like `which $BROWSER`
 * or simply `BROWSER=chrome` or `BROWSER=firefox` if you have them installed
+* For MacOS and Firefox, the full Application folder path to the binary is:
+  `BROWSER=/Applications/Firefox.app/Contents/MacOS/firefox-bin`
+* For MacOS and Chrome (complete with spaces that need to be escaped) use: `BROWSER=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome`
 
 ### Examples
 

--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -33,8 +33,17 @@ function setup_firefox {
         exit 1
       fi
     fi
+
+    # Geckodriver distribution is MacOS or Linux specific
+    os="$(uname -s)"
+    if [[ $os == "Darwin" ]]; then
+      os_dist="macos.tar.gz"
+    else
+      os_dist="linux64.tar.gz"
+    fi
+
     echo "Setting up geckodriver version $version ..."
-    url="https://github.com/mozilla/geckodriver/releases/download/${version}/geckodriver-${version}-linux64.tar.gz"
+    url="https://github.com/mozilla/geckodriver/releases/download/${version}/geckodriver-${version}-${os_dist}"
     wget -q -O /tmp/geckodriver.tar.gz "$url"
     sudo tar -xvf /tmp/geckodriver.tar.gz -C /usr/local/bin/
     sudo chmod a+x /usr/local/bin/geckodriver


### PR DESCRIPTION
Fixes #1896.

Per the comments on the thread, after my fix, and after manually calling the functions in setup_travis.sh from the command line in Terminal, I was able to run the selenium test suite using the command line: 

`BROWSER=/Applications/Firefox.app/Contents/MacOS/firefox pytest -v .`

and was able to complete the test run. Pytest Configuration:
platform darwin -- Python 3.6.4, pytest-3.7.2, py-1.5.4, pluggy-0.7.1

I did not see the second issue reported in the thread, but Python version (3.4 vs 3.6) may be a factor. 