### PR TITLE
Add replacement widget for Coub

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -15,6 +15,19 @@
             "type": 2
         }
     },
+    "Coub Player": {
+        "domain": "coub.com",
+        "buttonSelectors": [
+            "iframe[src^='//coub.com/embed/']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "coub.com"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
+    },
     "Digg": {
         "domain": "widgets.digg.com",
         "buttonSelectors": [


### PR DESCRIPTION
Fixes #2004.

Examples:
- https://444.hu/2018/12/18/a-belga-kormanyfo-beadja-a-lemondasat
- https://index.hu/belfold/2017/06/11/egy_csanadpalotai_no_kemenyen_kiosztotta_lazar_janost/ (lazy loading implementation, doesn't yet work); [another lazy loading example](https://vc.ru/marketing/29992-big-data-blokcheyn-mashinlening-sberbank-obygral-lyubov-grefa-k-trendam-v-reklame-studencheskoy-olimpiady) that doesn't work
- https://geektimes.com/post/300631/
- http://www.yaplakal.com/forum28/topic2009258.html

Follows up on #2262.