### PR TITLE
Update MDFP list for NBC News

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -795,7 +795,6 @@ var multiDomainFirstPartiesArray = [
   ],
   ["mobilism.org.in", "mobilism.org"],
   ["morganstanley.com", "morganstanleyclientserv.com", "stockplanconnect.com", "ms.com"],
-  ["msnbc.com", "nbcnews.com", "newsvine.com"],
   ["my-bookings.org", "my-bookings.cc"],
   ["mycanal.fr", "canal-plus.com"],
   ["mymerrill.com", "ml.com", "merrilledge.com"],
@@ -803,6 +802,15 @@ var multiDomainFirstPartiesArray = [
   ["mysmartedu.com", "mysmartabc.com"],
   ["mysql.com", "oracle.com"],
   ["myuv.com", "uvvu.com"],
+  [
+    "nbcnews.com",
+
+    "msnbc.com",
+    "today.com",
+
+    "newsvine.com",
+    "s-nbcnews.com",
+  ],
   ["nefcuonline.com", "nefcu.com"],
   ["netflix.com", "nflxext.com", "nflximg.net", "nflxvideo.net"],
   [


### PR DESCRIPTION
Lots of reports, not clear how to reproduce, easy fix though.

Error report counts by page domain and exact blocked "s-nbcnews.com" subdomain:
```
+----------------------------+------------------------+-------+
| fqdn                       | blocked_fqdn           | count |
+----------------------------+------------------------+-------+
| www.nbcnews.com            | media1.s-nbcnews.com   |    50 |
| www.nbcnews.com            | media2.s-nbcnews.com   |    49 |
| www.msnbc.com              | media1.s-nbcnews.com   |    44 |
| www.nbcnews.com            | media4.s-nbcnews.com   |    44 |
| www.nbcnews.com            | media3.s-nbcnews.com   |    43 |
| www.msnbc.com              | media2.s-nbcnews.com   |    40 |
| www.today.com              | media1.s-nbcnews.com   |    14 |
| www.today.com              | media2.s-nbcnews.com   |    13 |
| www.nbcnews.com            | ndassets.s-nbcnews.com |    11 |
| www.today.com              | media4.s-nbcnews.com   |     9 |
| www.today.com              | media3.s-nbcnews.com   |     8 |
...
```