### PR TITLE
added schautv.at to "apa.at"

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -263,6 +263,7 @@ var multiDomainFirstPartiesArray = [
     "kleinezeitung.at",
     "vn.at",
     "kurier.at",
+    "schautv.at",
     "nachrichten.at",
     "derstandard.at",
     "sn.at",


### PR DESCRIPTION
...because it is a TV channel owned by kurier.at and uses `apa.at` servers for its videos:
- `kf-kurier.sf.apa.at` (thumbnails)
- `uvp-kurier.sf.apa.at` (player)
- `kurier.sf.apa.at` (video)

hopefully it is ok, that i tried to "extend" #2342 and fix this myself?

or are their debug output still needed as in #2321?