### PR TITLE
Stop replacing yellowlisted widgets

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -95,7 +95,7 @@
         }
     },
     "SoundCloud": {
-        "domain": "soundcloud.com",
+        "domain": "w.soundcloud.com",
         "buttonSelectors": [
             "iframe[src^='https://w.soundcloud.com/player']"
         ],

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -559,11 +559,14 @@ let getWidgetBlockList = (function () {
     }
 
     badger.widgetList.forEach(function (widget) {
-      // Only replace blocked and yellowlisted widgets and only if the widget is not on the 'do not replace' list
+      // replace blocked widgets only
+      // and only if the widget is not on the 'do not replace' list
       const replace = !badger.getSettings().getItem('widgetReplacementExceptions').includes(widget.name);
+      const action = badger.storage.getBestAction(widget.domain);
 
-      widgetsToReplace[widget.name] = replace && constants.BLOCKED_ACTIONS.has(
-        badger.storage.getBestAction(widget.domain)
+      widgetsToReplace[widget.name] = replace && (
+        action == constants.BLOCK ||
+        action == constants.USER_BLOCK
       );
     });
 


### PR DESCRIPTION
Fixes #788, fixes #1860. Related to #2266.

Widgets that have replacements should not have their domains on the yellowlist. The value of replacement widgets is full blocking (best privacy) combined with a clear way to restore potentially useful blocked content (convenience). Mixing yellowlisting and replacement widgets gets us less privacy w/o any benefit (as well as timing-related bugs).

This should be followed up by adding any missing widgets (Facebook Comments, Facebook Video, #1467) and removing Facebook, Twitter, etc. from the yellowlist (#1474, #1593) so that their widgets will work by default again.

~~As this changes `unblockDomains` in the widgets JSON, will need to fix them for any outstanding widget PRs (#2265, #2279, #2280).~~