### PR TITLE
Add sidearmsports.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -533,6 +533,7 @@ sgizmo.com
 shopify.com
 shopping.com
 shoprunner.com
+sidearmsports.com
 siteimprove.com
 shield.sitelock.com
 sketchfab.com


### PR DESCRIPTION
Privacy Badger sees tracking from "ss.id" localStorage UUIDs (?); the localStorage seems to belong to `https://statcollector.sidearmsports.com/services/pixel.html?page_template=home&sport_name=0&sport_name_custom=0&site=umichigan&cbs_site_code=mich&content_id=null&sect=frontpage&sid=...` frames.


Error report counts by date, page domain and exact blocked "sidearmsports" subdomain:
```
+---------+---------------------------------+-----------------------+-------+
| ym      | blocked_fqdn                    | fqdn                  | count |
+---------+---------------------------------+-----------------------+-------+
| 2019-05 | fonts.sidearmsports.com         | mgoblue.com           |     1 |
| 2019-05 | fonts.sidearmsports.com         | umterps.com           |     1 |
| 2019-05 | images.sidearmsports.com        | mgoblue.com           |     1 |
| 2019-05 | umichigan_ftp.sidearmsports.com | mgoblue.com           |     1 |
| 2019-05 | v2-realtime.sidearmsports.com   | umterps.com           |     1 |
| 2019-04 | fonts.sidearmsports.com         | msuspartans.com       |     2 |
| 2019-04 | images.sidearmsports.com        | msuspartans.com       |     2 |
| 2019-04 | statcollector.sidearmsports.com | msuspartans.com       |     2 |
| 2019-04 | fonts.sidearmsports.com         | goheels.com           |     1 |
| 2019-04 | fonts.sidearmsports.com         | gozags.com            |     1 |
| 2019-04 | fonts.sidearmsports.com         | osubeavers.com        |     1 |
| 2019-04 | images.sidearmsports.com        | goheels.com           |     1 |
| 2019-04 | images.sidearmsports.com        | gozags.com            |     1 |
| 2019-04 | images.sidearmsports.com        | osubeavers.com        |     1 |
| 2019-04 | statcollector.sidearmsports.com | goheels.com           |     1 |
| 2019-04 | statcollector.sidearmsports.com | gozags.com            |     1 |
| 2019-04 | statcollector.sidearmsports.com | osubeavers.com        |     1 |
...
```