### PR TITLE
Options page layout fixes for small screens

### DIFF
--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -35,6 +35,8 @@ label
   float: left;
   clear: both;
   margin-bottom: 20px;
+  max-width: 700px;
+  width: 100%;
 }
 
 .btn-silo + .btn-silo {
@@ -45,6 +47,7 @@ label
 
 .btn-silo div {
   max-width: 350px;
+  width: 100%;
   float: left;
 }
 

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -18,6 +18,11 @@ button
   white-space: pre;
 }
 
+label
+{
+  display: inline-flex;
+}
+
 #pbInstructions {
   margin-bottom: 20px;
 }
@@ -39,7 +44,7 @@ button
 }
 
 .btn-silo div {
-  width: 350px;
+  max-width: 350px;
   float: left;
 }
 
@@ -51,7 +56,7 @@ button
 
 .btn-danger:hover {
   color: white;
-  background: #e02431; 
+  background: #e02431;
 }
 
 .importInput{
@@ -97,7 +102,7 @@ button
 #settings-suffix {
     color: #555;
     font-size: 12px;
-    width: 500px;
+    max-width: 500px;
     margin-left: 50px;
 }
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -114,25 +114,24 @@
     <p class="i18n_disabled_for_these_domains"></p>
 
     <form id="whitelistForm" action="#">
-      <table>
-        <tr>
-          <td style="max-width:100%">
+      <div>
+        <div>
+          <div style="float: left; max-width: 400px; width: 100%; margin-right: 30px">
             <input type="text" value="" id="newWhitelistDomain" style="width:100%" placeholder="i18n_whitelist_form_domain_input_placeholder">
-          </td>
-          <td>
+          </div>
+          <div style="float: left">
             <button class="addButton" type="submit"><span class="i18n_add_domain_button"></span></button>
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            <select id="excludedDomainsBox" size="10" multiple style="width:500px; background: white;"></select>
-          </td>
-          <td>
+          </div>
+        </div>
+        <div style="clear: both; overflow: hidden">
+          <div style="float: left; max-width: 420px; width: 100%; margin-right: 10px">
+            <select id="excludedDomainsBox" size="10" multiple style="width: 100%; background: white;"></select>
+          </div>
+          <div style="float: left">
             <button id="removeWhitelist" class="removeButton"><span class="i18n_remove_button"></span></button>
-          </td>
-        </tr>
-      </table>
+          </div>
+        </div>
+      </div>
     </form>
   </div>
 


### PR DESCRIPTION
Fixes #2166 

I went through all options pages, and made adjustments so that they display better on small screens. Here are some screenshots with my modifications:
## General Settings: 
![general settings](https://user-images.githubusercontent.com/7536089/46907911-56469180-cee8-11e8-9ffd-51bd717b7300.png)

## Disabled Sites:
![disabled sites](https://user-images.githubusercontent.com/7536089/46907916-69596180-cee8-11e8-90c0-8e6dec4ca011.png)

## Tracking Domains:
![tracking domains](https://user-images.githubusercontent.com/7536089/46907920-770ee700-cee8-11e8-8d7a-757fe64392fd.png)


## Manage Data:
![manage data](https://user-images.githubusercontent.com/7536089/46907921-7c6c3180-cee8-11e8-9a17-df9732aabba6.png)

