### PR TITLE
Improve localStorage clobbering

### DIFF
--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -15,24 +15,6 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * Runs in page content context. Injects a script that deletes cookies.
- * Communicates to webrequest.js to get orders if to delete cookies.
- */
-
-function insertCcScript(text) {
-  var parent = document.documentElement,
-    script = document.createElement('script');
-
-  script.text = text;
-  script.async = false;
-
-  parent.insertBefore(script, parent.firstChild);
-  parent.removeChild(script);
-}
-
-// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
-
 (function () {
 
 // don't inject into non-HTML documents (such as XML documents)
@@ -52,7 +34,7 @@ chrome.runtime.sendMessage({ checkLocation: window.FRAME_URL }, function (blocke
       document.__defineGetter__("cookie", function() { return ""; });
     } +')();';
 
-    insertCcScript(code);
+    window.injectScript(code);
   }
   return true;
 });

--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -45,7 +45,7 @@ if (document instanceof HTMLDocument === false && (
 }
 
 // TODO race condition; fix waiting on https://crbug.com/478183
-chrome.runtime.sendMessage({checkLocation:document.location.href}, function(blocked) {
+chrome.runtime.sendMessage({ checkLocation: window.FRAME_URL }, function (blocked) {
   if (blocked) {
     var code = '('+ function() {
       document.__defineSetter__("cookie", function(/*value*/) { });

--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -26,6 +26,11 @@ if (document instanceof HTMLDocument === false && (
   return;
 }
 
+// don't bother asking to run when trivially in first-party context
+if (window.top == window) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({ checkLocation: window.FRAME_URL }, function (blocked) {
   if (blocked) {

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -15,30 +15,6 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * Runs in page content context. Injects a script that deletes cookies.
- * Communicates to webrequest.js to get orders if to delete cookies.
- */
-
-/**
- * Insert script into page
- *
- * @param {String} text The script to insert into the page
- */
-
-function insertClsScript(text) {
-  var parent = document.documentElement,
-    script = document.createElement('script');
-
-  script.text = text;
-  script.async = false;
-
-  parent.insertBefore(script, parent.firstChild);
-  parent.removeChild(script);
-}
-
-// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
-
 (function () {
 
 // don't inject into non-HTML documents (such as XML documents)
@@ -88,7 +64,7 @@ chrome.runtime.sendMessage({ checkLocation: window.FRAME_URL }, function (blocke
         }
       } +')()';
 
-    insertClsScript(code);
+    window.injectScript(code);
   }
   return true;
 });

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -26,6 +26,11 @@ if (document instanceof HTMLDocument === false && (
   return;
 }
 
+// don't bother asking to run when trivially in first-party context
+if (window.top == window) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({ checkLocation: window.FRAME_URL }, function (blocked) {
   if (blocked) {

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -51,7 +51,7 @@ if (document instanceof HTMLDocument === false && (
 }
 
 // TODO race condition; fix waiting on https://crbug.com/478183
-chrome.runtime.sendMessage({checkLocation:document.location.href}, function(blocked) {
+chrome.runtime.sendMessage({ checkLocation: window.FRAME_URL }, function (blocked) {
   if (blocked) {
     // https://stackoverflow.com/questions/49092423/how-to-break-on-localstorage-changes
     var code =

--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -35,20 +35,6 @@ function getPageScript() {
 
 }
 
-/**
- * Executes a script in the page DOM context
- */
-function insertPageScript(text) {
-  var parent = document.documentElement,
-    script = document.createElement('script');
-
-  script.text = text;
-  script.async = false;
-
-  parent.insertBefore(script, parent.firstChild);
-  parent.removeChild(script);
-}
-
 // END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
 
 (function () {
@@ -67,7 +53,7 @@ chrome.runtime.sendMessage({
   checkDNT: true
 }, function (enabled) {
   if (enabled) {
-    insertPageScript(getPageScript());
+    window.injectScript(getPageScript());
   }
 });
 

--- a/src/js/contentscripts/fingerprinting.js
+++ b/src/js/contentscripts/fingerprinting.js
@@ -299,28 +299,6 @@ function getFpPageScript() {
 
 }
 
-/**
- * Executes a script in the page DOM context
- *
- * @param text The content of the script to insert
- * @param data attributes to set in the inserted script tag
- */
-function insertFpScript(text, data) {
-  var parent = document.documentElement,
-    script = document.createElement('script');
-
-  script.text = text;
-  script.async = false;
-
-  for (var key in data) {
-    script.setAttribute('data-' + key.replace('_', '-'), data[key]);
-  }
-
-  parent.insertBefore(script, parent.firstChild);
-  parent.removeChild(script);
-}
-
-
 // END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
 
 (function () {
@@ -353,7 +331,7 @@ chrome.runtime.sendMessage({checkEnabled: true},
       });
     });
 
-    insertFpScript(getFpPageScript(), {
+    window.injectScript(getFpPageScript(), {
       event_id: event_id
     });
   }

--- a/src/js/contentscripts/supercookie.js
+++ b/src/js/contentscripts/supercookie.js
@@ -27,50 +27,56 @@ function getScPageScript() {
   // code below is not a content script: no chrome.* APIs /////////////////////
 
   // return a string
-  return "(" + function (DOCUMENT, dispatchEvent, CUSTOM_EVENT, LOCAL_STORAGE, OBJECT, keys) {
+  return "(" + function () {
 
-    var event_id = DOCUMENT.currentScript.getAttribute('data-event-id-super-cookie');
+    try {
+      localStorage; // eslint-disable-line no-unused-expressions
+    } catch (ex) {
+      // abort when we can't access localStorage
+      // such as when "Block third-party cookies" is enabled in Chrome
+      return;
+    }
 
-    /**
-     * send message to the content script
-     *
-     * @param {*} message
-     */
-    var send = function (message) {
-      dispatchEvent.call(DOCUMENT, new CUSTOM_EVENT(event_id, {
-        detail: message
-      }));
-    };
+    (function (DOCUMENT, dispatchEvent, CUSTOM_EVENT, LOCAL_STORAGE, OBJECT, keys) {
 
-    /**
-     * Read HTML5 local storage and return contents
-     * @returns {Object}
-     */
-    let getLocalStorageItems = function () {
-      let lsItems = {};
-      try {
+      var event_id = DOCUMENT.currentScript.getAttribute('data-event-id-super-cookie');
+
+      /**
+       * send message to the content script
+       *
+       * @param {*} message
+       */
+      var send = function (message) {
+        dispatchEvent.call(DOCUMENT, new CUSTOM_EVENT(event_id, {
+          detail: message
+        }));
+      };
+
+      /**
+       * Read HTML5 local storage and return contents
+       * @returns {Object}
+       */
+      let getLocalStorageItems = function () {
+        let lsItems = {};
         for (let i = 0; i < LOCAL_STORAGE.length; i++) {
           let key = LOCAL_STORAGE.key(i);
           lsItems[key] = LOCAL_STORAGE.getItem(key);
         }
-      } catch (err) {
-        // We get a SecurityError when our injected script runs in a 3rd party frame and
-        // the user has disabled 3rd party cookies and site data. See, http://git.io/vLwff
-        return {};
-      }
-      return lsItems;
-    };
+        return lsItems;
+      };
 
-    if (event_id) { // inserted script may run before the event_id is available
-      let localStorageItems = getLocalStorageItems();
-      if (keys.call(OBJECT, localStorageItems).length) {
-        // send to content script
-        send({ localStorageItems });
+      if (event_id) { // inserted script may run before the event_id is available
+        let localStorageItems = getLocalStorageItems();
+        if (keys.call(OBJECT, localStorageItems).length) {
+          // send to content script
+          send({ localStorageItems });
+        }
       }
-    }
 
-  // save locally to keep from getting overwritten by site code
-  } + "(document, document.dispatchEvent, CustomEvent, localStorage, Object, Object.keys));";
+    // save locally to keep from getting overwritten by site code
+    } (document, document.dispatchEvent, CustomEvent, localStorage, Object, Object.keys));
+
+  } + "());";
 
   // code above is not a content script: no chrome.* APIs /////////////////////
 

--- a/src/js/contentscripts/supercookie.js
+++ b/src/js/contentscripts/supercookie.js
@@ -89,6 +89,11 @@ if (document instanceof HTMLDocument === false && (
   return;
 }
 
+// don't bother asking to run when trivially in first-party context
+if (window.top == window) {
+  return;
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
   checkEnabledAndThirdParty: window.FRAME_URL

--- a/src/js/contentscripts/supercookie.js
+++ b/src/js/contentscripts/supercookie.js
@@ -113,7 +113,7 @@ if (document instanceof HTMLDocument === false && (
 
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
-  checkEnabledAndThirdParty: true
+  checkEnabledAndThirdParty: window.FRAME_URL
 }, function (enabledAndThirdParty) {
   if (!enabledAndThirdParty) {
     return;
@@ -125,7 +125,8 @@ chrome.runtime.sendMessage({
   document.addEventListener(event_id_super_cookie, function (e) {
     // pass these on to the background page (handled by webrequest.js)
     chrome.runtime.sendMessage({
-      superCookieReport: e.detail
+      superCookieReport: e.detail,
+      frameUrl: window.FRAME_URL
     });
   });
 

--- a/src/js/contentscripts/supercookie.js
+++ b/src/js/contentscripts/supercookie.js
@@ -19,28 +19,6 @@
  */
 
 /**
- * Insert script into page
- *
- * @param {String} text The script to insert into the page
- * @param {Object} data a dictionary containing attribut-value pairs
- */
-function insertScScript(text, data) {
-  var parent = document.documentElement,
-    script = document.createElement('script');
-
-  script.text = text;
-  script.async = false;
-
-  for (var key in data) {
-    script.setAttribute('data-' + key.replace(/_/g, "-"), data[key]);
-  }
-
-  parent.insertBefore(script, parent.firstChild);
-  parent.removeChild(script);
-}
-
-
-/**
  * Generate script to inject into the page
  *
  * @returns {string}
@@ -130,7 +108,7 @@ chrome.runtime.sendMessage({
     });
   });
 
-  insertScScript(getScPageScript(), {
+  window.injectScript(getScPageScript(), {
     event_id_super_cookie: event_id_super_cookie
   });
 

--- a/src/js/contentscripts/utils.js
+++ b/src/js/contentscripts/utils.js
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Privacy Badger <https://www.eff.org/privacybadger>
+ * Copyright (C) 2018 Electronic Frontier Foundation
+ *
+ * Privacy Badger is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * Privacy Badger is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function getFrameUrl() {
+  let url = document.location.href,
+    parentFrame = (document != window.top) && window.parent;
+  while (parentFrame && url && !url.startsWith("http")) {
+    try {
+      url = parentFrame.document.location.href;
+    } catch (ex) {
+      // ignore 'Blocked a frame with origin "..."
+      // from accessing a cross-origin frame.' exceptions
+    }
+    parentFrame = (parentFrame != window.top) && parentFrame.parent;
+  }
+  return url;
+}
+window.FRAME_URL = getFrameUrl();

--- a/src/js/contentscripts/utils.js
+++ b/src/js/contentscripts/utils.js
@@ -15,6 +15,27 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * Executes a script in the page's JavaScript context.
+ *
+ * @param {String} text The content of the script to insert.
+ * @param {Object} data Data attributes to set on the inserted script tag.
+ */
+window.injectScript = function (text, data) {
+  var parent = document.documentElement,
+    script = document.createElement('script');
+
+  script.text = text;
+  script.async = false;
+
+  for (var key in data) {
+    script.setAttribute('data-' + key.replace(/_/g, '-'), data[key]);
+  }
+
+  parent.insertBefore(script, parent.firstChild);
+  parent.removeChild(script);
+};
+
 function getFrameUrl() {
   let url = document.location.href,
     parentFrame = (document != window.top) && window.parent;

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -683,12 +683,12 @@ function dispatcher(request, sender, sendResponse) {
 
   } else if (request.superCookieReport) {
     if (badger.hasSuperCookie(request.superCookieReport)) {
-      recordSuperCookie(sender.tab.id, sender.url);
+      recordSuperCookie(sender.tab.id, request.frameUrl);
     }
 
   } else if (request.checkEnabledAndThirdParty) {
     let tab_host = window.extractHostFromURL(sender.tab.url),
-      frame_host = window.extractHostFromURL(sender.url);
+      frame_host = window.extractHostFromURL(request.checkEnabledAndThirdParty);
 
     sendResponse(badger.isPrivacyBadgerEnabled(tab_host) && isThirdPartyDomain(frame_host, tab_host));
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -93,6 +93,7 @@
     },
     {
       "js": [
+        "js/contentscripts/utils.js",
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",
         "js/contentscripts/dnt.js",
@@ -102,6 +103,7 @@
         "<all_urls>"
       ],
       "all_frames": true,
+      "match_about_blank": true,
       "run_at": "document_start"
     },
     {
@@ -113,6 +115,7 @@
         "<all_urls>"
       ],
       "all_frames": true,
+      "match_about_blank": true,
       "run_at": "document_idle"
     }
   ],

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -10,12 +10,14 @@ class ClobberingTest(pbtest.PBSeleniumTest):
     def test_localstorage_clobbering(self):
         FIXTURE_TEST_RESULT_IDS = [
             'get-item',
+            'get-property',
+            'get-item-proto',
         ]
         # page loads a frame that writes to and reads from localStorage
         # TODO remove delays from fixture once race condition (https://crbug.com/478183) is fixed
         FIXTURE_URL = (
             "https://gitcdn.link/cdn/ghostwords/"
-            "95d3795b3e2d59b0a729825050c252d2/raw/df849c9ec692fb047f4a3b2c7218f8354fe2ce60/"
+            "95d3795b3e2d59b0a729825050c252d2/raw/f357323dba57eaae2fadd89ae8ad7644f47f621d/"
             "privacy-badger-clobbering-fixture.html"
         )
         FRAME_DOMAIN = "githack.com"
@@ -30,7 +32,13 @@ class ClobberingTest(pbtest.PBSeleniumTest):
             # wait for each test to run
             self.wait_for_script(
                 "return document.getElementById('%s')"
-                ".textContent != '...';" % selector
+                ".textContent != '...';" % selector,
+                timeout=2,
+                message=(
+                    "Timed out waiting for localStorage (%s) to finish ... "
+                    "This probably means the fixture "
+                    "errored out somewhere." % selector
+                )
             )
             self.assertNotEqual(
                 self.txt_by_css("#" + selector), "",
@@ -49,7 +57,13 @@ class ClobberingTest(pbtest.PBSeleniumTest):
             # wait for each test to run
             self.wait_for_script(
                 "return document.getElementById('%s')"
-                ".textContent != '...';" % selector
+                ".textContent != '...';" % selector,
+                timeout=2,
+                message=(
+                    "Timed out waiting for localStorage (%s) to finish ... "
+                    "This probably means the fixture "
+                    "errored out somewhere." % selector
+                )
             )
             self.assertEqual(
                 self.txt_by_css("#" + selector), "",

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -13,6 +13,10 @@ class ClobberingTest(pbtest.PBSeleniumTest):
             ('get-item', "qwerty", "null"),
             ('get-property', "asdf", "undefined"),
             ('get-item-proto', "qwerty", "null"),
+            ('get-item-srcdoc', "qwerty", "null"),
+            ('get-property-srcdoc', "asdf", "undefined"),
+            ('get-item-frames', "qwerty", "null"),
+            ('get-property-frames', "asdf", "undefined"),
         ]
         # page loads a frame that writes to and reads from localStorage
         # TODO remove delays from fixture once race condition (https://crbug.com/478183) is fixed

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import unittest
+
+import pbtest
+
+
+class ClobberingTest(pbtest.PBSeleniumTest):
+    def test_localstorage_clobbering(self):
+        FIXTURE_TEST_RESULT_IDS = [
+            'get-item',
+        ]
+        # page loads a frame that writes to and reads from localStorage
+        # TODO remove delays from fixture once race condition (https://crbug.com/478183) is fixed
+        FIXTURE_URL = (
+            "https://gitcdn.link/cdn/ghostwords/"
+            "95d3795b3e2d59b0a729825050c252d2/raw/df849c9ec692fb047f4a3b2c7218f8354fe2ce60/"
+            "privacy-badger-clobbering-fixture.html"
+        )
+        FRAME_DOMAIN = "githack.com"
+        COOKIEBLOCK_JS = (
+            "badger.storage.setupHeuristicAction('%s', constants.COOKIEBLOCK);"
+        ) % FRAME_DOMAIN
+
+        # first allow localStorage to be set
+        self.load_url(FIXTURE_URL)
+        self.wait_for_and_switch_to_frame('iframe')
+        for selector in FIXTURE_TEST_RESULT_IDS:
+            # wait for each test to run
+            self.wait_for_script(
+                "return document.getElementById('%s')"
+                ".textContent != '...';" % selector
+            )
+            self.assertNotEqual(
+                self.txt_by_css("#" + selector), "",
+                "localStorage (%s) was not read successfully"
+                "for some reason" % selector
+            )
+
+        # mark the frame domain for cookieblocking
+        self.load_url(self.options_url)
+        self.js(COOKIEBLOCK_JS)
+
+        # now rerun and check results for various localStorage access tests
+        self.load_url(FIXTURE_URL)
+        self.wait_for_and_switch_to_frame('iframe')
+        for selector in FIXTURE_TEST_RESULT_IDS:
+            # wait for each test to run
+            self.wait_for_script(
+                "return document.getElementById('%s')"
+                ".textContent != '...';" % selector
+            )
+            self.assertEqual(
+                self.txt_by_css("#" + selector), "",
+                "localStorage (%s) was read despite cookieblocking" % selector
+            )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -8,16 +8,17 @@ import pbtest
 
 class ClobberingTest(pbtest.PBSeleniumTest):
     def test_localstorage_clobbering(self):
-        FIXTURE_TEST_RESULT_IDS = [
-            'get-item',
-            'get-property',
-            'get-item-proto',
+        LOCALSTORAGE_TESTS = [
+            # (test result element ID, expected stored, expected empty)
+            ('get-item', "qwerty", "null"),
+            ('get-property', "asdf", "undefined"),
+            ('get-item-proto', "qwerty", "null"),
         ]
         # page loads a frame that writes to and reads from localStorage
         # TODO remove delays from fixture once race condition (https://crbug.com/478183) is fixed
         FIXTURE_URL = (
             "https://gitcdn.link/cdn/ghostwords/"
-            "95d3795b3e2d59b0a729825050c252d2/raw/f357323dba57eaae2fadd89ae8ad7644f47f621d/"
+            "95d3795b3e2d59b0a729825050c252d2/raw/a1017b1b0e991dc4a2f2903afb221b1f76da2300/"
             "privacy-badger-clobbering-fixture.html"
         )
         FRAME_DOMAIN = "githack.com"
@@ -28,32 +29,7 @@ class ClobberingTest(pbtest.PBSeleniumTest):
         # first allow localStorage to be set
         self.load_url(FIXTURE_URL)
         self.wait_for_and_switch_to_frame('iframe')
-        for selector in FIXTURE_TEST_RESULT_IDS:
-            # wait for each test to run
-            self.wait_for_script(
-                "return document.getElementById('%s')"
-                ".textContent != '...';" % selector,
-                timeout=2,
-                message=(
-                    "Timed out waiting for localStorage (%s) to finish ... "
-                    "This probably means the fixture "
-                    "errored out somewhere." % selector
-                )
-            )
-            self.assertNotEqual(
-                self.txt_by_css("#" + selector), "",
-                "localStorage (%s) was not read successfully"
-                "for some reason" % selector
-            )
-
-        # mark the frame domain for cookieblocking
-        self.load_url(self.options_url)
-        self.js(COOKIEBLOCK_JS)
-
-        # now rerun and check results for various localStorage access tests
-        self.load_url(FIXTURE_URL)
-        self.wait_for_and_switch_to_frame('iframe')
-        for selector in FIXTURE_TEST_RESULT_IDS:
+        for selector, expected, _ in LOCALSTORAGE_TESTS:
             # wait for each test to run
             self.wait_for_script(
                 "return document.getElementById('%s')"
@@ -66,7 +42,32 @@ class ClobberingTest(pbtest.PBSeleniumTest):
                 )
             )
             self.assertEqual(
-                self.txt_by_css("#" + selector), "",
+                self.txt_by_css("#" + selector), expected,
+                "localStorage (%s) was not read successfully"
+                "for some reason" % selector
+            )
+
+        # mark the frame domain for cookieblocking
+        self.load_url(self.options_url)
+        self.js(COOKIEBLOCK_JS)
+
+        # now rerun and check results for various localStorage access tests
+        self.load_url(FIXTURE_URL)
+        self.wait_for_and_switch_to_frame('iframe')
+        for selector, _, expected in LOCALSTORAGE_TESTS:
+            # wait for each test to run
+            self.wait_for_script(
+                "return document.getElementById('%s')"
+                ".textContent != '...';" % selector,
+                timeout=2,
+                message=(
+                    "Timed out waiting for localStorage (%s) to finish ... "
+                    "This probably means the fixture "
+                    "errored out somewhere." % selector
+                )
+            )
+            self.assertEqual(
+                self.txt_by_css("#" + selector), expected,
                 "localStorage (%s) was read despite cookieblocking" % selector
             )
 

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -386,7 +386,8 @@ class PBSeleniumTest(unittest.TestCase):
 
     def find_el_by_css(self, css_selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         return WebDriverWait(self.driver, timeout).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR, css_selector)))
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, css_selector)))
 
     def find_el_by_xpath(self, xpath, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         return WebDriverWait(self.driver, timeout).until(
@@ -404,6 +405,16 @@ class PBSeleniumTest(unittest.TestCase):
             lambda driver: driver.execute_script(script),
             message
         )
+
+    def wait_for_text(self, selector, text, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
+        return WebDriverWait(self.driver, timeout).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, selector), text))
+
+    def wait_for_and_switch_to_frame(self, selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
+        return WebDriverWait(self.driver, timeout).until(
+            EC.frame_to_be_available_and_switch_to_it(
+                (By.CSS_SELECTOR, selector)))
 
     @property
     def logs(self):

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -382,12 +382,16 @@ class PBSeleniumTest(unittest.TestCase):
 
     def txt_by_css(self, css_selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         """Find an element by CSS selector and return its text."""
-        return self.find_el_by_css(css_selector, timeout).text
+        return self.find_el_by_css(
+            css_selector, visible_only=False, timeout=timeout).text
 
-    def find_el_by_css(self, css_selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
+    def find_el_by_css(self, css_selector, visible_only=True, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
+        condition = (
+            EC.visibility_of_element_located if visible_only
+            else EC.presence_of_element_located
+        )
         return WebDriverWait(self.driver, timeout).until(
-            EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, css_selector)))
+            condition((By.CSS_SELECTOR, css_selector)))
 
     def find_el_by_xpath(self, xpath, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         return WebDriverWait(self.driver, timeout).until(

--- a/tests/selenium/surrogates_test.py
+++ b/tests/selenium/surrogates_test.py
@@ -5,9 +5,6 @@ import unittest
 import pbtest
 
 from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 from pbtest import retry_until
 from window_utils import switch_to_window_with_url
@@ -22,14 +19,10 @@ class SurrogatesTest(pbtest.PBSeleniumTest):
 
     def load_ga_js_test_page(self, timeout=12):
         self.load_url(SurrogatesTest.TEST_URL)
-        wait = WebDriverWait(self.driver, timeout)
         try:
-            wait.until(
-                EC.frame_to_be_available_and_switch_to_it((By.TAG_NAME, 'iframe'))
-            )
-            return wait.until(EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, 'h1'), "It worked!"
-            ))
+            self.wait_for_and_switch_to_frame('iframe', timeout=timeout)
+            self.wait_for_text('h1', "It worked!", timeout=timeout)
+            return True
         except TimeoutException:
             return False
 


### PR DESCRIPTION
- [x] Fix localStorage setItem/getItem overwriting in Firefox
- [x] Overwrite getting/setting localStorage via object properties
- [x] Inject into "about:blank" frames (https://github.com/EFForg/privacybadger/pull/2167#issuecomment-425260296) (fixes #1447)
- [x] Test that localStorage retrieval is successfully blocked
- [x] Review Badger Sett results (should obsolete [blank domain cleanup](https://github.com/EFForg/badger-sett/blob/33c9f8c51f6c1eabae18886aa47f93117918b20f/crawler.py#L433))
- [ ] Confirm that adding "match_about_blank" does not trigger permission warnings

Fixes #2231.