### PR TITLE
Delete fbclid parameter from facebook's urls

### DIFF
--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -22,9 +22,9 @@ function cleanLink(a) {
     return;
   }
 
-  let href_url = new URL(href)
-  href_url.searchParams.delete('fbclid')
-  href = href_url.toString()
+  let href_url = new URL(href);
+  href_url.searchParams.delete('fbclid');
+  href = href_url.toString();
 
   cleanAttrs(a);
   a.href = href;


### PR DESCRIPTION
Facebook added this tracking parameter a few days ago. With this commit privacybadger deletes it after link unwrapping.

See [https://news.ycombinator.com/item?id=18275061](https://news.ycombinator.com/item?id=18275061) and [http://thisinterestsme.com/facebook-fbclid-parameter/](http://thisinterestsme.com/facebook-fbclid-parameter/)