### PR TITLE
Add scdn.co to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -501,6 +501,7 @@ rssinclude.com
 salesforce.com
 salsalabs.com
 sbnation.com
+scdn.co
 schd.ws
 sched.org
 scribd.com


### PR DESCRIPTION
This domain is Spotify’s public CDN domain which is used to serve assets required to display and add functionality to a variety of our public web properties. For example:

- https://artists.spotify.com/
- https://adstudio.spotify.com