### PR TITLE
Fix popup layout for overflow menu in Firefox

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -26,7 +26,7 @@ body {
   font-size: 12px;
 
   margin: 0;
-  padding: 7px 15px 0;
+  padding: 7px 15px;
 
   min-width: 430px; /* Chrome */
   max-width: 100%;  /* FF android */
@@ -160,7 +160,7 @@ font-size: 16px;
   cursor: move;
 }
 #siteControls {
-  margin-bottom: 5px;
+  margin-top: 5px;
 }
 
 #firstRun {
@@ -261,7 +261,7 @@ font-size: 16px;
   padding: 5px;
   cursor: pointer;
   text-align: center;
-  margin: 8px 0;
+  margin-top: 8px;
   border: 2px solid #707070;
   width: 100%;
   color: #707070;
@@ -348,7 +348,6 @@ font-size: 16px;
 }
 #siteControls button {
   font-size: 12px;
-  display: block;
 }
 
 #version{

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -369,3 +369,28 @@ font-size: 16px;
 .tooltipster-sidetip .tooltipster-arrow-border {
     border: none;
 }
+
+@media screen and (max-width: 325px){
+  .origin {
+    max-width: 150px;
+  }
+
+  .switch-container{
+    width: 100px;
+    display: block;
+    margin-left: 150px;
+  }
+
+  .key {
+    padding-left: 150px;
+  }
+  .key img{
+    margin-left: 12px;
+  }
+
+  .honeybadgerPowered {
+    float: right;
+    left: 0;
+    margin-right: 0;
+  }
+}

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -370,7 +370,7 @@ font-size: 16px;
     border: none;
 }
 
-@media screen and (max-width: 325px){
+@media screen and (max-width: 350px){
   .origin {
     max-width: 150px;
   }


### PR DESCRIPTION
Fix #1120 by setting ad-hoc styles for the popup shown from the overflow menu.

One odd thing I've noticed, and maybe you can check if it happens to you as well: the *first* time the popup is opened from the overflow menu, the popup is wider than it should be and there is a blank space on the right. Screenshot:

<img width="451" alt="a1q5ftfstqc_lgigometgw" src="https://user-images.githubusercontent.com/794578/45653114-cf4af880-baa4-11e8-88cc-a6d0585603aa.png">

From then on the popup is shown correctly.
Also, the problem is not present if the option "disable popup auto hide" is set. It looks like firefox is not updating the width of the popup fast enough.