### PR TITLE
Add payments-amazon.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -460,6 +460,7 @@ outlook.com
 pandacommerce.net
 parastorage.com
 passwordbox.com
+payments-amazon.com
 paypal.com
 paypalobjects.com
 pdf.yt


### PR DESCRIPTION
Fixes #2169. Related to #2238. Yellowlisting may not actually fix the payment flow, but let's see.