### PR TITLE
Add wmfusercontent.org to Wikimedia MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1715,7 +1715,8 @@ var multiDomainFirstPartiesArray = [
   ["wetter.com", "tiempo.es", "wettercomassets.com"],
   ["wikipedia.org", "wikimedia.org", "wikimediafoundation.org", "wiktionary.org",
     "wikiquote.org", "wikibooks.org", "wikisource.org", "wikinews.org",
-    "wikiversity.org", "mediawiki.org", "wikidata.org", "wikivoyage.org"],
+    "wikiversity.org", "mediawiki.org", "wikidata.org", "wikivoyage.org",
+    "wmfusercontent.org"],
   ["wix.com", "wixapps.net", "wixstatic.com", "parastorage.com"],
   ["wordpress.com", "wp.com"],
   [


### PR DESCRIPTION
Privacy Badger was blocking `phab.wmfusercontent.org`, which was making the website at `phabricator.wikimedia.org` render without the appropriate styling.
```
**** ACTION_MAP for wmfusercontent.org
phab.wmfusercontent.org {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 1555600002198
}
wmfusercontent.org {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
}
**** SNITCH_MAP for wmfusercontent.org
wmfusercontent.org [
  "wikimedia.org",
  "stackexchange.com",
  "wikipedia.org"
]