### PR TITLE
added naming convention section in develop docs

### DIFF
--- a/doc/develop.md
+++ b/doc/develop.md
@@ -23,3 +23,16 @@ You can review our set of ESLint rules in [`.eslintrc.yml`](/.eslintrc.yml). Fil
 ### Writing good commit messages
 
 I highly suggest reviewing the suggestions in this [excellent guide to writing commit messages](https://chris.beams.io/posts/git-commit/).
+
+### Naming conventions
+
+There hasn't been strict naming conventions in the past for this project, though as we move forward we've decided to stick to something like this:
+
+Objects and their properties should be named in camelCase.
+All primitive types should be Python style, snake_case.
+Constants should be ALL CAPS UPPERCASE.
+
+Examples:
+
+`TRACKER_ENTROPY_THRESHOLD = 33`
+`let tab_id = details.tabId`

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -35,4 +35,5 @@ Constants should be ALL CAPS UPPERCASE.
 Examples:
 
 `TRACKER_ENTROPY_THRESHOLD = 33`
+
 `let tab_id = details.tabId`


### PR DESCRIPTION
Per recent discussions about naming conventions, I figured this is worth adding into the docs. Low hanging fruit, not what's currently reflected in the codebase, but worth adding as an aspirational note and for reference for future development.