### PR TITLE
Add NettiX domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -691,6 +691,19 @@ var multiDomainFirstPartiesArray = [
   ["myuv.com", "uvvu.com"],
   ["nefcuonline.com", "nefcu.com"],
   ["netflix.com", "nflxext.com", "nflximg.net", "nflxvideo.net"],
+  [
+    "nettix.fi",
+
+    "nettiauto.com",
+    "nettikaravaani.com",
+    "nettikone.com",
+    "nettimarkkina.com",
+    "nettimokki.com",
+    "nettimoto.com",
+    "nettivaraosa.com",
+    "nettivene.com",
+    "nettivuokraus.com",
+  ],
   ["newegg.com", "neweggbusiness.com", "neweggimages.com", "newegg.ca"],
   [
     "newscorpaustralia.com",


### PR DESCRIPTION
Domain list taken from https://www.nettix.fi/in-english/ and error reports (below).

Another set of broken sites caused by Badger not auto-learning to block Google Analytics (#367). GA sets a first-party cookie on `nettix.fi`; NettiX uses `nettix.fi` subdomains scoped to the GA cookie to serve static resources on NettiX sites.