### PR TITLE
Add dsw.tt.omtrdc.net to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -451,6 +451,7 @@ olark.com
 omroep.nl
 amazoncustomerservice.d2.sc.omtrdc.net
 attservicesinc.tt.omtrdc.net
+dsw.tt.omtrdc.net
 onswipe.com
 api.ooyala.com
 c.ooyala.com


### PR DESCRIPTION
Blocking `dsw.tt.omtrdc.net` is responsible for breaking product pages on `www.dsw.com`. Please see error reports for more information.

Previously: #565, #873.