### PR TITLE
Add amazonpay.com to Amazon's MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -73,6 +73,7 @@ var multiDomainFirstPartiesArray = [
     "twitch.tv",
     "zappos.com",
 
+    "amazonpay.com",
     "media-amazon.com",
     "ssl-images-amazon.com",
   ],


### PR DESCRIPTION
As its snitch map entry in the current pre-trained list is entirely other Amazon domains: https://github.com/EFForg/privacybadger/blob/master/src/data/seed.json#L7894-L7898