### PR TITLE
Add weebly.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -637,6 +637,7 @@ webflow.com
 webs.com
 websimages.com
 webtype.com
+weebly.com
 where.com
 widgetserver.com
 wikidata.org


### PR DESCRIPTION
Fixes #1383. Follows up on #2303.

Seems to be yet another case of getting first-party GA cookies and then seeing them in third-party contexts (#367).