### PR TITLE
Add app.reelcrafter.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -495,6 +495,7 @@ recurly.com
 reddit.com
 redditmedia.com
 redditstatic.com
+app.reelcrafter.com
 cdngeneral.rentcafe.com
 resellerratings.com
 resultspage.com


### PR DESCRIPTION
The page on http://tburkes.com/music/testreelcrafter.html embeds two frames from `app.reelcrafter.com` where some `app.reelcrafter` resources set a "galaxy-sticky=oDopRy..." cookie.