### PR TITLE
add Visual Studio domains to Microsoft MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -923,6 +923,8 @@ var multiDomainFirstPartiesArray = [
     "skype.com",
     "s-microsoft.com",
     "visualstudio.com",
+    "vsallin.net",
+    "vsassets.io",
     "windowsazure.com",
     "windows.com",
     "xbox.com",


### PR DESCRIPTION
Adding vsassets.io and vsallin.net (from CSAN list) to fix breakage on Visual Studio Marketplace. 
Closes #2347.