### PR TITLE
ignores error messages related to Firefox IndexedDB issues

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -607,7 +607,9 @@ var _syncStorage = (function () {
   function cb() {
     if (chrome.runtime.lastError) {
       let err = chrome.runtime.lastError.message;
-      if (!err.startsWith("IO error:") && !err.startsWith("Corruption:")) {
+      if (!err.startsWith("IO error:") && !err.startsWith("Corruption:")
+      && !err.startsWith("InvalidStateError:") && !err.startsWith("AbortError:")
+      ) {
         badger.criticalError = err;
       }
       console.error("Error writing to chrome.storage.local:", err);


### PR DESCRIPTION
Fixes https://github.com/EFForg/privacybadger/issues/2156 by ignoring Firefox error messages relevant to IndexedDB. 

I filed an issue in Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1555491

Here are the Firefox errors we’ve seen so far:
* `InvalidStateError: A mutation operation was attempted on a database that did not allow mutations.`
* `AbortError: A request was aborted, for example through a call to IDBTransaction.abort.`