### PR TITLE
Replacement widget improvements

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -509,6 +509,10 @@
             }
         }
     },
+    "allow_once": {
+        "message": "Allow once",
+        "description": "Button in the placeholder shown in place of certain third-party (video, audio, commenting) widgets. Clicking it will allow the third-party widget to load this one time only."
+    },
     "sync_intro": {
         "message": "Cloud sync:<ul><li>Requires Firefox/Chrome Sync</li><li>Upload overwrites any existing Privacy Badger data in the cloud</li><li>Download combines the lists of sites where your Badger is disabled</li></ul>",
         "description": "A brief explanation of how syncing works. Shown above the upload/download cloud data buttons under the Manage Data options page tab."

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -197,8 +197,8 @@
     "Vimeo": {
         "domain": "player.vimeo.com",
         "buttonSelectors": [
-            "iframe[src^='https://player.vimeo.com/video/']",
-            "iframe[src^='//player.vimeo.com/video/']"
+            "iframe[src^='https://player.vimeo.com/video/']:not([src*='background=1'])",
+            "iframe[src^='//player.vimeo.com/video/']:not([src*='background=1'])"
         ],
         "replacementButton": {
             "details": "",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -27,22 +27,22 @@ var pbStorage = require("storage");
 var HeuristicBlocking = require("heuristicblocking");
 var FirefoxAndroid = require("firefoxandroid");
 var webrequest = require("webrequest");
-var socialWidgetLoader = require("socialwidgetloader");
+var widgetLoader = require("widgetloader");
 
 var Migrations = require("migrations").Migrations;
 var incognito = require("incognito");
 
 /**
-* privacy badger initializer
-*/
+ * Privacy Badger initializer.
+ */
 function Badger() {
   var self = this;
 
   self.webRTCAvailable = checkWebRTCBrowserSupport();
 
-  self.socialWidgetList = [];
-  socialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json", (response) => {
-    self.socialWidgetList = response;
+  self.widgetList = [];
+  widgetLoader.loadWidgetsFromFile("data/socialwidgets.json", (response) => {
+    self.widgetList = response;
   });
 
   self.storage = new pbStorage.BadgerPen(function(thisStorage) {
@@ -488,7 +488,7 @@ Badger.prototype = {
   }, constants.DNT_POLICY_CHECK_INTERVAL),
 
   /**
-   * Default privacy badger settings
+   * Default Privacy Badger settings
    */
   defaultSettings: {
     checkForDNTPolicy: true,
@@ -654,9 +654,9 @@ Badger.prototype = {
   },
 
   /**
-   * Check if social widget replacement functionality is enabled
+   * Check if widget replacement functionality is enabled.
    */
-  isSocialWidgetReplacementEnabled: function() {
+  isWidgetReplacementEnabled: function () {
     return this.getSettings().getItem("socialWidgetReplacementEnabled");
   },
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -44,7 +44,7 @@
  */
 
 /**
- * Social widget tracker data, read from file.
+ * Widget data, read from file.
  */
 let trackerInfo;
 
@@ -62,7 +62,7 @@ function initialize() {
 
   // Set up listener for blocks that happen after initial check
   chrome.runtime.onMessage.addListener(function(request/*, sender, sendResponse*/) {
-    if (request.replaceSocialWidget) {
+    if (request.replaceWidget) {
       replaceSubsequentTrackerButtonsHelper(request.trackerDomain);
     }
   });
@@ -416,7 +416,7 @@ function getTrackerData(callback) {
  */
 function unblockTracker(buttonUrls, callback) {
   let request = {
-    unblockSocialWidget: true,
+    unblockWidget: true,
     buttonUrls: buttonUrls
   };
   chrome.runtime.sendMessage(request, callback);
@@ -436,9 +436,9 @@ if (document instanceof HTMLDocument === false && (
 }
 
 chrome.runtime.sendMessage({
-  checkSocialWidgetReplacementEnabled: true
-}, function (checkSocialWidgetReplacementEnabled) {
-  if (!checkSocialWidgetReplacementEnabled) {
+  checkWidgetReplacementEnabled: true
+}, function (checkWidgetReplacementEnabled) {
+  if (!checkWidgetReplacementEnabled) {
     return;
   }
   initialize();

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -48,6 +48,9 @@
  */
 let trackerInfo;
 
+// cached chrome.i18n.getMessage() results
+const TRANSLATIONS = [];
+
 
 /**
  * Initializes the content script.
@@ -116,7 +119,7 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
 
   button.setAttribute(
     "title",
-    chrome.i18n.getMessage("social_tooltip_pb_has_replaced", tracker.name)
+    TRANSLATIONS.social_tooltip_pb_has_replaced.replace("XXX", tracker.name)
   );
 
   let styleAttrs = [
@@ -318,7 +321,7 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
   textDiv.appendChild(document.createTextNode(
-    chrome.i18n.getMessage("social_tooltip_pb_has_replaced", name)));
+    TRANSLATIONS.social_tooltip_pb_has_replaced.replace("XXX", name)));
   widgetDiv.appendChild(textDiv);
 
   let buttonDiv = document.createElement('div');
@@ -400,9 +403,10 @@ function replaceIndividualButton(tracker) {
 function getTrackerData(callback) {
   chrome.runtime.sendMessage({checkReplaceButton: true}, function(response) {
     if (response) {
-      var trackers = response.trackers;
-      var trackerButtonsToReplace = response.trackerButtonsToReplace;
-      callback(trackers, trackerButtonsToReplace);
+      for (const key in response.translations) {
+        TRANSLATIONS[key] = response.translations[key];
+      }
+      callback(response.trackers, response.trackerButtonsToReplace);
     }
   });
 }

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -350,7 +350,7 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
   icon.setAttribute("alt", "");
   button.appendChild(icon);
 
-  button.appendChild(document.createTextNode("Allow once"));
+  button.appendChild(document.createTextNode(TRANSLATIONS.allow_once));
 
   buttonDiv.appendChild(button);
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -154,7 +154,7 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
   // in-place widget type:
   // reinitialize the widget by reinserting its element's HTML
   } else if (buttonType == 3) {
-    let widget = createReplacementWidget(button, trackerElem, buttonData.unblockDomains);
+    let widget = createReplacementWidget(tracker.name, button, trackerElem, buttonData.unblockDomains);
     return callback(widget);
   }
 
@@ -279,7 +279,7 @@ function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
   });
 }
 
-function createReplacementWidget(button, buttonToReplace, trackerUrls) {
+function createReplacementWidget(name, button, buttonToReplace, trackerUrls) {
   let widgetFrame = document.createElement('iframe');
 
   // widget replacement frame styles
@@ -317,19 +317,49 @@ function createReplacementWidget(button, buttonToReplace, trackerUrls) {
 
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
-  textDiv.appendChild(document.createTextNode(button.title));
+  textDiv.appendChild(document.createTextNode(
+    chrome.i18n.getMessage("social_tooltip_pb_has_replaced", name)));
   widgetDiv.appendChild(textDiv);
 
   let buttonDiv = document.createElement('div');
   buttonDiv.style = styleAttrs.join(" !important;") + " !important";
-  buttonDiv.appendChild(button);
+
+  // "activate once" button
+  let anchor = document.createElement('a');
+  let button_id = Math.random();
+  anchor.id = button_id;
+  anchor.href = "#";
+  styleAttrs = [
+    "border: 2px solid #ec9329",
+    "border-radius: 3px",
+    "color: #ec9329",
+    "cursor: pointer",
+    "font-weight: bold",
+    "line-height: 30px",
+    "padding: 8px",
+    "text-decoration: none",
+  ];
+  anchor.style = styleAttrs.join(" !important;") + " !important";
+
+  button.style.setProperty("margin", "0 5px", "important");
+  button.style.setProperty("height", "30px", "important");
+  button.style.setProperty("vertical-align", "middle", "important");
+  button.setAttribute("alt", "");
+  anchor.appendChild(button);
+
+  anchor.appendChild(document.createTextNode("Allow once"));
+
+  buttonDiv.appendChild(anchor);
+
   widgetDiv.appendChild(buttonDiv);
 
+  // set up click handler
   let parentEl = buttonToReplace.parentNode;
   widgetFrame.addEventListener('load', function () {
-    // click handler
-    widgetFrame.contentDocument.querySelector('img').addEventListener("click", function () {
+    let el = widgetFrame.contentDocument.getElementById(button_id);
+    el.addEventListener("click", function (e) {
       reinitializeWidgetAndUnblockTracker(widgetFrame, trackerUrls, buttonToReplace, parentEl);
+      e.preventDefault();
     }, { once: true });
   }, false);
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -291,6 +291,8 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
     "border: 1px solid #ec9329",
     "width:" + elToReplace.clientWidth + "px",
     "height:" + elToReplace.clientHeight + "px",
+    "min-width: 220px",
+    "min-height: 165px",
     "z-index: 2147483647",
   ];
   widgetFrame.style = styleAttrs.join(" !important;") + " !important";

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -279,15 +279,15 @@ function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
   });
 }
 
-function createReplacementWidget(name, button, buttonToReplace, trackerUrls) {
+function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
   let widgetFrame = document.createElement('iframe');
 
   // widget replacement frame styles
   let styleAttrs = [
     "background-color: #fff",
     "border: 1px solid #ec9329",
-    "width:" + buttonToReplace.clientWidth + "px",
-    "height:" + buttonToReplace.clientHeight + "px",
+    "width:" + elToReplace.clientWidth + "px",
+    "height:" + elToReplace.clientHeight + "px",
     "z-index: 2147483647",
   ];
   widgetFrame.style = styleAttrs.join(" !important;") + " !important";
@@ -325,10 +325,10 @@ function createReplacementWidget(name, button, buttonToReplace, trackerUrls) {
   buttonDiv.style = styleAttrs.join(" !important;") + " !important";
 
   // "activate once" button
-  let anchor = document.createElement('a');
+  let button = document.createElement('a');
   let button_id = Math.random();
-  anchor.id = button_id;
-  anchor.href = "#";
+  button.id = button_id;
+  button.href = "#";
   styleAttrs = [
     "border: 2px solid #ec9329",
     "border-radius: 3px",
@@ -339,26 +339,26 @@ function createReplacementWidget(name, button, buttonToReplace, trackerUrls) {
     "padding: 8px",
     "text-decoration: none",
   ];
-  anchor.style = styleAttrs.join(" !important;") + " !important";
+  button.style = styleAttrs.join(" !important;") + " !important";
 
-  button.style.setProperty("margin", "0 5px", "important");
-  button.style.setProperty("height", "30px", "important");
-  button.style.setProperty("vertical-align", "middle", "important");
-  button.setAttribute("alt", "");
-  anchor.appendChild(button);
+  icon.style.setProperty("margin", "0 5px", "important");
+  icon.style.setProperty("height", "30px", "important");
+  icon.style.setProperty("vertical-align", "middle", "important");
+  icon.setAttribute("alt", "");
+  button.appendChild(icon);
 
-  anchor.appendChild(document.createTextNode("Allow once"));
+  button.appendChild(document.createTextNode("Allow once"));
 
-  buttonDiv.appendChild(anchor);
+  buttonDiv.appendChild(button);
 
   widgetDiv.appendChild(buttonDiv);
 
   // set up click handler
-  let parentEl = buttonToReplace.parentNode;
+  let parentEl = elToReplace.parentNode;
   widgetFrame.addEventListener('load', function () {
     let el = widgetFrame.contentDocument.getElementById(button_id);
     el.addEventListener("click", function (e) {
-      reinitializeWidgetAndUnblockTracker(widgetFrame, trackerUrls, buttonToReplace, parentEl);
+      reinitializeWidgetAndUnblockTracker(widgetFrame, trackerUrls, elToReplace, parentEl);
       e.preventDefault();
     }, { once: true });
   }, false);

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -335,11 +335,11 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
   buttonDiv.style = styleAttrs.join(" !important;") + " !important";
 
   // "allow once" button
-  let button = document.createElement('a');
+  let button = document.createElement('button');
   let button_id = Math.random();
   button.id = button_id;
-  button.href = "#";
   styleAttrs = [
+    "background-color: #fff",
     "border: 2px solid #ec9329",
     "border-radius: 3px",
     "color: #ec9329",
@@ -347,7 +347,6 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
     "font-weight: bold",
     "line-height: 30px",
     "padding: 8px",
-    "text-decoration: none",
   ];
   button.style = styleAttrs.join(" !important;") + " !important";
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -106,8 +106,9 @@ function loadOptions() {
   $("#removeAllData").button("option", "icons", {primary: "ui-icon-closethick"});
   $("#show_counter_checkbox").on("click", updateShowCounter);
   $("#show_counter_checkbox").prop("checked", OPTIONS_DATA.showCounter);
-  $("#replace_social_widgets_checkbox").on("click", updateSocialWidgetReplacement);
-  $("#replace_social_widgets_checkbox").prop("checked", OPTIONS_DATA.isSocialWidgetReplacementEnabled);
+  $("#replace-widgets-checkbox")
+    .on("click", updateWidgetReplacement)
+    .prop("checked", OPTIONS_DATA.isWidgetReplacementEnabled);
   $("#enable_dnt_checkbox").on("click", updateDNTCheckboxClicked);
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
@@ -357,16 +358,15 @@ function updateShowCounter() {
 }
 
 /**
- * Update setting for whether or not to replace social widgets.
+ * Update setting for whether or not to replace
+ * social buttons/video players/commenting widgets.
  */
-function updateSocialWidgetReplacement() {
-  const enabled = $("#replace_social_widgets_checkbox").prop("checked");
+function updateWidgetReplacement() {
+  const socialWidgetReplacementEnabled = $("#replace-widgets-checkbox").prop("checked");
 
   chrome.runtime.sendMessage({
     type: "updateSettings",
-    data: {
-      socialWidgetReplacementEnabled: enabled
-    }
+    data: { socialWidgetReplacementEnabled }
   });
 }
 

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -45,10 +45,10 @@
 
 var utils = require('utils');
 
-require.scopes.socialwidgetloader = (function() {
+require.scopes.widgetloader = (function() {
 
 var exports = {};
-exports.loadSocialWidgetsFromFile = loadSocialWidgetsFromFile;
+exports.loadWidgetsFromFile = loadWidgetsFromFile;
 
 /**
  * Loads a JSON file at filePath and returns the parsed object.
@@ -97,18 +97,18 @@ function getFileContents(filePath, callback) {
  *                          extension's data folder
  * @param {Function} callback callback(socialwidgets)
  */
-function loadSocialWidgetsFromFile(filePath, callback) {
-  loadJSONFromFile(filePath, function(socialwidgetsJson) {
-    var socialwidgets = [];
+function loadWidgetsFromFile(filePath, callback) {
+  loadJSONFromFile(filePath, function(widgetsJson) {
+    let widgets = [];
 
-    // loop over each socialwidget, making a SocialWidget object
-    for (var socialwidgetName in socialwidgetsJson) {
-      var socialwidgetProperties = socialwidgetsJson[socialwidgetName];
-      var socialwidgetObject = new SocialWidget(socialwidgetName, socialwidgetProperties);
-      socialwidgets.push(socialwidgetObject);
+    // loop over each widget, making a SocialWidget object
+    for (let widget_name in widgetsJson) {
+      let widgetProperties = widgetsJson[widget_name];
+      let widget = new SocialWidget(widget_name, widgetProperties);
+      widgets.push(widget);
     }
 
-    callback(socialwidgets);
+    callback(widgets);
   });
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -565,6 +565,7 @@ let getWidgetBlockList = (function () {
       key: "social_tooltip_pb_has_replaced",
       placeholders: ["XXX"]
     },
+    { key: "allow_once" },
   ];
 
   return function () {

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -160,7 +160,7 @@
       </div>
       <div class="checkbox">
         <label>
-          <input type="checkbox" id="replace_social_widgets_checkbox">
+          <input type="checkbox" id="replace-widgets-checkbox">
           <span class="i18n_options_social_widgets_checkbox"></span>
         </label>
       </div>


### PR DESCRIPTION
Before:
![screenshot from 2019-02-06 12 25 38](https://user-images.githubusercontent.com/794578/52360786-d306f980-2a0a-11e9-949f-dabf88869df3.png)
After:
![screenshot from 2019-02-06 12 25 45](https://user-images.githubusercontent.com/794578/52360787-d39f9000-2a0a-11e9-9400-2452a37678b9.png)

No longer relying on the icon alone to convey meaning:
- Should make it more clear that the widgets are interactive. Some of the error reports just say that Privacy Badger replaced or blocked Vimeo, which suggests some users don't know what to do with the replacement.
- Improves accessibility (meaningful text, responds to <kbd>Tab</kbd> and <kbd>Enter</kbd>).
- Provides a workaround in cases like https://www.kontakthub.com/product/Resona/ where the page's CSP disallows our data URI-based icon.

Specifying minimum dimensions fixes cases like https://write.as/jesusinbooks/what-utterly-destroy-actually-means-in-the-old-testament and https://www.sophos.com/en-us/products/intercept-x.aspx / https://turo.com/c/garyg593 (click the "Play Video" button)

Having all widgets of the same type activate together when activating any one helps in cases such as http://www.glowfilms.com.au/ and http://killingforprofit.com/video/ and https://landslovsprosjektet.w.uib.no/

Ignoring background Vimeo videos makes #2281 less bad (see the issue for examples and rationale).

Follows up on #2262.