### PR TITLE
Fix cookie sharing detection in Firefox when first-party isolation is enabled

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -39,6 +39,7 @@ function Badger() {
   var self = this;
 
   self.webRTCAvailable = checkWebRTCBrowserSupport();
+  self.firstPartyDomainPotentiallyRequired = testCookiesFirstPartyDomain();
 
   self.widgetList = [];
   widgetLoader.loadWidgetsFromFile("data/socialwidgets.json", (response) => {
@@ -94,8 +95,8 @@ function Badger() {
   });
 
   /**
-  * WebRTC availability check
-  */
+   * WebRTC availability check
+   */
   function checkWebRTCBrowserSupport() {
     if (!(chrome.privacy && chrome.privacy.network &&
       chrome.privacy.network.webRTCIPHandlingPolicy)) {
@@ -122,6 +123,27 @@ function Badger() {
 
     return available;
   }
+
+  /**
+   * Checks for availability of firstPartyDomain chrome.cookies API parameter.
+   * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll#Parameters
+   *
+   * firstPartyDomain is required when privacy.websites.firstPartyIsolate is enabled,
+   * and is in Firefox since Firefox 59. (firstPartyIsolate is in Firefox since 58).
+   *
+   * Not in Chrome.
+   */
+  function testCookiesFirstPartyDomain() {
+    try {
+      chrome.cookies.getAll({
+        firstPartyDomain: null
+      }, function () {});
+    } catch (ex) {
+      return false;
+    }
+    return true;
+  }
+
 }
 
 Badger.prototype = {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -151,9 +151,15 @@ HeuristicBlocker.prototype = {
       // get all cookies for the top-level frame and pass those to the
       // cookie-share accounting function
       let tab_url = tabURLs[details.tabId];
-      chrome.cookies.getAll({
+
+      let config = {
         url: tab_url
-      }, function(cookies) {
+      };
+      if (badger.firstPartyDomainPotentiallyRequired) {
+        config.firstPartyDomain = null;
+      }
+
+      chrome.cookies.getAll(config, function (cookies) {
         if (cookies.length >= 1) {
           self.pixelCookieShareAccounting(tab_url, tab_origin, details.url, request_host, request_origin, cookies);
         }


### PR DESCRIPTION
Fixes #2426.

Tested learning to block `google-analytics.com` in Chrome, and then both with and without first-party isolation in Firefox 58 and also Firefox 69 (beta). Reviewed background console for any related exceptions.