### PR TITLE
WIP Add surrogate script for addthis_widget.js

### DIFF
--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -69,6 +69,7 @@ const hostnames = {
   ],
   'cdn.krxd.net': 'noopjs',
   'widgets.outbrain.com': '/outbrain.js',
+  's7.addthis.com': '/addthis_widget.js',
 };
 
 /**
@@ -513,6 +514,27 @@ const surrogates = {
         obr.extern[a] = noopfn;
       });
       window.OBR = window.OBR || obr;
+    } + ')();',
+
+
+  // https://github.com/uBlockOrigin/uAssets/blob/577af0626fde9e7c48658891be045bd0fac7f27a/filters/resources.txt#L890-L906
+  '/addthis_widget.js': '(' +
+    function() {
+      var noopfn = function() {
+        ;
+      };
+      window.addthis = {
+        addEventListener: noopfn,
+        button: noopfn,
+        init: noopfn,
+        layers: noopfn,
+        ready: noopfn,
+        sharecounters: {
+          getShareCounts: noopfn
+        },
+        toolbox: noopfn,
+        update: noopfn
+      };
     } + ')();',
 
   // https://github.com/uBlockOrigin/uAssets/blob/0efcadb2ecc2a9f0daa5a1df79841d794b83860f/filters/resources.txt#L38-L41


### PR DESCRIPTION
Fixes #1298.

Need to figure out how to make surrogates and replacement widgets work well together. Looks like having this surrogate breaks the activation of our [AddThis replacement widget](https://github.com/EFForg/privacybadger/blob/bf38a6a14c442c5497dff58928f80293766b5d80/src/data/socialwidgets.json#L2-L17) ([for example](http://sharemenot.cs.washington.edu/Test%20Installation.shtml)). Is it possible to have the widget work correctly with the surrogate? Could we force the browser to ignore the dummy `addthis_widget.js` script and re-fetch it (without reloading the page)?