### PR TITLE
Add Crate and Barrel domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -269,6 +269,7 @@ var multiDomainFirstPartiesArray = [
     "upload.com",
     "zdnet.com",
   ],
+  ["cb2.com", "crateandbarrel.com"],
   ["century21.com", "21online.com"],
   ["chart.io", "chartio.com"],
   ["concur.com", "concursolutions.com"],


### PR DESCRIPTION
Some assets on the CB2 site are loaded from the crateandbarrel.com domain and are getting blocked. CB2 is a brand of Crate and Barrel.