### PR TITLE
Ignore separator characters when computing entropy for pixel cookie sharing

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -139,9 +139,9 @@ function estimateMaxEntropy(str) {
   // separator character should be removed before the main calculations
   const sepsArray = SEPS.split('');
   sepsArray.forEach((char) => {
-    while(str.includes(char)) {
+    while (str.includes(char)) {
       str = str.replace(char, "");
-    };
+    }
   });
 
   if (str.length > MAX_LS_LEN_FOR_ENTROPY_EST) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -136,6 +136,14 @@ function estimateMaxEntropy(str) {
   let B64 = ALPHANUM + ALPHA.toUpperCase() + "/+";
   let URL = ALPHANUM + ALPHA.toUpperCase() + "~%";
 
+  // separator character should be removed before the main calculations
+  const sepsArray = SEPS.split('');
+  sepsArray.forEach((char) => {
+    while(str.includes(char)) {
+      str = str.replace(char, "");
+    };
+  });
+
   if (str.length > MAX_LS_LEN_FOR_ENTROPY_EST) {
     /*
      * Just return a higher-than-threshold entropy estimate.

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -467,4 +467,12 @@ QUnit.test("getHostFromDomainInput", assert => {
   );
 });
 
+QUnit.test("estimateMaxEntropy", assert => {
+  assert.equal(
+    utils.estimateMaxEntropy('google.com/123_123-123/an.alytics'),
+    utils.estimateMaxEntropy('go.ogle.com/123123.123/an.aly.tics'),
+    "method properly removes separator characters"
+  );
+});
+
 })();


### PR DESCRIPTION
WIP: This doesn't resolve each point in #2436 , but it does touch on the initial discovery that separator characters aren't being correctly handled in `estimateMaxEntropy`. These proposed changes remove those separator characters from the input string. There's a basic unit test put in place here, though that will have to be properly merged in after the bigger set of test coverage is finally merged in from #2425  . 