### PR TITLE
Add replacement widget for Vimeo

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -192,5 +192,21 @@
             "imagePath": "Twitter.svg",
             "type": 0
         }
+    },
+
+    "Vimeo": {
+        "domain": "player.vimeo.com",
+        "buttonSelectors": [
+            "iframe[src^='https://player.vimeo.com/video/']",
+            "iframe[src^='//player.vimeo.com/video/']"
+        ],
+        "replacementButton": {
+            "details": "",
+            "unblockDomains": [
+                "https://player.vimeo.com/"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
     }
 }

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -284,6 +284,7 @@ function createReplacementWidget(button, buttonToReplace, trackerUrls) {
 
   // widget replacement frame styles
   let styleAttrs = [
+    "background-color: #fff",
     "border: 1px solid #ec9329",
     "width:" + buttonToReplace.clientWidth + "px",
     "height:" + buttonToReplace.clientHeight + "px",


### PR DESCRIPTION
The first part of the fix for #188. The second part will be to remove Vimeo from the yellowlist once #1474 is done.

Note that this hardcodes the background color for replacement widgets to white.

Most of these restricted embeds seem to live on various member-only course websites. Here are a few publicly available examples though. You have to manually set `player.vimeo.com` to "red" first or you'll run into the original issue.

- https://www.bringyourownlaptop.com/courses/Animated-Infographic-aVideo-and-Data-Visualisation/animated-infographics-data-visualization-introduction
- https://aeon.co/videos/not-quite-ashore-the-in-between-world-of-a-cargo-ship-rest-stop
- https://www.theyeshivaworld.com/news/israel-news/1648608/shocking-footage-child-falls-out-of-moving-vehicle-in-beitar-walks-away-unharmed.html