### PR TITLE
Add bigcommerce.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -57,6 +57,7 @@ bankrate.com
 bazaarvoice.com
 bcbits.com
 betterttv.net
+bigcommerce.com
 www.bing.com
 bit.ly
 bizrate.com


### PR DESCRIPTION
Fixes #1497.

Not clear how to reproduce, but we get a lot of reports:

Error report counts by date, page domain and exact blocked "bigcommerce" subdomain:
```
+---------+--------------------------------+----------------------------------------------+-------+
| ym      | blocked_fqdn                   | fqdn                                         | count |
+---------+--------------------------------+----------------------------------------------+-------+
| 2019-01 | cdn1.bigcommerce.com           | www.carbideprocessors.com                    |     1 |
| 2019-01 | cdn1.bigcommerce.com           | www.innermountainoutfitters.com              |     1 |
| 2019-01 | cdn10.bigcommerce.com          | www.carbideprocessors.com                    |     1 |
| 2019-01 | cdn10.bigcommerce.com          | www.grillgrate.com                           |     1 |
| 2019-01 | cdn10.bigcommerce.com          | www.innermountainoutfitters.com              |     1 |
| 2019-01 | cdn11.bigcommerce.com          | absoluteliftparts.com                        |     1 |
| 2019-01 | cdn11.bigcommerce.com          | halotopwholesale.com                         |     1 |
| 2019-01 | cdn11.bigcommerce.com          | lifestylemarkets.com                         |     1 |
| 2019-01 | cdn11.bigcommerce.com          | passionplanner.com                           |     1 |
| 2019-01 | cdn11.bigcommerce.com          | sincerelynuts.com                            |     1 |
| 2019-01 | cdn11.bigcommerce.com          | www.80percentarms.com                        |     1 |
| 2019-01 | cdn11.bigcommerce.com          | www.dorcousa.com                             |     1 |
| 2019-01 | cdn11.bigcommerce.com          | www.encore-editions.com                      |     1 |
| 2019-01 | cdn11.bigcommerce.com          | www.gamenerdz.com                            |     1 |
| 2019-01 | cdn11.bigcommerce.com          | www.homeopathyworks.com                      |     1 |
| 2019-01 | cdn11.bigcommerce.com          | www.paracordplanet.com                       |     1 |
| 2019-01 | cdn2.bigcommerce.com           | www.carbideprocessors.com                    |     1 |
| 2019-01 | cdn2.bigcommerce.com           | www.innermountainoutfitters.com              |     1 |
| 2019-01 | cdn3.bigcommerce.com           | www.grillgrate.com                           |     1 |
| 2019-01 | cdn3.bigcommerce.com           | www.stormykromer.com                         |     1 |
| 2019-01 | cdn6.bigcommerce.com           | spinning.com                                 |     1 |
| 2019-01 | cdn6.bigcommerce.com           | www.grillgrate.com                           |     1 |
| 2019-01 | cdn7.bigcommerce.com           | sincerelynuts.com                            |     1 |
| 2019-01 | cdn7.bigcommerce.com           | www.stormykromer.com                         |     1 |
| 2019-01 | cdn8.bigcommerce.com           | passionplanner.com                           |     1 |
| 2019-01 | cdn8.bigcommerce.com           | spinning.com                                 |     1 |
| 2019-01 | cdn8.bigcommerce.com           | www.gamenerdz.com                            |     1 |
| 2019-01 | cdn8.bigcommerce.com           | www.manhattanhomedesign.com                  |     1 |
| 2019-01 | cdn9.bigcommerce.com           | www.carbideprocessors.com                    |     1 |
| 2019-01 | cdn9.bigcommerce.com           | www.grillgrate.com                           |     1 |
| 2019-01 | cdn9.bigcommerce.com           | www.innermountainoutfitters.com              |     1 |
...
```

