### PR TITLE
Add verify.monzo.com to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -380,6 +380,7 @@ microsoftonline.com
 microsofttranslator.com
 mlive.com
 mobify.com
+verify.monzo.com
 loop.services.mozilla.com
 mozilla.net
 mozilla.org


### PR DESCRIPTION
This PR yellowlists verify.monzo.com and fixes #2175 
Unfortunately we don't have the debug information as the issue was appearing in our customer's browsers. We couldn't reproduce it ourselves.