### PR TITLE
Spoof Referer header of third party requests

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -135,6 +135,10 @@
         "message": "Replace social widgets",
         "description": "Checkbox label on the general settings page"
     },
+    "options_spoof_referrer_checkbox": {
+        "message": "Spoof the Referrer header",
+        "description": "Checkbox label for spoofing referrer on the general settings page"
+    },
     "options_incognito_warning": {
         "message": "** Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
         "description": "Detailed explanation shown under checkboxes on the general settings page"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -478,7 +478,8 @@ Badger.prototype = {
     sendDNTSignal: true,
     showCounter: true,
     showTrackingDomains: false,
-    socialWidgetReplacementEnabled: true
+    socialWidgetReplacementEnabled: true,
+    spoofReferrerEnabled: true
   },
 
   /**
@@ -634,6 +635,10 @@ Badger.prototype = {
    */
   isSocialWidgetReplacementEnabled: function() {
     return this.getSettings().getItem("socialWidgetReplacementEnabled");
+  },
+
+  isSpoofReferrerEnabled: function() {
+    return this.getSettings().getItem("spoofReferrerEnabled");
   },
 
   isDNTSignalEnabled: function() {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -107,6 +107,7 @@ function loadOptions() {
   $("#show_counter_checkbox").prop("checked", badger.showCounter());
   $("#replace_social_widgets_checkbox").on("click", updateSocialWidgetReplacement);
   $("#replace_social_widgets_checkbox").prop("checked", badger.isSocialWidgetReplacementEnabled());
+  $("#spoof_referrer_checkbox").prop("checked", badger.isSpoofReferrerEnabled());
   $("#enable_dnt_checkbox").on("click", updateDNTCheckboxClicked);
   $("#enable_dnt_checkbox").prop("checked", badger.isDNTSignalEnabled());
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
@@ -326,6 +327,20 @@ function updateSocialWidgetReplacement() {
     type: "updateSettings",
     data: {
       socialWidgetReplacementEnabled: enabled
+    }
+  });
+}
+
+/**
+ * Update setting for spoofing the referrer header of all 3rd party requests.
+ */
+function updateSpoofReferrer() {
+  const enabled = $("#spoof_referrer_checkbox").prop("checked");
+
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: {
+      spoofReferrerEnabled: enabled
     }
   });
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -107,6 +107,7 @@ function loadOptions() {
   $("#show_counter_checkbox").prop("checked", badger.showCounter());
   $("#replace_social_widgets_checkbox").on("click", updateSocialWidgetReplacement);
   $("#replace_social_widgets_checkbox").prop("checked", badger.isSocialWidgetReplacementEnabled());
+  $("#spoof_referrer_checkbox").on("click", updateSpoofReferrer);
   $("#spoof_referrer_checkbox").prop("checked", badger.isSpoofReferrerEnabled());
   $("#enable_dnt_checkbox").on("click", updateDNTCheckboxClicked);
   $("#enable_dnt_checkbox").prop("checked", badger.isDNTSignalEnabled());

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -173,9 +173,9 @@ function onBeforeSendHeaders(details) {
       return {};
     }
   } else {
+    // spoof referer header for third party requests
     const refererHeader = details.requestHeaders.find(header => header.name === "Referer");
     if (refererHeader) {
-      // console.log('before: referer', JSON.parse(JSON.stringify(details.requestHeaders)));
       if (details.method === "GET") {
         // spoof referer value
         const requestUrl = new URL(details.url);
@@ -185,7 +185,6 @@ function onBeforeSendHeaders(details) {
         const refererHeaderIndex = details.requestHeaders.indexOf(refererHeader);
         details.requestHeaders.splice(refererHeaderIndex, 1);
       }
-      // console.log('after: referer', details.requestHeaders);
     }
   }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -172,6 +172,21 @@ function onBeforeSendHeaders(details) {
     } else {
       return {};
     }
+  } else {
+    const refererHeader = details.requestHeaders.find(header => header.name === "Referer");
+    if (refererHeader) {
+      // console.log('before: referer', JSON.parse(JSON.stringify(details.requestHeaders)));
+      if (details.method === "GET") {
+        // spoof referer value
+        const requestUrl = new URL(details.url);
+        refererHeader.value = requestUrl.origin;
+      } else {
+        // remove referer header from non-GET request
+        const refererHeaderIndex = details.requestHeaders.indexOf(refererHeader);
+        details.requestHeaders.splice(refererHeaderIndex, 1);
+      }
+      // console.log('after: referer', details.requestHeaders);
+    }
   }
 
   var requestAction = checkAction(tab_id, requestDomain, frame_id);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -172,18 +172,21 @@ function onBeforeSendHeaders(details) {
     } else {
       return {};
     }
-  } else {
-    // spoof referer header for third party requests
-    const refererHeader = details.requestHeaders.find(header => header.name === "Referer");
-    if (refererHeader) {
-      if (details.method === "GET") {
-        // spoof referer value
-        const requestUrl = new URL(details.url);
-        refererHeader.value = requestUrl.origin;
-      } else {
-        // remove referer header from non-GET request
-        const refererHeaderIndex = details.requestHeaders.indexOf(refererHeader);
-        details.requestHeaders.splice(refererHeaderIndex, 1);
+
+  } else if (badger.isSpoofReferrerEnabled()) {
+    if (badger.isPrivacyBadgerEnabled(tabDomain) && badger.isPrivacyBadgerEnabled(requestDomain)) {
+      // spoof referer header for third party requests
+      const refererHeader = details.requestHeaders.find(header => header.name === "Referer");
+      if (refererHeader) {
+        if (details.method === "GET") {
+          // spoof referer value
+          const requestUrl = new URL(details.url);
+          refererHeader.value = requestUrl.origin;
+        } else {
+          // remove referer header from non-GET request
+          const refererHeaderIndex = details.requestHeaders.indexOf(refererHeader);
+          details.requestHeaders.splice(refererHeaderIndex, 1);
+        }
       }
     }
   }

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -152,6 +152,12 @@
       </div>
       <div class="checkbox">
         <label>
+          <input type="checkbox" id="spoof_referrer_checkbox">
+          <span class="i18n_options_spoof_referrer_checkbox"></span>
+        </label>
+      </div>
+      <div class="checkbox">
+        <label>
           <input type="checkbox" id="enable_dnt_checkbox">
           <span class="i18n_options_enable_dnt_checkbox"></span>
         </label>


### PR DESCRIPTION
This PR will spoof the `Referer` header of all third party `GET` requests.

For other third party requests, the `Referer` header is removed - this is the same as what uMatrix does.
See [this comment in uMatrix](https://github.com/gorhill/uMatrix/issues/773#issuecomment-350509427) and [the implementation in uMatrix](https://github.com/gorhill/uMatrix/blob/2714193b736d2723f5282ed491423b6d0df9b1ed/src/js/traffic.js#L293-L299)

Fixes #855 except that spoofing is mandatory, there is no option to turn it off.

Should an option be added for this? Is it not needed?