### PR TITLE
Migrate off Rawgit

### DIFF
--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -24,11 +24,11 @@ class DNTTest(pbtest.PBSeleniumTest):
     # TODO switch to non-delayed version (see below)
     # once race condition (https://crbug.com/478183) is fixed
     NAVIGATOR_DNT_TEST_URL = (
-        "https://cdn.rawgit.com/ghostwords/"
-        "1c50869a0469e38d5dabd53f1204d3de/raw/01e06af8d2b3e35228bf8f000bdc12d0b2871b64/"
+        "https://gitcdn.link/cdn/ghostwords/"
+        "1c50869a0469e38d5dabd53f1204d3de/raw/64e98fc95256978e119adae9c769f8a8da24f4d8/"
         "privacy-badger-navigator-donottrack-delayed-fixture.html"
         # non-delayed version:
-        #"9fc6900566a2f93edd8e4a1e48bbaa28/raw/741627c60ca53be69bc11bf21d6d1d0b42edb52a/"
+        #"9fc6900566a2f93edd8e4a1e48bbaa28/raw/b7a6d9e70ce103da49e74ba239da4443fb514c2f/"
         #"privacy-badger-navigator-donottrack-fixture.html"
     )
 
@@ -78,8 +78,8 @@ class DNTTest(pbtest.PBSeleniumTest):
     @pbtest.repeat_if_failed(3)
     def test_dnt_check_should_happen_for_blocked_domains(self):
         PAGE_URL = (
-            "https://cdn.rawgit.com/ghostwords/"
-            "74585c942a918509b20bf2db5659646e/raw/f42d25717e5b4f735c7affa527a2e0b62286c005/"
+            "https://gitcdn.link/cdn/ghostwords/"
+            "74585c942a918509b20bf2db5659646e/raw/2401659e678442de6309339882f19fbb21dbc959/"
             "privacy_badger_dnt_test_fixture.html"
         )
         DNT_DOMAIN = "www.eff.org"
@@ -193,8 +193,8 @@ class DNTTest(pbtest.PBSeleniumTest):
 
     def test_should_not_record_nontracking_domains(self):
         TEST_URL = (
-            "https://cdn.rawgit.com/ghostwords/"
-            "eef2c982fc3151e60a78136ca263294d/raw/13ed3d1e701994640b8d8065b835f8a9684ece92/"
+            "https://gitcdn.link/cdn/ghostwords/"
+            "eef2c982fc3151e60a78136ca263294d/raw/9f83f7ad9b7aa04484a9682b937dec7bcbfb7a6e/"
             "privacy_badger_recording_nontracking_domains_fixture.html"
         )
         TRACKING_DOMAIN = "dnt-request-cookies-test.trackersimulator.org"

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -40,9 +40,9 @@ return (
     @pbtest.repeat_if_failed(3)
     def test_canvas_fingerprinting_detection(self):
         PAGE_URL = (
-            "https://cdn.rawgit.com/ghostwords"
-            "/ff6347b93ec126d4f73a9ddfd8b09919/raw/2332f82d3982bd4a84cd2380aed90228955d1f2a"
-            "/privacy_badger_fingerprint_test_fixture.html"
+            "https://gitcdn.link/cdn/ghostwords/"
+            "ff6347b93ec126d4f73a9ddfd8b09919/raw/6b215b3f052115d36831ecfca758081ca7da7e37/"
+            "privacy_badger_fingerprint_test_fixture.html"
         )
         FINGERPRINTING_DOMAIN = "cdn.jsdelivr.net"
 

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -27,9 +27,9 @@ class SupercookieTest(pbtest.PBSeleniumTest):
     @pbtest.repeat_if_failed(5)
     def test_async_tracking_misattribution_bug(self):
         self.load_url(
-            "https://cdn.rawgit.com/ghostwords"
-            "/d3685dc39f7e67dddf1edf2614beb6fc/raw/a78cfd6c86d51a8d8ab1e214e4e49e2c025d4715"
-            "/privacy_badger_async_bug_test_fixture.html"
+            "https://gitcdn.link/cdn/ghostwords/"
+            "d3685dc39f7e67dddf1edf2614beb6fc/raw/f52060b329dfeb4e264fcd21c48206cff98786f6/"
+            "privacy_badger_async_bug_test_fixture.html"
         )
 
         # the above HTML page reloads itself furiously to trigger our bug
@@ -56,7 +56,11 @@ class SupercookieTest(pbtest.PBSeleniumTest):
         # perhaps because the script runs before we start intercepting the calls.
 
         # Perhaps related to: https://github.com/ghostwords/chameleon/issues/5
-        self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html")
+        self.load_url(
+            "https://gitcdn.link/cdn/gunesacar/"
+            "24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/"
+            "frame_ls.html"
+        )
         # TODO might also be related to https://github.com/EFForg/privacybadger/pull/1522
         time.sleep(1)
         self.assertTrue(pbtest.retry_until(
@@ -79,9 +83,9 @@ class SupercookieTest(pbtest.PBSeleniumTest):
     def test_should_not_detect_ls_of_third_party_script(self):
         # a third-party script included by the top page (not a 3rd party frame)
         self.load_url(
-            "https://rawgit.com/gunesacar"
-            "/b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11"
-            "/localstorage_from_third_party_script.html"
+            "https://gitcdn.link/cdn/gunesacar/"
+            "b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11/"
+            "localstorage_from_third_party_script.html"
         )
         time.sleep(4)
         self.assertFalse(self.detected_tracking_by("githack.com"))

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -68,16 +68,16 @@ class SupercookieTest(pbtest.PBSeleniumTest):
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):
         self.load_url(
-            "https://gistcdn.githack.com/gunesacar"
-            "/6f0c39fb728a218ccd91215bfefbd4e0/raw/f438eb4e5ce10dc8623a8834b1298fd4a846c6fa"
-            "/low_entropy_localstorage_from_third_party_script.html"
+            "https://gitcdn.link/cdn/gunesacar/"
+            "6f0c39fb728a218ccd91215bfefbd4e0/raw/f438eb4e5ce10dc8623a8834b1298fd4a846c6fa/"
+            "low_entropy_localstorage_from_third_party_script.html"
         )
-        time.sleep(4)
+        time.sleep(3)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_first_party_ls(self):
         self.load_url("https://gistcdn.githack.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html")
-        time.sleep(4)
+        time.sleep(3)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
     def test_should_not_detect_ls_of_third_party_script(self):
@@ -87,7 +87,7 @@ class SupercookieTest(pbtest.PBSeleniumTest):
             "b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11/"
             "localstorage_from_third_party_script.html"
         )
-        time.sleep(4)
+        time.sleep(3)
         self.assertFalse(self.detected_tracking_by("githack.com"))
 
 


### PR DESCRIPTION
> RawGit is now in a sunset phase and will soon shut down. It's been a fun five years, but all things must end.
> 
> GitHub repositories that served content through RawGit within the last month will continue to be served until at least October of 2019. URLs for other repositories are no longer being served.
> 
> If you're currently using RawGit, please stop using it as soon as you can.

-- https://rawgit.com/