### PR TITLE
Add geetest.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -212,6 +212,7 @@ gannett-tv.com
 gasbuddy.com
 gawkerassets.com
 geenstijl.nl
+geetest.com
 geoplugin.net
 geotrust.com
 getpocket.com


### PR DESCRIPTION
Fixes #1440.

Let's see if yellowlisting will help.