### PR TITLE
Add helpful text to popup on special browser pages

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -586,5 +586,13 @@
     "copy_button_copied": {
         "message": "Copied",
         "description": "On-click text of the copy button on the share overlay."
+    },
+    "popup_special_page_header": {
+        "message": "Nothing to do on this page",
+        "description": "Heading for popup_special_page_paragraph"
+    },
+    "popup_special_page_paragraph": {
+        "message": "Privacy Badger doesn't work on special pages like this one. Try browsing somewhere else.",
+        "description": "Shown in the popup for special browser pages such as the New Tab page and 'about:' pages."
     }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -248,7 +248,10 @@ Badger.prototype = {
     self.tabData = self.tabData || {};
     chrome.tabs.query({}, tabs => {
       tabs.forEach(tab => {
-        self.recordFrame(tab.id, 0, tab.url);
+        // don't record on special browser pages
+        if (!utils.isRestrictedUrl(tab.url)) {
+          self.recordFrame(tab.id, 0, tab.url);
+        }
       });
     });
   },
@@ -831,9 +834,11 @@ Badger.prototype = {
       return;
     }
 
-    let iconFilename;
+    let self = this, iconFilename;
+
     // TODO grab hostname from tabData instead
-    if (this.isPrivacyBadgerEnabled(window.extractHostFromURL(tab_url))) {
+    if (!utils.isRestrictedUrl(tab_url) &&
+        self.isPrivacyBadgerEnabled(window.extractHostFromURL(tab_url))) {
       iconFilename = {
         19: chrome.runtime.getURL("icons/badger-19.png"),
         38: chrome.runtime.getURL("icons/badger-38.png")

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -438,11 +438,10 @@ function refreshPopup() {
   window.SLIDERS_DONE = false;
 
   // must be a special browser page,
-  // or a page that loaded everything before our most recent initialization
   if (POPUP_DATA.noTabData) {
     // replace inapplicable summary text with a Badger logo
     $('#blockedResourcesContainer').hide();
-    $('#big-badger-logo').show();
+    $('#special-browser-page').show();
 
     // hide inapplicable buttons
     $('#deactivate_site_btn').hide();
@@ -459,7 +458,7 @@ function refreshPopup() {
   // revert any hiding/showing above for cases when refreshPopup gets called
   // more than once for the same popup, such as during functional testing
   $('#blockedResourcesContainer').show();
-  $('#big-badger-logo').hide();
+  $('#special-browser-page').hide();
   $('#deactivate_site_btn').show();
   $('#error').show();
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -427,6 +427,24 @@ function isThirdPartyDomain(domain1, domain2) {
   return false;
 }
 
+
+/**
+ * Checks whether a given URL is a special browser page.
+ * TODO account for browser-specific pages:
+ * https://github.com/hackademix/noscript/blob/a8b35486571933043bb62e90076436dff2a34cd2/src/lib/restricted.js
+ *
+ * @param {String} url
+ *
+ * @return {Boolean} whether the URL is restricted
+ */
+function isRestrictedUrl(url) {
+  // permitted schemes from
+  // https://developer.chrome.com/extensions/match_patterns
+  return !(
+    url.startsWith('http') || url.startsWith('file') || url.startsWith('ftp')
+  );
+}
+
 /************************************** exports */
 var exports = {
   arrayBufferToBase64,
@@ -434,6 +452,7 @@ var exports = {
   explodeSubdomains,
   findCommonSubstrings,
   getHostFromDomainInput,
+  isRestrictedUrl,
   isThirdPartyDomain,
   nDaysFromNow,
   oneDay,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -519,8 +519,8 @@
   "name": "__MSG_name__",
   "browser_action": {
     "default_icon": {
-      "19": "icons/badger-19.png",
-      "38": "icons/badger-38.png"
+      "19": "icons/badger-19-disabled.png",
+      "38": "icons/badger-38-disabled.png"
     },
     "default_popup": "skin/popup.html",
     "default_title": "__MSG_name__"

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -255,11 +255,16 @@ font-size: 16px;
   padding-top: 7px;
   cursor: pointer;
 }
-#pbInstructions{
-  color: #505050;
-  font-size: 16px;
-  padding-top: 10px;
-  margin: 0;
+#pbInstructions, #special-browser-page {
+    color: #505050;
+    font-size: 16px;
+    margin: 0;
+    padding-top: 10px;
+}
+#special-browser-page {
+    text-align: center;
+    margin: 45px 0;
+    padding: 0;
 }
 
 .pbButton{

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -110,8 +110,9 @@
   <div id="blockedResources"></div>
 </div>
 
-<div id="big-badger-logo" style="display:none; text-align:center; margin:25px 0;">
-    <img src="/icons/badger-128.png" alt="">
+<div id="special-browser-page" style="display:none">
+    <p><b><span class="i18n_popup_special_page_header"></span></b></p>
+    <p><span class="i18n_popup_special_page_paragraph"></span></p>
 </div>
 
 <div id="siteControls">


### PR DESCRIPTION
Before:

![Screenshot from 2019-09-03 11:33:21](https://user-images.githubusercontent.com/794578/64188422-6046eb00-ce40-11e9-85e4-5a86be487613.png)

After:

![Screenshot from 2019-09-03 11:32:43](https://user-images.githubusercontent.com/794578/64188440-6b018000-ce40-11e9-82e8-851f491ed22f.png)

Prompted by the following AMO review:

>Literally all I saw when I installed it and clicked on the toolbar icon was a pop-up was a badger's head and button to donate. The controls at the top (eg. settings) didn't give me any more info, even when I selected absolutely everything. So it's worth nothing to me... uninstalled it.

Follows up on #1737.