### PR TITLE
Add Facebook Comments/Video, Twitch Player and YouTube (Privacy-Enhanced Mode) replacements

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -214,16 +214,21 @@
     },
     "YouTube": {
         "domains": [
+            "youtube.com",
             "www.youtube.com",
             "www.youtube-nocookie.com"
         ],
         "buttonSelectors": [
+            "iframe[src^='//www.youtube.com/embed/']",
             "iframe[src^='http://www.youtube.com/embed/']",
             "iframe[src^='https://www.youtube.com/embed/']",
+            "iframe[src^='https://youtube.com/embed/']",
+            "iframe[src^='//www.youtube-nocookie.com/embed/']",
             "iframe[src^='https://www.youtube-nocookie.com/embed/']"
         ],
         "replacementButton": {
             "unblockDomains": [
+                "youtube.com",
                 "www.youtube.com",
                 "www.youtube-nocookie.com"
             ],

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -60,6 +60,19 @@
             "type": 1
         }
     },
+    "Facebook Video": {
+        "domain": "www.facebook.com",
+        "buttonSelectors": [
+            "iframe[src^='https://www.facebook.com/plugins/video.php?']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "www.facebook.com"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
+    },
     "Google reCAPTCHA": {
         "domains": [
             "google.com",

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -26,6 +26,19 @@
             "type": 0
         }
     },
+    "Facebook Comments": {
+        "domain": "www.facebook.com",
+        "buttonSelectors": [
+            "div.fb-comments.fb_iframe_widget"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "www.facebook.com"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
+    },
     "Facebook Like": {
         "domain": "www.facebook.com",
         "buttonSelectors": [

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -199,14 +199,19 @@
         }
     },
     "YouTube": {
-        "domain": "www.youtube.com",
+        "domains": [
+            "www.youtube.com",
+            "www.youtube-nocookie.com"
+        ],
         "buttonSelectors": [
             "iframe[src^='http://www.youtube.com/embed/']",
-            "iframe[src^='https://www.youtube.com/embed/']"
+            "iframe[src^='https://www.youtube.com/embed/']",
+            "iframe[src^='https://www.youtube-nocookie.com/embed/']"
         ],
         "replacementButton": {
             "unblockDomains": [
-                "www.youtube.com"
+                "www.youtube.com",
+                "www.youtube-nocookie.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -173,6 +173,20 @@
             "type": 3
         }
     },
+    "Twitch Player": {
+        "domain": "player.twitch.tv",
+        "buttonSelectors": [
+            "iframe[src^='https://player.twitch.tv/']",
+            "iframe[src^='//player.twitch.tv/']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "player.twitch.tv"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
+    },
     "Twitter": {
         "domain": "platform.twitter.com",
         "buttonSelectors": [


### PR DESCRIPTION
In preparation for removing `www.facebook.com` from the yellowlist (#1593). Should be useful right away though because users often intentionally block `www.facebook.com` (#2021).

Interestingly, does not fix the [broken page](https://insider.foxnews.com/amp/article/59322) in #1815 because that uses a different API (needs more investigation) for producing the video player.

Examples follow.

Facebook Video:
- https://petapixel.com/2018/11/30/tricks-food-photographers-use-to-make-food-look-delicious/
- https://videosift.com/video/This-is-why-women-love-him
- https://www.getup.org.au/campaigns/aboriginal-and-torres-strait-islander/origin-reportback/traditional-owners-stood-their-ground
- http://www.napolitoday.it/attualita/paolantoni-risposta-gottardo-zanzara.html

Facebook Comments:
- https://fivethirtyeight.com/features/bernie-sanders-is-the-front-runner/#entry-comments
- https://www.dinside.no/okonomi/de-ti-storste-digitale-truslene-na/72105868
- https://www.pep.ph/news/local/151765/solgen-calida-coco-martin-a718-20200601?ref=home_featured_big
- https://www.winemag.com/recipe/pink-lady-classic-cocktail/#fb-comments-accordion
- https://www.ynetnews.com/article/B1EW11Rzn8/#articleComments
- https://www.prosportsdaily.com/RedZone/Article/unearthed-interview-proves-horace-grant-was-a-snitch-630606

Twitch Player:
- https://f1esports.com/live-stream
- https://www.chess.com/tv
- https://www.giantbomb.com/chat/

YouTube (youtube-nocookie.com):
- https://uplift.tv/2019/creating-a-new-world/
- https://connectiv.events/peter-denk-ueber-die-momentanen-lage/
- https://www.weathertech.com/weathertech-cupfone/cupfone/
- https://www.provinzial-online.de/content/privat/meine-provinzial-anmelden/login/index.html#!/anmeldung
- https://www.eurooptic.com/Zeiss-CONQUEST-V6-3-18x50-6-Hunting-Turret-522241-9906-000.aspx
- Video search results on https://duckduckgo.com/