### PR TITLE
Add danid.dk to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -120,6 +120,7 @@ cursecdn.com
 custhelp.com
 d3js.org
 dailymotion.com
+danid.dk
 dealer.com
 dealerinspire.com
 delicious.com


### PR DESCRIPTION
> ... the domain `applet.danid.dk` is not a tracker, but the universal government login system in Denmark called NemID. The reason I write to you is because when you enable Privacy Badger and you're not aware of it later on, it can get frustrating to find out what was blocking access to ones online bank, government mail and so on.

Error report counts by page domain and exact blocked `danid.dk` subdomain:
```
+-----------------------------------+----------------------------+-------+
| fqdn                              | blocked_fqdn               | count |
+-----------------------------------+----------------------------+-------+
| nemlog-in.dk                      | applet.danid.dk            |    48 |
| www.nemadgang.dk                  | applet.danid.dk            |    31 |
| www.netbank.nordea.dk             | applet.danid.dk            |    15 |
| danskebank.dk                     | applet.danid.dk            |    11 |
| logon.e-boks.dk                   | applet.danid.dk            |     9 |
| www.merkur.dk                     | applet.danid.dk            |     6 |
...
| nemlog-in.dk                      | codefileclient.danid.dk    |     2 |
| www.medarbejdersignatur.dk        | codefileclient.danid.dk    |     2 |
| acs4.3dsecure.no                  | applet.danid.dk            |     1 |
| blanket.kk.dk                     | applet.danid.dk            |     1 |
...
```

Error report counts by date and exact blocked `danid.dk` subdomain:
```
+---------+----------------------------+-------+
| ym      | blocked_fqdn               | count |
+---------+----------------------------+-------+
| 2018-09 | applet.danid.dk            |    14 |
| 2018-08 | applet.danid.dk            |    16 |
| 2018-07 | applet.danid.dk            |     9 |
| 2018-06 | applet.danid.dk            |    10 |
| 2018-05 | applet.danid.dk            |     7 |
| 2018-04 | applet.danid.dk            |     4 |
| 2018-04 | codefileclient.pp.danid.dk |     1 |
| 2018-03 | applet.danid.dk            |     8 |
| 2018-02 | applet.danid.dk            |    12 |
| 2018-02 | codefileclient.danid.dk    |     1 |
...
```