### PR TITLE
Add smartlock.google.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -265,6 +265,7 @@ picasaweb.google.com
 play.google.com
 plus.google.com
 sites.google.com
+smartlock.google.com
 spreadsheets.google.com
 storage.googleapis.com
 talkgadget.google.com


### PR DESCRIPTION
Getting lots of reports that blocking `smartlock.google.com` breaks www.redfin.com.

> Site no longer functions when the smartlock.google.com tracker is completely blocked. When it's set to the no cookies setting, it works again.

Report counts where "smartlock.google.com" was blocked/user-allowed/user-cookieblocked grouped by site and month (partial data for 2019-02):
```
+---------+-------------------------------+-------+
| ym      | fqdn                          | count |
+---------+-------------------------------+-------+
| 2019-02 | www.redfin.com                |    33 |
| 2019-02 | id.atlassian.com              |     2 |
| 2019-02 | www.pinterest.co.uk           |     1 |
| 2019-02 | www.nerdwallet.com            |     1 |
| 2019-02 | www.paypal.com                |     1 |
| 2019-02 | groww.in                      |     1 |
| 2019-02 | www.linkedin.com              |     1 |
| 2019-01 | www.pinterest.com             |     5 |
| 2019-01 | id.atlassian.com              |     3 |
| 2019-01 | www.redfin.com                |     2 |
| 2019-01 | www.vrbo.com                  |     2 |
| 2019-01 | www.nerdwallet.com            |     2 |
| 2019-01 | www.volagratis.com            |     1 |
| 2019-01 | joblift.com                   |     1 |
| 2019-01 | zapier.com                    |     1 |
| 2019-01 | www.pinterest.co.uk           |     1 |
| 2019-01 | www.momondo.co.uk             |     1 |
| 2019-01 | www.pinterest.se              |     1 |
| 2019-01 | drive.google.com              |     1 |
| 2019-01 | matterapp.com                 |     1 |
| 2019-01 | www.zillow.com                |     1 |
| 2019-01 | www.mako.co.il                |     1 |
| 2019-01 | id.stg.internal.atlassian.com |     1 |
| 2019-01 | www.paypal.com                |     1 |
| 2019-01 | www.landsend.com              |     1 |
...
```