### PR TITLE
add availabilitycalendar.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -50,6 +50,7 @@ assets-cdk.com
 auth0.com
 authorize.net
 autoforums.com
+availabilitycalendar.com
 azureedge.net
 bac-assets.com
 bandcamp.com


### PR DESCRIPTION
Domain was being blocked here: https://www.mastourdumonde.nl/prijzen-beschikbaarheid

The domain is for a third-party calendar widget. It's being blocked because of a PHP log-in session cookie.

We shouldn't merge yet. Is this a good candidate for the yellowlist?