### PR TITLE
Add two amazonpay.com domains to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -18,6 +18,8 @@ ally.com
 amazon.com
 s3.amazonaws.com
 amazonaws.com
+coin.amazonpay.com
+coin-eu.amazonpay.com
 americanhomecomings.com
 ancestry.com
 angularjs.org


### PR DESCRIPTION
Error report counts by date and exact blocked "amazonpay" subdomain:
```
+---------+-----------------------+-------+
| ym      | blocked_fqdn          | count |
+---------+-----------------------+-------+
| 2018-12 | coin.amazonpay.com    |    10 |
| 2018-12 | coin-eu.amazonpay.com |     2 |
| 2018-11 | coin.amazonpay.com    |    36 |
| 2018-11 | coin-eu.amazonpay.com |     3 |
| 2018-10 | coin.amazonpay.com    |    27 |
| 2018-09 | coin.amazonpay.com    |    19 |
| 2018-08 | coin.amazonpay.com    |    16 |
| 2018-07 | coin.amazonpay.com    |     7 |
+---------+-----------------------+-------+
```
It's on our pre-trained list ... https://github.com/EFForg/privacybadger/blob/master/src/data/seed.json#L7894-L7898

Will add to the MDFP for Amazon next. [Edit: #2239]

I don't know if cookieblocking will allow the Amazon checkout workflow to proceed, but it's worth a try.