### PR TITLE
Fix replacement widget creating zero-width styles

### DIFF
--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -291,14 +291,14 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
   let widgetFrame = document.createElement('iframe');
 
   let frameBorderWidthPx = 1;
-  let frameWidth = elToReplace.offsetWidth - frameBorderWidthPx; 
+  let frameWidth = elToReplace.offsetWidth - frameBorderWidthPx;
   let frameHeight = elToReplace.offsetHeight - frameBorderWidthPx;
 
-  // if we didn't get a value that makes sense from .offsetHeight/.offsetWidth, 
+  // if we didn't get a value that makes sense from .offsetHeight/.offsetWidth,
   // then don't set a rule at all
-  let widthRule = frameWidth > 0 ? "width:" + frameWidth + "px" : false; 
+  let widthRule = frameWidth > 0 ? "width:" + frameWidth + "px" : false;
   let heightRule = frameHeight > 0 ? "height:" + frameHeight + "px" : false;
-  
+
   // widget replacement frame styles
   let styleAttrs = [
     "background-color: #fff",
@@ -309,7 +309,7 @@ function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
     "min-height: 165px",
     "z-index: 2147483647",
   ];
-  
+
   styleAttrs = styleAttrs.filter(rule => rule); // Remove 'false' style rules
   widgetFrame.style = styleAttrs.join(" !important;") + " !important";
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -290,16 +290,27 @@ function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
 function createReplacementWidget(name, icon, elToReplace, trackerUrls) {
   let widgetFrame = document.createElement('iframe');
 
+  let frameBorderWidthPx = 1;
+  let frameWidth = elToReplace.offsetWidth - frameBorderWidthPx; 
+  let frameHeight = elToReplace.offsetHeight - frameBorderWidthPx;
+
+  // if we didn't get a value that makes sense from .offsetHeight/.offsetWidth, 
+  // then don't set a rule at all
+  let widthRule = frameWidth > 0 ? "width:" + frameWidth + "px" : false; 
+  let heightRule = frameHeight > 0 ? "height:" + frameHeight + "px" : false;
+  
   // widget replacement frame styles
   let styleAttrs = [
     "background-color: #fff",
-    "border: 1px solid #ec9329",
-    "width:" + elToReplace.clientWidth + "px",
-    "height:" + elToReplace.clientHeight + "px",
+    "border: " + frameBorderWidthPx + "px solid #ec9329",
+    widthRule,
+    heightRule,
     "min-width: 220px",
     "min-height: 165px",
     "z-index: 2147483647",
   ];
+  
+  styleAttrs = styleAttrs.filter(rule => rule); // Remove 'false' style rules
   widgetFrame.style = styleAttrs.join(" !important;") + " !important";
 
   let widgetDiv = document.createElement('div');


### PR DESCRIPTION
This uses .offsetWidth instead of .clientWidth(), and then subtracts the border width to get a better approximation of the original element's dimensions. It also checks to make sure we got dimensions that makes sense (>0px) before adding width/height rules to the replacement element.