### PR TITLE
Add replacement widget for YouTube

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -164,5 +164,20 @@
             "imagePath": "badger-play.png",
             "type": 3
         }
+    },
+    "YouTube": {
+        "domain": "www.youtube.com",
+        "buttonSelectors": [
+            "iframe[src^='http://www.youtube.com/embed/']",
+            "iframe[src^='https://www.youtube.com/embed/']"
+        ],
+        "replacementButton": {
+            "details": "",
+            "unblockDomains": [
+                "https://www.youtube.com/"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 3
+        }
     }
 }


### PR DESCRIPTION
Fixes #2337.

In preparation for removing `www.youtube.com` from the yellowlist (#1593). (What other kinds of embeds is it required by?)

Should be useful right away though because users often intentionally block www.youtube.com (#2021).

- [ ] Should also handle `youtube-nocookie.com`, plain http (not https) embeds
- [ ] See about handling the lazy loading implementations at https://kotaku.com/peach-is-a-monster-in-smash-ultimate-pros-say-1831613178 and https://www.huffingtonpost.com/entry/trevor-noah-scheme-voter-suppression_us_5bc99e6fe4b0d38b5876e1c6 ([similar issue seen previously on Deadspin](https://github.com/EFForg/privacybadger/pull/2262#issuecomment-451493405))

Examples:
- https://www.mortenhansen.com/discover-passion-purpose/
- https://uncrate.com/video/beatles-rooftop-concert-50th-anniversary/ (requires `www.youtube.com` to be blocked to work)
- https://pamela-vosseller.squarespace.com/subscriber-love
- https://blog.frontiersin.org/2018/10/02/cellular-neuroscience-brain-neurons-memory/
- https://boingboing.net/2018/11/01/lose-yourself-in-a-new-track-f.html
- https://www.diyphotography.net/secret-filming-fast-moving-objects-25-million-frames-per-second-mirrors/
- https://itsfoss.com/linuxboot-uefi/
- https://www.rollingstone.com/music/music-news/see-jennifer-hudsons-powerful-bob-dylan-cover-at-march-for-our-lives-rally-202446/
- http://ministryfeeds.com/justin-taylor/a-short-documentary-on-albert-mohler/#.W8U1cvlReHs (plain http example)