### PR TITLE
Hide non-tracking domains by default

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -137,7 +137,7 @@
     },
     "options_show_nontracking_domains_checkbox": {
         "message": "Show domains that don't appear to be tracking you",
-        "description": "Checkbox label on the general settings page"
+        "description": "Checkbox label on the general settings page. Should match wording used in the 'non_tracker' message."
     },
     "options_incognito_warning": {
         "message": "** Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
@@ -170,7 +170,7 @@
         "description": "Checkbox label on the general settings page"
     },
     "show_counter_checkbox": {
-        "message": "Show count of blocked items",
+        "message": "Show count of trackers",
         "description": "Checkbox label on the general settings page"
     },
     "what_is_a_tracker": {
@@ -485,7 +485,7 @@
     },
     "non_tracker": {
         "message": "The domains below don't appear to be tracking you",
-        "description": ""
+        "description": "Header text; separates tracking from non-tracking domains in the popup."
     },
     "popup_options_button": {
         "message": "Options",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -135,6 +135,10 @@
         "message": "Replace social widgets",
         "description": "Checkbox label on the general settings page"
     },
+    "options_show_nontracking_domains_checkbox": {
+        "message": "Show domains that don't appear to be tracking you",
+        "description": "Checkbox label on the general settings page"
+    },
     "options_incognito_warning": {
         "message": "** Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
         "description": "Detailed explanation shown under checkboxes on the general settings page"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -501,6 +501,7 @@ Badger.prototype = {
     sendDNTSignal: true,
     showCounter: true,
     showIntroPage: true,
+    showNonTrackingDomains: false,
     showTrackingDomains: false,
     socialWidgetReplacementEnabled: true
   },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -540,6 +540,7 @@ Badger.prototype = {
       Migrations.forgetNontrackingDomains,
       Migrations.forgetMistakenlyBlockedDomains,
       Migrations.resetWebRTCIPHandlingPolicy,
+      Migrations.enableShowNonTrackingDomains,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -248,6 +248,19 @@ exports.Migrations= {
     });
   },
 
