### PR TITLE
Stop first time message from stealing focus

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -67,7 +67,8 @@ function showNagMaybe() {
       chrome.tabs.query({url: firstRunUrl}, function (tabs) {
         if (tabs.length == 0) {
           chrome.tabs.create({
-            url: chrome.extension.getURL("/skin/firstRun.html#slideshow")
+            url: chrome.extension.getURL("/skin/firstRun.html#slideshow"),
+            active: false
           });
         } else {
           chrome.tabs.update(tabs[0].id, {active: true}, function (tab) {


### PR DESCRIPTION
See decentraleyes at https://github.com/Synzvato/decentraleyes/blob/master/core/main.js#L79. (this is such minor change that I did not run the tests locally. As of https://github.com/EFForg/privacybadger/blob/master/doc/tests.md, Travis does this, right?)