### PR TITLE
Make AddThis selector exclude empty divs

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -2,7 +2,7 @@
 	"AddThis": {
 		"domain": "s7.addthis.com",
 		"buttonSelectors": [
-			".addthis_toolbox"
+			"div.addthis_toolbox:not(:empty)"
 		],
 		"replacementButton": {
 			"details": "<!-- AddThis Button BEGIN --> <div class='addthis_toolbox addthis_default_style addthis_32x32_style'> <a class='addthis_button_preferred_1'></a> <a class='addthis_button_preferred_2'></a> <a class='addthis_button_preferred_3'></a> <a class='addthis_button_preferred_4'></a> <a class='addthis_button_compact'></a> <a class='addthis_counter addthis_bubble_style'></a> </div> <script type='text/javascript'>var addthis_config = {'data_track_addressbar':true};</script> <script type='text/javascript' src='//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-522d600d3b535ebf'></script> <!-- AddThis Button END -->",


### PR DESCRIPTION
Fixes #2206.

As the AddThis widget we mean to replace contains one or more child anchor elements.

The ":has()" selector would be better but it's not yet supported.