### PR TITLE
Ignore messenger images when instrumenting Facebook links.

### DIFF
--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -1,6 +1,6 @@
 /* globals findInAllFrames:false, observeMutations:false */
 // Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
-let fb_wrapped_link = `a[href*='${document.domain}/l.php?'`;
+let fb_wrapped_link = `a[href*='${document.domain}/l.php?']:not([aria-label='photo'])`;
 
 // remove all attributes from a link except for class and ARIA attributes
 function cleanAttrs(elem) {
@@ -50,6 +50,5 @@ chrome.runtime.sendMessage({checkEnabled: true},
 
     // Execute redirect unwrapping each time new content is added to the page
     observeMutations(fb_wrapped_link, cleanLink);
-
   }
 );


### PR DESCRIPTION
Closes #2214. In order to keep the feature broken by #2214, we need to avoid overriding the click handler on images. I think the modification to the selector should be enough, and I haven't found any false positives that it matches yet.