### PR TITLE
Add Nine Entertainment Co. news domains to MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1610,6 +1610,18 @@ var multiDomainFirstPartiesArray = [
   ["skysports.com", "skybet.com", "skyvegas.com"],
   ["slashdot.org", "sourceforge.net", "fsdn.com"],
   ["slickdeals.net", "slickdealscdn.com"],
+  [
+    "smh.com.au",
+
+    "afr.com",
+    "brisbanetimes.com.au",
+    "canberratimes.com.au",
+    "fairfaxmedia.com.au",
+    "theage.com.au",
+    "watoday.com.au",
+
+    "ffx.io",
+  ],
   ["snapfish.com", "snapfish.ca"],
   ["sony.com", "sonyrewards.com"],
   ["soundcu.com", "netteller.com"],


### PR DESCRIPTION
Error report counts by page domain and exact blocked "ffx.io" subdomain:
```
+--------------------------+---------------------+-------+
| fqdn                     | blocked_fqdn        | count |
+--------------------------+---------------------+-------+
| www.smh.com.au           | api.ffx.io          |   159 |
| www.smh.com.au           | static.ffx.io       |   149 |
| www.smh.com.au           | l.ffx.io            |   132 |
| www.smh.com.au           | i.ffx.io            |   127 |
| www.theage.com.au        | api.ffx.io          |   115 |
| www.theage.com.au        | static.ffx.io       |   111 |
| www.theage.com.au        | l.ffx.io            |    96 |
| www.theage.com.au        | i.ffx.io            |    71 |
| www.brisbanetimes.com.au | static.ffx.io       |    32 |
| www.brisbanetimes.com.au | api.ffx.io          |    29 |
| www.brisbanetimes.com.au | i.ffx.io            |    23 |
| www.brisbanetimes.com.au | l.ffx.io            |    23 |
| www.canberratimes.com.au | static.ffx.io       |    20 |
| www.canberratimes.com.au | api.ffx.io          |    19 |
| www.canberratimes.com.au | l.ffx.io            |    15 |
| www.canberratimes.com.au | i.ffx.io            |    14 |
| www.watoday.com.au       | api.ffx.io          |    11 |
| www.watoday.com.au       | static.ffx.io       |    11 |
| www.smh.com.au           | csp.ffx.io          |     9 |
| www.watoday.com.au       | i.ffx.io            |     9 |
| www.watoday.com.au       | l.ffx.io            |     9 |
...
```