### PR TITLE
Add api.openshift.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -34,6 +34,7 @@ mcp-media5.anvato.net
 aol.com
 aolcdn.com
 ap.org
+api.openshift.com
 apnewsregistry.com
 apple.com
 hiroservers.appspot.com


### PR DESCRIPTION
The `api.openshift.com` site hosts a collection of REST APIs that are needed by other sites like, for example `cloud.redhat.com`.

Privacy Badger is popular amongst our user base, and we get frequent reports that it is blocking `api.openshift.com`, which breaks the complete site.

We believe that this belongs in the "Is domain necessary for functionality the users expects" category described in the [yellowlist-criteria.md](https://github.com/EFForg/privacybadger/blob/master/doc/yellowlist-criteria.md) file.

Would you consider merging this? Any additional information you need?