### PR TITLE
Removed Repeated Colon from RegEx

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -288,7 +288,7 @@ function exportUserData() {
     var escapedDate = currDate
       // illegal filename charset regex from
       // https://github.com/parshap/node-sanitize-filename/blob/ef1e8ad58e95eb90f8a01f209edf55cd4176e9c8/index.js
-      .replace(/[\/\?<>\\:\*\|":]/g, '_') /* eslint no-useless-escape:off */
+      .replace(/[\/\?<>\\:\*\|"]/g, '_') /* eslint no-useless-escape:off */
       // also collapse-replace commas and spaces
       .replace(/[, ]+/g, '_');
     var filename = 'PrivacyBadger_user_data-' + escapedDate + '.json';


### PR DESCRIPTION
This fixes a [warning from lgtm](https://lgtm.com/projects/g/EFForg/privacybadger/snapshot/7c5e2ead339e92d4700858d308977e6cb9212cb8/files/src/js/options.js?sort=name&dir=ASC&mode=heatmap).