### PR TITLE
Add squareup.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -528,6 +528,7 @@ cdn-a.sonyentertainmentnetwork.com
 soundcloud.com
 springboardplatform.com
 squarespace.com
+squareup.com
 squirt.io
 ssl-images-amazon.com
 cdn.sstatic.net


### PR DESCRIPTION
Fixes #2209.

Error report counts by date, page domain and exact blocked "squareup.com" subdomain:
```
+---------+--------------------------+-----------------------------+-------+
| ym      | blocked_fqdn             | fqdn                        | count |
+---------+--------------------------+-----------------------------+-------+
| 2018-09 | api.squareup.com         | www.trycaviar.com           |     1 |
| 2018-09 | js.squareup.com          | www.trycaviar.com           |     1 |
| 2018-09 | pci-connect.squareup.com | www.trycaviar.com           |     1 |
| 2018-08 | api.squareup.com         | www.studio51-50.com         |     1 |
| 2018-08 | squareup.com             | www.studio51-50.com         |     1 |
| 2018-06 | js.squareup.com          | secure.acuityscheduling.com |     1 |
| 2018-06 | pci-connect.squareup.com | secure.acuityscheduling.com |     1 |
...
```