### PR TITLE
Add acdn.adnxs.com to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -3,6 +3,7 @@
 112.2o7.net
 5min.com
 accuweather.com
+acdn.adnxs.com
 actionnetwork.org
 auth.adobe.com
 wwwimages.adobe.com


### PR DESCRIPTION
The domain `acdn.adnxs.com` is necessary to the outlook dark mode switch (and maybe others features too) work correctly.