### PR TITLE
Add arcot.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -42,6 +42,7 @@ appspot.com
 arcgis.com
 archive.org
 secure5.arcot.com
+arcot.com
 cdn.arstechnica.net
 art19.com
 aspnetcdn.com


### PR DESCRIPTION
Fixes #2332.

Leaving `secure5.arcot.com` removal for #1593.