### PR TITLE
Add cdn.hometogo.net to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -306,6 +306,7 @@ hellobar.com
 herokuapp.com
 code.highcharts.com
 homestead.com
+cdn.hometogo.net
 honcode.ch
 hootsuite.com
 howaboutwe.com


### PR DESCRIPTION
Fixes #2440.

Error report counts by date, page domain and exact blocked "hometogo" subdomain:
```
+---------+------------------+------------------+-------+
| ym      | blocked_fqdn     | fqdn             | count |
+---------+------------------+------------------+-------+
| 2019-07 | cdn.hometogo.net | www.hometogo.com |     1 |
| 2019-07 | cdn.hometogo.net | www.hometogo.de  |     1 |
| 2019-07 | cdn.hometogo.net | www.wimdu.nl     |     1 |
| 2019-07 | tc.hometogo.net  | www.hometogo.com |     1 |
| 2019-07 | tc.hometogo.net  | www.hometogo.de  |     1 |
| 2019-07 | tc.hometogo.net  | www.wimdu.nl     |     1 |
| 2019-05 | cdn.hometogo.net | www.wimdu.es     |     1 |
| 2019-05 | tc.hometogo.net  | www.wimdu.es     |     1 |
...
```