### PR TITLE
ignore error messages beginning with QuotaExceededError

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -609,6 +609,7 @@ var _syncStorage = (function () {
       let err = chrome.runtime.lastError.message;
       if (!err.startsWith("IO error:") && !err.startsWith("Corruption:")
       && !err.startsWith("InvalidStateError:") && !err.startsWith("AbortError:")
+      && !err.startsWith("QuotaExceededError:")
       ) {
         badger.criticalError = err;
       }


### PR DESCRIPTION
Fixes #2417 .

Since this is probably another Firefox IndexedDB storage error, for now going with a solution for Privacy Badger to ignore error messages that begin with this particular `QuotaExceededError` string. Next step is filing another bug with Mozilla, similar to [this one](https://bugzilla.mozilla.org/show_bug.cgi?id=1555491)

