### PR TITLE
Add NYU domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1153,6 +1153,11 @@ var multiDomainFirstPartiesArray = [
   ],
   ["nytimes.com", "newyorktimes.com", "nyt.com"],
   [
+    "nyu.edu",
+
+    "nyupress.org",
+  ],
+  [
     "nvidia.com",
 
     "nvidia.at",


### PR DESCRIPTION
Fixed linting, and removed mediacommons.org because we have yet to see an issues with Privacy Badger and Media Commons. This PR replaces #2333. 