### PR TITLE
Add sb subdomain to Comscore surrogate

### DIFF
--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -39,6 +39,10 @@ const hostnames = {
     '/beacon.js',
     '/c2/plugins/streamsense_plugin_html5.js',
   ],
+  'sb.scorecardresearch.com': [
+    '/beacon.js',
+    '/c2/plugins/streamsense_plugin_html5.js',
+  ],
   'ssl.google-analytics.com': [
     '/ga.js',
     '/analytics.js',


### PR DESCRIPTION
Fixes dynamic image loading on https://www.motorcyclenews.com/.

Did you know Firefox's Network Inspector doesn't show cancelled requests? Crazy!