### PR TITLE
Improve tab data bookkeeping with webNavigation

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -320,6 +320,17 @@ function onNavigate(details) {
 
   forgetTab(tab_id);
   badger.recordFrame(tab_id, 0, url);
+
+  // initialize tab data bookkeeping used by heuristicBlockingAccounting()
+  // to avoid missing or misattributing learning
+  // when there is no "main_frame" webRequest callback
+  // (such as on Service Worker pages)
+  //
+  // see the tabOrigins TODO in heuristicblocking.js
+  // as to why we don't just use tabData
+  let base = window.getBaseDomain(badger.tabData[tab_id].frames[0].host);
+  badger.heuristicBlocking.tabOrigins[tab_id] = base;
+  badger.heuristicBlocking.tabUrls[tab_id] = url;
 }
 
 /******** Utility Functions **********/

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,6 +14,7 @@
     "tabs",
     "http://*/*",
     "https://*/*",
+    "webNavigation",
     "webRequest",
     "webRequestBlocking",
     "storage",


### PR DESCRIPTION
Fixes #2423, fixes #2335, fixes #1144.

Use cases:
- [x] Navigate to a special browser or extension page (New Tab page, Privacy Badger's options, ...) from a website. Before, the popup on the special page would show you tracker findings for the site you were previously on. You should now see the "Nothing to do on this page" popup.
- [x] Navigate to a website that uses Service Workers (to initialize the SW). Navigate somewhere else within the same tab. Navigate back to the website with Service Workers. (For example: `slate.com` → `example.com` → `slate.com`.) Before, the popup would show you all resources for the SW site as if they loaded on the site you went to previously. This means all first-party resources would show up as third-party if your previous site's domain is different from the SW site's domain.
- [x] Navigate to a SW site to get first party cookies set. Then navigate to the same SW site while on a different site. Privacy Badger attributes tracking by the SW site domain to the previous site you were on. This is due to separate, not-yet-corrected tab bookkeeping (`tabOrigins`) in `heuristicblocking.js`: the `tabOrigins` entry for the tab never gets updated for active SW sites.
- [x] Set a SW site domain to be blocked. Initialize the SW. Visit the SW site from a different site. The initial request for the site's Service Worker comes in before the `webNavigation.onCommitted()` callback gets to update `tabData`, and so the SW gets blocked and the user sees some version of the "you are offline" message on the site.

  **Update**:  Listening to `webNavigation.onBeforeNavigate()` events instead of `onCommitted()` fixes this case as `onBeforeNavigate` callbacks seem to come before the initial Service Worker.

Does not do anything about #1997.