+  enableShowNonTrackingDomains: function (badger) {
+    console.log("Enabling showNonTrackingDomains for some users");
+
+    let actionMap = badger.storage.getBadgerStorageObject("action_map"),
+      actions = actionMap.getItemClones();
+
+    // if we have any customized sliders
+    if (Object.keys(actions).some(domain => actions[domain].userAction != "")) {
+      // keep showing non-tracking domains in the popup
+      badger.getSettings().setItem("showNonTrackingDomains", true);
+    }
+  },
+
 };
 
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -136,6 +136,16 @@ function loadOptions() {
     .on("click", updateLearnInIncognito)
     .prop("checked", OPTIONS_DATA.isLearnInIncognitoEnabled);
 
+  $('#show-nontracking-domains-checkbox')
+    .on("click", (event) => {
+      let showNonTrackingDomains = $(event.currentTarget).prop("checked");
+      chrome.runtime.sendMessage({
+        type: "updateSettings",
+        data: { showNonTrackingDomains }
+      });
+    })
+    .prop("checked", OPTIONS_DATA.showNonTrackingDomains);
+
   reloadWhitelist();
   reloadTrackingDomainsTab();
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -503,7 +503,6 @@ function refreshPopup() {
   var printable = [];
   var nonTracking = [];
   originsArr = htmlUtils.sortDomains(originsArr);
-  var num_trackers = 0;
 
   for (let i=0; i < originsArr.length; i++) {
     var origin = originsArr[i];
@@ -514,9 +513,6 @@ function refreshPopup() {
       continue;
     }
 
-    if (action != constants.DNT) {
-      num_trackers++;
-    }
     printable.push(
       htmlUtils.getOriginHtml(origin, action, action == constants.DNT)
     );
@@ -545,14 +541,14 @@ function refreshPopup() {
   // activate tooltips
   $('.tooltip').tooltipster();
 
-  if (num_trackers === 0) {
+  if (POPUP_DATA.trackerCount === 0) {
     // hide multiple trackers message
     $("#instructions-many-trackers").hide();
 
     // show "no trackers" message
     $("#instructions_no_trackers").show();
 
-  } else if (num_trackers == 1) {
+  } else if (POPUP_DATA.trackerCount == 1) {
     // hide multiple trackers message
     $("#instructions-many-trackers").hide();
 
@@ -562,7 +558,7 @@ function refreshPopup() {
   } else {
     $('#instructions-many-trackers').html(chrome.i18n.getMessage(
       "popup_instructions", [
-        num_trackers,
+        POPUP_DATA.trackerCount,
         "<a target='_blank' title='" + _.escape(chrome.i18n.getMessage("what_is_a_tracker")) + "' class='tooltip' href='https://www.eff.org/privacybadger/faq#What-is-a-third-party-tracker'>"
       ]
     )).find(".tooltip").tooltipster();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -487,8 +487,10 @@ function refreshPopup() {
     // show "no trackers" message
     $("#instructions_no_trackers").show();
 
-    // show the "no third party resources on this site" message
-    $("#blockedResources").html(chrome.i18n.getMessage("popup_blocked"));
+    if (POPUP_DATA.showNonTrackingDomains) {
+      // show the "no third party resources on this site" message
+      $("#blockedResources").html(chrome.i18n.getMessage("popup_blocked"));
+    }
 
     // activate tooltips
     $('.tooltip').tooltipster();
@@ -497,12 +499,6 @@ function refreshPopup() {
 
     return;
   }
-
-  // Get containing HTML for domain list along with toggle legend icons.
-  $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
-
-  // activate tooltips
-  $('.tooltip').tooltipster();
 
   var printable = [];
   var nonTracking = [];
@@ -526,12 +522,13 @@ function refreshPopup() {
     );
   }
 
-  var nonTrackerText = chrome.i18n.getMessage("non_tracker");
-  var nonTrackerTooltip = chrome.i18n.getMessage("non_tracker_tip");
-
-  if (nonTracking.length > 0) {
+  if (POPUP_DATA.showNonTrackingDomains && nonTracking.length > 0) {
     printable.push(
-      '<div class="clicker tooltip" id="nonTrackers" title="'+nonTrackerTooltip+'" data-tooltipster=\'{"side":"top"}\'>'+nonTrackerText+'</div>'
+      '<div class="clicker tooltip" id="nonTrackers" title="' +
+      chrome.i18n.getMessage("non_tracker_tip") +
+      '" data-tooltipster=\'{"side":"top"}\'>' +
+      chrome.i18n.getMessage("non_tracker") +
+      '</div>'
     );
     for (let i = 0; i < nonTracking.length; i++) {
       printable.push(
@@ -539,6 +536,14 @@ function refreshPopup() {
       );
     }
   }
+
+  if (printable.length) {
+    // get containing HTML for domain list along with toggle legend icons
+    $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
+  }
+
+  // activate tooltips
+  $('.tooltip').tooltipster();
 
   if (num_trackers === 0) {
     // hide multiple trackers message
@@ -587,7 +592,12 @@ function refreshPopup() {
       window.SLIDERS_DONE = true;
     }
   }
-  requestAnimationFrame(renderDomains);
+
+  if (printable.length) {
+    requestAnimationFrame(renderDomains);
+  } else {
+    window.SLIDERS_DONE = true;
+  }
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -748,7 +748,8 @@ function dispatcher(request, sender, sendResponse) {
       showNonTrackingDomains: badger.getSettings().getItem("showNonTrackingDomains"),
       tabHost: tab_host,
       tabId: tab_id,
-      tabUrl: tab_url
+      tabUrl: tab_url,
+      trackerCount: has_tab_data && badger.getTrackerCount(tab_id)
     });
 
   } else if (request.type == "getOptionsData") {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -745,6 +745,7 @@ function dispatcher(request, sender, sendResponse) {
       noTabData: !has_tab_data,
       origins: has_tab_data && badger.tabData[tab_id].origins,
       seenComic: badger.getSettings().getItem("seenComic"),
+      showNonTrackingDomains: badger.getSettings().getItem("showNonTrackingDomains"),
       tabHost: tab_host,
       tabId: tab_id,
       tabUrl: tab_url
@@ -759,6 +760,7 @@ function dispatcher(request, sender, sendResponse) {
       isWidgetReplacementEnabled: badger.isWidgetReplacementEnabled(),
       origins: badger.storage.getTrackingDomains(),
       showCounter: badger.showCounter(),
+      showNonTrackingDomains: badger.getSettings().getItem("showNonTrackingDomains"),
       showTrackingDomains: badger.getSettings().getItem("showTrackingDomains"),
       webRTCAvailable: badger.webRTCAvailable,
     });

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -17,6 +17,15 @@ h3 {
     margin: 10px 0;
 }
 
+hr {
+    border: 0;
+    height: 1px;
+    background-color: #d3d3d3;
+    margin: 20px 0;
+    max-width: 700px;
+    width: 100%;
+}
+
 td
 {
   font-size: 13px;

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -176,6 +176,15 @@
           <span class="i18n_options_dnt_policy_setting"></span>
         </label>
       </div>
+
+      <hr>
+
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" id="show-nontracking-domains-checkbox">
+          <span class="i18n_options_show_nontracking_domains_checkbox"></span>
+        </label>
+      </div>
       <div class="checkbox" id="webRTCToggle">
         <label>
           <input type="checkbox" id="toggle_webrtc_mode" disabled>
@@ -188,6 +197,7 @@
           <span class="i18n_options_incognito_setting"></span>
         </label>
       </div>
+
       <div id="settings-suffix">
         <div id="webrtc-warning" class="i18n_options_webrtc_warning"></div>
         <div id="incognito-warning" class="i18n_options_incognito_warning"></div>

--- a/src/tests/tests/tabData.js
+++ b/src/tests/tests/tabData.js
@@ -40,16 +40,16 @@ function() {
     const DOMAIN = "example.com";
 
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 0, "count starts at zero"
+      badger.getTrackerCount(this.tabId), 0, "count starts at zero"
     );
 
-    // set up domain blocking (used by getBlockedOriginCount)
+    // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log blocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 1, "count gets incremented"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledOnce,
@@ -64,11 +64,26 @@ function() {
   QUnit.test("logging unblocked domain", function (assert) {
     badger.logThirdPartyOriginOnTab(this.tabId, "example.com", constants.ALLOW);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 0, "count stays at zero"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
+    );
+    assert.ok(
+      chrome.browserAction.setBadgeText.calledOnce,
+      "updateBadge gets called when we see an unblocked domain"
+    );
+    assert.ok(chrome.browserAction.setBadgeText.calledWithExactly({
+      tabId: this.tabId,
+      text: "1"
+    }), "setBadgeText was called with expected args");
+  });
+
+  QUnit.test("logging DNT-compliant domain", function (assert) {
+    badger.logThirdPartyOriginOnTab(this.tabId, "example.com", constants.DNT);
+    assert.equal(
+      badger.getTrackerCount(this.tabId), 0, "count stays at zero"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.notCalled,
-      "updateBadge does not get called when we see an unblocked domain"
+      "updateBadge does not get called when we see a DNT-compliant domain"
     );
   });
 
@@ -78,13 +93,13 @@ function() {
     // log unblocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.ALLOW);
 
-    // set up domain blocking (used by getBlockedOriginCount)
+    // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log the same domain, this time as blocked
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 1, "count gets incremented"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledOnce,
@@ -99,13 +114,13 @@ function() {
   QUnit.test("logging blocked domain twice", function (assert) {
     const DOMAIN = "example.com";
 
-    // set up domain blocking (used by getBlockedOriginCount)
+    // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log blocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 1, "count gets incremented"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledOnce,
@@ -119,7 +134,7 @@ function() {
     // log the same blocked domain again
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId),
+      badger.getTrackerCount(this.tabId),
       1,
       "count does not get incremented"
     );
@@ -136,13 +151,13 @@ function() {
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.ALLOW);
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.ALLOW);
 
-    // set up domain blocking (used by getBlockedOriginCount)
+    // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log blocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 1, "count gets incremented"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledOnce,
@@ -156,7 +171,7 @@ function() {
     // log the same blocked domain again
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId),
+      badger.getTrackerCount(this.tabId),
       1,
       "count does not get incremented"
     );
@@ -169,13 +184,13 @@ function() {
   QUnit.test("logging cookieblocked domain", function (assert) {
     const DOMAIN = "example.com";
 
-    // set up domain blocking (used by getBlockedOriginCount)
+    // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.COOKIEBLOCK);
 
     // log cookieblocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.COOKIEBLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 1, "count gets incremented"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledOnce,
@@ -191,14 +206,14 @@ function() {
     const DOMAIN1 = "example.com",
       DOMAIN2 = "example.net";
 
-    // set up domain blocking (used by getBlockedOriginCount)
+    // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN1, constants.BLOCK);
     badger.storage.setupHeuristicAction(DOMAIN2, constants.COOKIEBLOCK);
 
     // log blocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN1, constants.BLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 1, "count gets incremented"
+      badger.getTrackerCount(this.tabId), 1, "count gets incremented"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledOnce,
@@ -212,7 +227,7 @@ function() {
     // log cookieblocked domain
     badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN2, constants.COOKIEBLOCK);
     assert.equal(
-      badger.getBlockedOriginCount(this.tabId), 2, "count gets incremented again"
+      badger.getTrackerCount(this.tabId), 2, "count gets incremented again"
     );
     assert.ok(
       chrome.browserAction.setBadgeText.calledTwice,

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -42,6 +42,11 @@ class CookieTest(pbtest.PBSeleniumTest):
         self.driver.delete_all_cookies()
         # fixme: check for chrome settings for third party cookies?
 
+        self.js(
+            "chrome.extension.getBackgroundPage()."
+            "badger.getSettings().setItem('showNonTrackingDomains', true);"
+        )
+
         # load the first site with the third party code that reads and writes a cookie
         self.load_url(SITE1_URL)
         self.load_pb_ui(SITE1_URL)


### PR DESCRIPTION
This hides the non-tracking domains section in the popup (screenshot below) to help with #2021.

![Screenshot from 2019-05-07 15:06:58](https://user-images.githubusercontent.com/794578/57326209-f7da3e00-70d9-11e9-8414-f35626625f48.png)

This is meant to be low-hanging fruit to help users avoid breaking the Web for themselves. Top user-blocked domains like `ajax.googleapis.com`, `cdnjs.cloudflare.com` and `maxcdn.bootstrapcdn.com` are almost certainly non-tracking and break much of the Web when blocked.

Users (Privacy Badger developers ...) who wish to continue to see all third-party domains in the popup can enable the new "Show domains that don't appear to be tracking you setting" setting (the name is meant to mirror existing non-tracking domains section header text in the popup):

![Screenshot from 2019-05-07 14:26:38](https://user-images.githubusercontent.com/794578/57326449-8353cf00-70da-11e9-8bed-f6e3543057a4.png)

## Changes

- [x] Hide non-tracking domains in popup by default.
- [x] Add option to restore showing domains that Privacy Badger doesn't consider to be tracking for whatever reason. This should primarily be useful to Privacy Badger developers.
- [x] Keep showing non-tracking domains for users who customized any domain slider settings. This should eliminate any disruption to existing users.
- [x] Update the badge counter to match the count in the popup. Popup text counts total tracking domains but badge currently counts blocked domains only. This just seems needlessly complicated; let's have both count total tracking domains.