### PR TITLE
Fix issues with google link unwrapping

### DIFF
--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -5,7 +5,9 @@ let trap_link = "a[onmousedown^='return rwt(this,'], a[ping]";
 
 // Remove excessive attributes and event listeners from link a
 function cleanLink(a) {
-  // remove all attributes from a link except for href
+  // remove all attributes from a link except for href,
+  // target (to support "Open each selected result in a new browser window"),
+  // class and ARIA attributes
   for (let i = a.attributes.length - 1; i >= 0; --i) {
     const attr = a.attributes[i];
     if (attr.name !== 'href' && attr.name !== 'target' &&

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -8,7 +8,8 @@ function cleanLink(a) {
   // remove all attributes from a link except for href
   for (let i = a.attributes.length - 1; i >= 0; --i) {
     const attr = a.attributes[i];
-    if (attr.name !== 'href') {
+    if (attr.name !== 'href' && attr.name !== 'target' &&
+      attr.name !== 'class' && !attr.name.startsWith('aria-')) {
       a.removeAttribute(attr.name);
     }
   }

--- a/src/js/firstparties/google-static.js
+++ b/src/js/firstparties/google-static.js
@@ -7,10 +7,13 @@ function unwrapLink(a) {
     return;
   }
 
-  // remove all attributes from a link except for target
+  // remove all attributes from a link except for target, class, and aria-*
+  // attributes. This should prevent the script from breaking styles and
+  // features for people with disabilities.
   for (let i = a.attributes.length - 1; i >= 0; --i) {
     const attr = a.attributes[i];
-    if (attr.name !== "target") {
+    if (attr.name !== 'target' && attr.name !== 'class' &&
+      !attr.name.startsWith('aria-')) {
       a.removeAttribute(attr.name);
     }
   }


### PR DESCRIPTION
When cleaning links, don't remove 'about', 'class', or 'aria-*' attributes. Fixes #2181.