### PR TITLE
Add disqus comments widget

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -7,9 +7,9 @@
         "replacementButton": {
             "details": "<!-- AddThis Button BEGIN --> <div class='addthis_toolbox addthis_default_style addthis_32x32_style'> <a class='addthis_button_preferred_1'></a> <a class='addthis_button_preferred_2'></a> <a class='addthis_button_preferred_3'></a> <a class='addthis_button_preferred_4'></a> <a class='addthis_button_compact'></a> <a class='addthis_counter addthis_bubble_style'></a> </div> <script type='text/javascript'>var addthis_config = {'data_track_addressbar':true};</script> <script type='text/javascript' src='//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-522d600d3b535ebf'></script> <!-- AddThis Button END -->",
             "unblockDomains": [
-                "http://s7.addthis.com/",
-                "http://ct1.addthis.com/",
-                "http://api-public.addthis.com/"
+                "s7.addthis.com",
+                "ct1.addthis.com",
+                "api-public.addthis.com"
             ],
             "imagePath": "AddThis.svg",
             "type": 2
@@ -24,7 +24,7 @@
         "replacementButton": {
             "details": "http://www.digg.com/submit?url=",
             "unblockDomains": [
-                "http://www.digg.com/submit?url="
+                "www.digg.com"
             ],
             "imagePath": "Digg.svg",
             "type": 0
@@ -42,8 +42,7 @@
         "replacementButton": {
             "details": "https://www.facebook.com/plugins/like.php?href=",
             "unblockDomains": [
-                "https://www.facebook.com/plugins/like.php?href=",
-                "https://www.facebook.com/v2.0/plugins/like.php?href="
+                "www.facebook.com"
             ],
             "imagePath": "FacebookLike.svg",
             "type": 1
@@ -61,8 +60,7 @@
         "replacementButton": {
             "details": "https://www.facebook.com/plugins/share_button.php?href=",
             "unblockDomains": [
-                "https://www.facebook.com/plugins/share_button.php?href=",
-                "https://www.facebook.com/v2.0/plugins/share_button.php?href="
+                "www.facebook.com"
             ],
             "imagePath": "FacebookShare.svg",
             "type": 1
@@ -78,9 +76,9 @@
         "replacementButton": {
             "details": "https://plusone.google.com/se/0/_/+1/fastbutton?url=",
             "unblockDomains": [
-                "https://plusone.google.com/se/0/_/+1/fastbutton?url=",
-                "http://clients6.google.com/",
-                "http://apis.google.com/"
+                "plusone.google.com",
+                "clients6.google.com",
+                "apis.google.com"
             ],
             "imagePath": "GooglePlus.svg",
             "type": 1
@@ -95,7 +93,7 @@
         "replacementButton": {
             "details": "http://www.linkedin.com/shareArticle?mini=true&url=",
             "unblockDomains": [
-                "http://www.linkedin.com/shareArticle?mini=true&url="
+                "www.linkedin.com"
             ],
             "imagePath": "LinkedIn.svg",
             "type": 0
@@ -111,7 +109,7 @@
         "replacementButton": {
             "details": "http://pinterest.com/pin/create/button/?url=",
             "unblockDomains": [
-                "http://pinterest.com/pin/create/button/?url="
+                "pinterest.com"
             ],
             "imagePath": "Pinterest.svg",
             "type": 0
@@ -126,7 +124,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://w.soundcloud.com/"
+                "w.soundcloud.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3
@@ -141,7 +139,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://open.spotify.com/"
+                "open.spotify.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3
@@ -156,7 +154,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://streamable.com/"
+                "streamable.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3
@@ -172,7 +170,7 @@
         "replacementButton": {
             "details": "http://www.stumbleupon.com/badge/?url=",
             "unblockDomains": [
-                "http://www.stumbleupon.com/badge/?url="
+                "www.stumbleupon.com"
             ],
             "imagePath": "StumbleUpon.svg",
             "type": 0
@@ -187,7 +185,7 @@
         "replacementButton": {
             "details": "https://twitter.com/intent/tweet?url=",
             "unblockDomains": [
-                "https://twitter.com/intent/tweet?url="
+                "twitter.com"
             ],
             "imagePath": "Twitter.svg",
             "type": 0

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -117,7 +117,7 @@
     },
 
     "SoundCloud": {
-        "domain": "soundcloud.com",
+        "domain": "w.soundcloud.com",
         "buttonSelectors": [
             "iframe[src^='https://w.soundcloud.com/player']"
         ],

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -31,6 +31,25 @@
         }
     },
 
+    "Disqus": {
+        "domain": "disqus.com",
+        "buttonSelectors": [
+            "div#disqus_thread"
+        ],
+        "scriptSelectors": [
+            "script[src^='.disqus.com/embed.js']"
+        ],
+        "replacementButton": {
+            "details": "",
+            "unblockDomains": [
+                "disqus.com",
+                "disquscdn.com"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 4
+        }
+    },
+
     "Facebook Like": {
         "domain": "www.facebook.com",
         "buttonSelectors": [

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -37,13 +37,14 @@
             "div#disqus_thread"
         ],
         "scriptSelectors": [
-            "script[src^='.disqus.com/embed.js']"
+            "script[src*='.disqus.com/embed.js']"
         ],
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "disqus.com",
-                "disquscdn.com"
+                "https://cyphers-test.disqus.com/embed.js",
+                "https://disqus.com/",
+                "https://referrer.disqus.com/"
             ],
             "imagePath": "badger-play.png",
             "type": 4

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -190,5 +190,21 @@
             "imagePath": "Twitter.svg",
             "type": 0
         }
+    },
+
+    "Vimeo": {
+        "domain": "player.vimeo.com",
+        "buttonSelectors": [
+            "iframe[src^='https://player.vimeo.com/video/']",
+            "iframe[src^='//player.vimeo.com/video/']"
+        ],
+        "replacementButton": {
+            "details": "",
+            "unblockDomains": [
+                "https://player.vimeo.com/"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
     }
 }

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -42,9 +42,8 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://cyphers-test.disqus.com/embed.js",
-                "https://disqus.com/",
-                "https://referrer.disqus.com/"
+                "/.*\\.disqus\\.com/",
+                "disqus.com"
             ],
             "imagePath": "badger-play.png",
             "type": 4

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -27,22 +27,22 @@ var pbStorage = require("storage");
 var HeuristicBlocking = require("heuristicblocking");
 var FirefoxAndroid = require("firefoxandroid");
 var webrequest = require("webrequest");
-var socialWidgetLoader = require("socialwidgetloader");
+var widgetLoader = require("widgetloader");
 
 var Migrations = require("migrations").Migrations;
 var incognito = require("incognito");
 
 /**
-* privacy badger initializer
-*/
+ * Privacy Badger initializer.
+ */
 function Badger() {
   var self = this;
 
   self.webRTCAvailable = checkWebRTCBrowserSupport();
 
-  self.socialWidgetList = [];
-  socialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json", (response) => {
-    self.socialWidgetList = response;
+  self.widgetList = [];
+  widgetLoader.loadWidgetsFromFile("data/socialwidgets.json", (response) => {
+    self.widgetList = response;
   });
 
   self.storage = new pbStorage.BadgerPen(function(thisStorage) {
@@ -488,7 +488,7 @@ Badger.prototype = {
   }, constants.DNT_POLICY_CHECK_INTERVAL),
 
   /**
-   * Default privacy badger settings
+   * Default Privacy Badger settings
    */
   defaultSettings: {
     checkForDNTPolicy: true,
@@ -654,9 +654,9 @@ Badger.prototype = {
   },
 
   /**
-   * Check if social widget replacement functionality is enabled
+   * Check if widget replacement functionality is enabled.
    */
-  isSocialWidgetReplacementEnabled: function() {
+  isWidgetReplacementEnabled: function () {
     return this.getSettings().getItem("socialWidgetReplacementEnabled");
   },
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -240,12 +240,12 @@ function reinitializeWidgetAndUnblockTracker(replacementWidget, domains, widget,
  * The teardown to the initialization defined in createReplacementWidget().
  *
  * @param {HTMLElement} replacementWidget the DOM element of replacement widget
- * @param {Array} urls tracker URLs
+ * @param {Array} domains tracker domains
  * @param {HTMLElement} widget the DOM element for the third-party widget
  * @param {HTMLElement} parentEl the parent DOM element
  */
-function replaceWidgetAndReloadScripts(replacementWidget, urls, widget, parentEl, scriptSelectors) {
-  unblockTracker(urls, function() {
+function replaceWidgetAndReloadScripts(replacementWidget, domains, widget, parentEl, scriptSelectors) {
+  unblockTracker(domains, function() {
     parentEl.replaceChild(widget, replacementWidget);
     reloadScripts(scriptSelectors);
   });
@@ -303,7 +303,7 @@ function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
   });
 }
 
-function createReplacementLazyLoader(button, divToReplace, trackerUrls, scriptSelectors) {
+function createReplacementLazyLoader(button, divToReplace, trackerDomains, scriptSelectors) {
   let widgetFrame = document.createElement('iframe');
 
   let divWidth = divToReplace.clientWidth || 300;
@@ -356,7 +356,7 @@ function createReplacementLazyLoader(button, divToReplace, trackerUrls, scriptSe
   widgetFrame.addEventListener('load', function () {
     // click handler
     widgetFrame.contentDocument.querySelector('img').addEventListener("click", function () {
-      replaceWidgetAndReloadScripts(widgetFrame, trackerUrls, divToReplace, parentEl, scriptSelectors);
+      replaceWidgetAndReloadScripts(widgetFrame, trackerDomains, divToReplace, parentEl, scriptSelectors);
     }, { once: true });
   }, false);
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -450,7 +450,14 @@ function reloadScripts(selectors) {
   let scriptsToReload = document.querySelectorAll(selectors.toString());
 
   scriptsToReload.forEach(function (scriptToReplace) {
-    scriptToReplace.parentNode.replaceChild(scriptToReplace, scriptToReplace);
+    let script = document.createElement("script");
+    script.text = scriptToReplace.innerHTML;
+    script.src = scriptToReplace.src;
+    script.src = scriptToReplace.src;
+    for (var i = 0, atts = scriptToReplace.attributes, n = atts.length, arr = []; i < n; i++){
+          script.setAttribute(atts[i].nodeName, atts[i].nodeValue);
+    }
+    scriptToReplace.parentNode.replaceChild(script, scriptToReplace);
   });
 }
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -284,6 +284,7 @@ function createReplacementWidget(button, buttonToReplace, trackerDomains) {
 
   // widget replacement frame styles
   let styleAttrs = [
+    "background-color: #fff",
     "border: 1px solid #ec9329",
     "width:" + buttonToReplace.clientWidth + "px",
     "height:" + buttonToReplace.clientHeight + "px",

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -44,7 +44,7 @@
  */
 
 /**
- * Social widget tracker data, read from file.
+ * Widget data, read from file.
  */
 let trackerInfo;
 
@@ -62,7 +62,7 @@ function initialize() {
 
   // Set up listener for blocks that happen after initial check
   chrome.runtime.onMessage.addListener(function(request/*, sender, sendResponse*/) {
-    if (request.replaceSocialWidget) {
+    if (request.replaceWidget) {
       replaceSubsequentTrackerButtonsHelper(request.trackerDomain);
     }
   });
@@ -384,7 +384,7 @@ function getTrackerData(callback) {
  */
 function unblockTracker(buttonUrls, callback) {
   let request = {
-    unblockSocialWidget: true,
+    unblockWidget: true,
     buttonUrls: buttonUrls
   };
   chrome.runtime.sendMessage(request, callback);
@@ -404,9 +404,9 @@ if (document instanceof HTMLDocument === false && (
 }
 
 chrome.runtime.sendMessage({
-  checkSocialWidgetReplacementEnabled: true
-}, function (checkSocialWidgetReplacementEnabled) {
-  if (!checkSocialWidgetReplacementEnabled) {
+  checkWidgetReplacementEnabled: true
+}, function (checkWidgetReplacementEnabled) {
+  if (!checkWidgetReplacementEnabled) {
     return;
   }
   initialize();

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -167,11 +167,11 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
  * pointing to the given URL.
  *
  * @param {Element} button the DOM element of the button to replace
- * @param {Array} urls the associated URLs
+ * @param {Array} domains the button's domains
  * @param {String} iframeUrl the URL of the iframe to replace the button
  */
-function replaceButtonWithIframeAndUnblockTracker(button, urls, iframeUrl) {
-  unblockTracker(urls, function() {
+function replaceButtonWithIframeAndUnblockTracker(button, domains, iframeUrl) {
+  unblockTracker(domains, function () {
     // check is needed as for an unknown reason this callback function is
     // executed for buttons that have already been removed; we are trying
     // to prevent replacing an already removed button
@@ -191,11 +191,11 @@ function replaceButtonWithIframeAndUnblockTracker(button, urls, iframeUrl) {
  * HTML code defined in the provided Tracker object.
  *
  * @param {Element} button the DOM element of the button to replace
- * @param {Array} urls the associated URLs
+ * @param {Array} domains the button's domains
  * @param {String} html the HTML string that should replace the button
  */
-function replaceButtonWithHtmlCodeAndUnblockTracker(button, urls, html) {
-  unblockTracker(urls, function() {
+function replaceButtonWithHtmlCodeAndUnblockTracker(button, domains, html) {
+  unblockTracker(domains, function () {
     // check is needed as for an unknown reason this callback function is
     // executed for buttons that have already been removed; we are trying
     // to prevent replacing an already removed button
@@ -217,12 +217,12 @@ function replaceButtonWithHtmlCodeAndUnblockTracker(button, urls, html) {
  * The teardown to the initialization defined in createReplacementWidget().
  *
  * @param {HTMLElement} replacementWidget the DOM element of replacement widget
- * @param {Array} urls tracker URLs
+ * @param {Array} domains the widget's domains
  * @param {HTMLElement} widget the DOM element for the third-party widget
  * @param {HTMLElement} parentEl the parent DOM element
  */
-function reinitializeWidgetAndUnblockTracker(replacementWidget, urls, widget, parentEl) {
-  unblockTracker(urls, function() {
+function reinitializeWidgetAndUnblockTracker(replacementWidget, domains, widget, parentEl) {
+  unblockTracker(domains, function () {
     parentEl.replaceChild(widget, replacementWidget);
   });
 }
@@ -279,7 +279,7 @@ function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
   });
 }
 
-function createReplacementWidget(button, buttonToReplace, trackerUrls) {
+function createReplacementWidget(button, buttonToReplace, trackerDomains) {
   let widgetFrame = document.createElement('iframe');
 
   // widget replacement frame styles
@@ -327,7 +327,7 @@ function createReplacementWidget(button, buttonToReplace, trackerUrls) {
   widgetFrame.addEventListener('load', function () {
     // click handler
     widgetFrame.contentDocument.querySelector('img').addEventListener("click", function () {
-      reinitializeWidgetAndUnblockTracker(widgetFrame, trackerUrls, buttonToReplace, parentEl);
+      reinitializeWidgetAndUnblockTracker(widgetFrame, trackerDomains, buttonToReplace, parentEl);
     }, { once: true });
   }, false);
 
@@ -376,16 +376,16 @@ function getTrackerData(callback) {
 }
 
 /**
- * Messages the background page to temporarily allow an array of URLs.
+ * Messages the background page to temporarily allow an array of domains.
  * Calls the provided callback function upon response.
  *
- * @param {Array} buttonUrls the URLs to be temporarily allowed
+ * @param {Array} domains the domains to be temporarily allowed
  * @param {Function} callback the callback function
  */
-function unblockTracker(buttonUrls, callback) {
+function unblockTracker(domains, callback) {
   let request = {
     unblockWidget: true,
-    buttonUrls: buttonUrls
+    domains: domains
   };
   chrome.runtime.sendMessage(request, callback);
 }

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -288,6 +288,7 @@ function createReplacementWidget(button, buttonToReplace, trackerDomains) {
     "border: 1px solid #ec9329",
     "width:" + buttonToReplace.clientWidth + "px",
     "height:" + buttonToReplace.clientHeight + "px",
+    "z-index: 2147483647",
   ];
   widgetFrame.style = styleAttrs.join(" !important;") + " !important";
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -106,8 +106,9 @@ function loadOptions() {
   $("#removeAllData").button("option", "icons", {primary: "ui-icon-closethick"});
   $("#show_counter_checkbox").on("click", updateShowCounter);
   $("#show_counter_checkbox").prop("checked", OPTIONS_DATA.showCounter);
-  $("#replace_social_widgets_checkbox").on("click", updateSocialWidgetReplacement);
-  $("#replace_social_widgets_checkbox").prop("checked", OPTIONS_DATA.isSocialWidgetReplacementEnabled);
+  $("#replace-widgets-checkbox")
+    .on("click", updateWidgetReplacement)
+    .prop("checked", OPTIONS_DATA.isWidgetReplacementEnabled);
   $("#enable_dnt_checkbox").on("click", updateDNTCheckboxClicked);
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
@@ -357,16 +358,15 @@ function updateShowCounter() {
 }
 
 /**
- * Update setting for whether or not to replace social widgets.
+ * Update setting for whether or not to replace
+ * social buttons/video players/commenting widgets.
  */
-function updateSocialWidgetReplacement() {
-  const enabled = $("#replace_social_widgets_checkbox").prop("checked");
+function updateWidgetReplacement() {
+  const socialWidgetReplacementEnabled = $("#replace-widgets-checkbox").prop("checked");
 
   chrome.runtime.sendMessage({
     type: "updateSettings",
-    data: {
-      socialWidgetReplacementEnabled: enabled
-    }
+    data: { socialWidgetReplacementEnabled }
   });
 }
 

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -45,10 +45,10 @@
 
 var utils = require('utils');
 
-require.scopes.socialwidgetloader = (function() {
+require.scopes.widgetloader = (function() {
 
 var exports = {};
-exports.loadSocialWidgetsFromFile = loadSocialWidgetsFromFile;
+exports.loadWidgetsFromFile = loadWidgetsFromFile;
 
 /**
  * Loads a JSON file at filePath and returns the parsed object.
@@ -97,18 +97,18 @@ function getFileContents(filePath, callback) {
  *                          extension's data folder
  * @param {Function} callback callback(socialwidgets)
  */
-function loadSocialWidgetsFromFile(filePath, callback) {
-  loadJSONFromFile(filePath, function(socialwidgetsJson) {
-    var socialwidgets = [];
+function loadWidgetsFromFile(filePath, callback) {
+  loadJSONFromFile(filePath, function(widgetsJson) {
+    let widgets = [];
 
-    // loop over each socialwidget, making a SocialWidget object
-    for (var socialwidgetName in socialwidgetsJson) {
-      var socialwidgetProperties = socialwidgetsJson[socialwidgetName];
-      var socialwidgetObject = new SocialWidget(socialwidgetName, socialwidgetProperties);
-      socialwidgets.push(socialwidgetObject);
+    // loop over each widget, making a SocialWidget object
+    for (let widget_name in widgetsJson) {
+      let widgetProperties = widgetsJson[widget_name];
+      let widget = new SocialWidget(widget_name, widgetProperties);
+      widgets.push(widget);
     }
 
-    callback(socialwidgets);
+    callback(widgets);
   });
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -591,12 +591,28 @@ function isWidgetTemporaryUnblock(tabId, requestHost, frameId) {
     return false;
   }
 
-  var requestExcept = (exceptions.indexOf(requestHost) != -1);
+  if (exceptions.indexOf(requestHost) != -1) {
+    return true;
+  }
 
-  var frameHost = badger.getFrameData(tabId, frameId).host;
-  var frameExcept = (exceptions.indexOf(frameHost) != -1);
+  let frameData = badger.getFrameData(tabId, frameId);
+  let frameHost = frameData && frameData.host;
+  if (exceptions.indexOf(frameHost) != -1) {
+    return true;
+  }
 
-  return (requestExcept || frameExcept);
+  for (let i = 0; i < exceptions.length; i++) {
+    if (exceptions[i].match(/[\/].*[\/]/)) {
+      let regex = exceptions.slice(1, -1);
+
+      if (requestHost.match(regex) ||
+          frameHost.match(regex)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -600,20 +600,18 @@ function isWidgetTemporaryUnblock(tabId, requestHost, frameId) {
 }
 
 /**
- * Unblocks a tracker just temporarily on this tab, because the user has clicked the
- * corresponding replacement widget.
+ * Unblocks a tracker just temporarily on this tab, because the user has
+ * clicked the corresponding replacement widget.
  *
- * @param {Integer} tabId The id of the tab
- * @param {Array} widgetUrls an array of widget urls
+ * @param {Integer} tabId tab ID
+ * @param {Array} domains widget domains
  */
-function unblockWidgetOnTab(tabId, widgetUrls) {
+function unblockWidgetOnTab(tabId, domains) {
   if (temporaryWidgetUnblock[tabId] === undefined) {
     temporaryWidgetUnblock[tabId] = [];
   }
-  for (let i in widgetUrls) {
-    let url = widgetUrls[i];
-    let host = window.extractHostFromURL(url);
-    temporaryWidgetUnblock[tabId].push(host);
+  for (let i = 0; i < domains.length; i++) {
+    temporaryWidgetUnblock[tabId].push(domains[i]);
   }
 }
 
@@ -652,7 +650,7 @@ function dispatcher(request, sender, sendResponse) {
     }
 
   } else if (request.unblockWidget) {
-    unblockWidgetOnTab(sender.tab.id, request.buttonUrls);
+    unblockWidgetOnTab(sender.tab.id, request.domains);
     sendResponse();
 
   } else if (request.getReplacementButton) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -563,9 +563,11 @@ function getSocialWidgetBlockList() {
   var socialWidgetsToReplace = {};
 
   badger.socialWidgetList.forEach(function (socialwidget) {
-    // Only replace blocked and yellowlisted widgets
-    socialWidgetsToReplace[socialwidget.name] = constants.BLOCKED_ACTIONS.has(
-      badger.storage.getBestAction(socialwidget.domain)
+    // replace blocked widgets only
+    let action = badger.storage.getBestAction(socialwidget.domain);
+    socialWidgetsToReplace[socialwidget.name] = (
+      action == constants.BLOCK ||
+      action == constants.USER_BLOCK
     );
   });
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -35,7 +35,7 @@ var mdfp = require("multiDomainFP");
 var utils = require("utils");
 
 /************ Local Variables *****************/
-var temporarySocialWidgetUnblock = {};
+var temporaryWidgetUnblock = {};
 
 /***************** Blocking Listener Functions **************/
 
@@ -109,7 +109,7 @@ function onBeforeRequest(details) {
 
   // Notify the content script...
   var msg = {
-    replaceSocialWidget: true,
+    replaceWidget: true,
     trackerDomain: requestDomain
   };
   chrome.tabs.sendMessage(tab_id, msg);
@@ -219,7 +219,7 @@ function onBeforeSendHeaders(details) {
 
     // Notify the content script...
     var msg = {
-      replaceSocialWidget: true,
+      replaceWidget: true,
       trackerDomain: requestDomain
     };
     chrome.tabs.sendMessage(tab_id, msg);
@@ -489,7 +489,7 @@ function recordFingerprinting(tabId, msg) {
  */
 function forgetTab(tabId) {
   delete badger.tabData[tabId];
-  delete temporarySocialWidgetUnblock[tabId];
+  delete temporaryWidgetUnblock[tabId];
 }
 
 /**
@@ -501,9 +501,9 @@ function forgetTab(tabId) {
  * @returns {(String|Boolean)} false or the action to take
  */
 function checkAction(tabId, requestHost, frameId) {
-  // Ignore requests from temporarily unblocked social widgets.
+  // Ignore requests from temporarily unblocked widgets.
   // Someone clicked the widget, so let it load.
-  if (isSocialWidgetTemporaryUnblock(tabId, requestHost, frameId)) {
+  if (isWidgetTemporaryUnblock(tabId, requestHost, frameId)) {
     return false;
   }
 
@@ -551,29 +551,29 @@ function _isTabAnExtension(tabId) {
 }
 
 /**
- * Provides the social widget blocking content script with list of social widgets to block
+ * Provides the widget replacing content script with list of widgets to replace.
  *
  * @returns {Object} dict containing the complete list of widgets
  * as well as a mapping to indicate which ones should be replaced
  */
-function getSocialWidgetBlockList() {
+function getWidgetBlockList() {
 
   // A mapping of individual SocialWidget objects to boolean values that determine
-  // whether the content script should replace that tracker's social buttons
-  var socialWidgetsToReplace = {};
+  // whether the content script should replace that tracker's button/widget
+  var widgetsToReplace = {};
 
-  badger.socialWidgetList.forEach(function (socialwidget) {
+  badger.widgetList.forEach(function (widget) {
     // replace blocked widgets only
-    let action = badger.storage.getBestAction(socialwidget.domain);
-    socialWidgetsToReplace[socialwidget.name] = (
+    let action = badger.storage.getBestAction(widget.domain);
+    widgetsToReplace[widget.name] = (
       action == constants.BLOCK ||
       action == constants.USER_BLOCK
     );
   });
 
   return {
-    trackers: badger.socialWidgetList,
-    trackerButtonsToReplace: socialWidgetsToReplace
+    trackers: badger.widgetList,
+    trackerButtonsToReplace: widgetsToReplace
   };
 }
 
@@ -585,8 +585,8 @@ function getSocialWidgetBlockList() {
  * @param {Integer} frameId frame id to check
  * @returns {Boolean} true if in exception list
  */
-function isSocialWidgetTemporaryUnblock(tabId, requestHost, frameId) {
-  var exceptions = temporarySocialWidgetUnblock[tabId];
+function isWidgetTemporaryUnblock(tabId, requestHost, frameId) {
+  var exceptions = temporaryWidgetUnblock[tabId];
   if (exceptions === undefined) {
     return false;
   }
@@ -601,19 +601,19 @@ function isSocialWidgetTemporaryUnblock(tabId, requestHost, frameId) {
 
 /**
  * Unblocks a tracker just temporarily on this tab, because the user has clicked the
- * corresponding replacement social widget.
+ * corresponding replacement widget.
  *
  * @param {Integer} tabId The id of the tab
- * @param {Array} socialWidgetUrls an array of social widget urls
+ * @param {Array} widgetUrls an array of widget urls
  */
-function unblockSocialWidgetOnTab(tabId, socialWidgetUrls) {
-  if (temporarySocialWidgetUnblock[tabId] === undefined) {
-    temporarySocialWidgetUnblock[tabId] = [];
+function unblockWidgetOnTab(tabId, widgetUrls) {
+  if (temporaryWidgetUnblock[tabId] === undefined) {
+    temporaryWidgetUnblock[tabId] = [];
   }
-  for (var i in socialWidgetUrls) {
-    var socialWidgetUrl = socialWidgetUrls[i];
-    var socialWidgetHost = window.extractHostFromURL(socialWidgetUrl);
-    temporarySocialWidgetUnblock[tabId].push(socialWidgetHost);
+  for (let i in widgetUrls) {
+    let url = widgetUrls[i];
+    let host = window.extractHostFromURL(url);
+    temporaryWidgetUnblock[tabId].push(host);
   }
 }
 
@@ -646,13 +646,13 @@ function dispatcher(request, sender, sendResponse) {
     sendResponse(cookieBlock);
 
   } else if (request.checkReplaceButton) {
-    if (badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) && badger.isSocialWidgetReplacementEnabled()) {
-      var socialWidgetBlockList = getSocialWidgetBlockList();
-      sendResponse(socialWidgetBlockList);
+    if (badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) && badger.isWidgetReplacementEnabled()) {
+      let widgetBlockList = getWidgetBlockList();
+      sendResponse(widgetBlockList);
     }
-  } else if (request.unblockSocialWidget) {
-    var socialWidgetUrls = request.buttonUrls;
-    unblockSocialWidgetOnTab(sender.tab.id, socialWidgetUrls);
+
+  } else if (request.unblockWidget) {
+    unblockWidgetOnTab(sender.tab.id, request.buttonUrls);
     sendResponse();
 
   } else if (request.getReplacementButton) {
@@ -706,8 +706,11 @@ function dispatcher(request, sender, sendResponse) {
 
     sendResponse(badger.isPrivacyBadgerEnabled(tab_host) && isThirdPartyDomain(frame_host, tab_host));
 
-  } else if (request.checkSocialWidgetReplacementEnabled) {
-    sendResponse(badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) && badger.isSocialWidgetReplacementEnabled());
+  } else if (request.checkWidgetReplacementEnabled) {
+    sendResponse(
+      badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) &&
+      badger.isWidgetReplacementEnabled()
+    );
 
   } else if (request.type == "getPopupData") {
     let tab_id = request.tabId,
@@ -733,7 +736,7 @@ function dispatcher(request, sender, sendResponse) {
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),
       isLearnInIncognitoEnabled: badger.isLearnInIncognitoEnabled(),
-      isSocialWidgetReplacementEnabled: badger.isSocialWidgetReplacementEnabled(),
+      isWidgetReplacementEnabled: badger.isWidgetReplacementEnabled(),
       origins: badger.storage.getTrackingDomains(),
       showCounter: badger.showCounter(),
       showTrackingDomains: badger.getSettings().getItem("showTrackingDomains"),

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -160,7 +160,7 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" id="replace_social_widgets_checkbox">
+          <input type="checkbox" id="replace-widgets-checkbox">
           <span class="i18n_options_social_widgets_checkbox"></span>
         </label>
       </div>


### PR DESCRIPTION
Widget replacement for Disqus comments. Since the main script in charge of lazy-loading the comments is served from a custom subdomain (my-site.disqus.com), I added regex-based fuzzy domain unblocking as well. Facebook comments work much the same way, so those should be pretty easy to do after this.

This is rebased on #2267 , so that should be merged first.

Test pages:
https://cyphe.rs/test/disqus.html
https://thehill.com/homenews/administration/426112-trump-teases-major-announcement-about-shutdown-on-saturday
https://www.motherjones.com/politics/2019/01/trump-leaked-pelosi-travel-plans/