### PR TITLE
Add epoq.de to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -167,6 +167,7 @@ cdn.embedly.com
 i-cdn.embed.ly
 i.embed.ly
 epoch.com
+epoq.de
 estara.com
 ethn.io
 evcdn.com


### PR DESCRIPTION
Fixes #2108.

Error report counts by date, page domain and exact blocked "epoq.de" subdomain:
```
+---------+--------------------------+--------------------------+-------+
| ym      | blocked_fqdn             | fqdn                     | count |
+---------+--------------------------+--------------------------+-------+
| 2019-02 | rs.epoq.de               | www.notebooksbilliger.de |     1 |
| 2019-02 | search.epoq.de           | www.notebooksbilliger.de |     1 |
| 2019-02 | search.epoq.de           | www.villeroy-boch.de     |     1 |
| 2019-02 | searchstandby.epoq.de    | www.notebooksbilliger.de |     1 |
| 2019-02 | searchstandby.epoq.de    | www.villeroy-boch.de     |     1 |
| 2019-02 | vub-tk-de-de.arc.epoq.de | www.villeroy-boch.de     |     1 |
| 2018-11 | cdn.epoq.de              | www.manufactum.de        |     1 |
| 2018-11 | search.epoq.de           | www.iba.ch               |     1 |
| 2018-11 | searchstandby.epoq.de    | www.iba.ch               |     1 |
| 2018-10 | cdn.epoq.de              | direkt.jacob.de          |     1 |
| 2018-10 | jacob-de.arc.epoq.de     | direkt.jacob.de          |     1 |
| 2018-09 | cdn.epoq.de              | www.villeroy-boch.de     |     1 |
| 2018-09 | search.epoq.de           | www.villeroy-boch.de     |     1 |
| 2018-09 | vub-tk-de-de.arc.epoq.de | www.villeroy-boch.de     |     1 |
| 2018-08 | rs.epoq.de               | www.notebooksbilliger.de |     1 |
| 2018-08 | rs.epoq.de               | www.postshop.ch          |     1 |
| 2018-08 | search.epoq.de           | www.notebooksbilliger.de |     1 |
| 2018-08 | searchstandby.epoq.de    | www.notebooksbilliger.de |     1 |
| 2018-06 | cdn.epoq.de              | direkt.jacob.de          |     1 |
| 2018-06 | rs.epoq.de               | www.notebooksbilliger.de |     1 |
| 2018-05 | rs.epoq.de               | www.notebooksbilliger.de |     1 |
| 2018-05 | rs.epoq.de               | www.worldshop.eu         |     1 |
| 2018-05 | searchstandby.epoq.de    | www.notebooksbilliger.de |     1 |
| 2018-05 | worldshop-eu.arc.epoq.de | www.worldshop.eu         |     1 |
| 2018-03 | cdn.epoq.de              | www.jacob.de             |     1 |
...
```