### PR TITLE
Add an option to hide the tracker count when zero

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -173,6 +173,10 @@
         "message": "Show count of trackers",
         "description": "Checkbox label on the general settings page"
     },
+    "options_hide_zero_count_checkbox": {
+        "message": "Hide if the tracker count is zero",
+        "description": "Checkbox label on the general settings page"
+    },
     "what_is_a_tracker": {
         "message": "What is a tracker?",
         "description": "Tooltip that comes up when you hover over the 'tracking domains' link under the Tracking Domains tab on the options page."

--- a/src/data/schema.json
+++ b/src/data/schema.json
@@ -14,6 +14,11 @@
                 "type": "string"
             }
         },
+        "hideZeroCount": {
+            "title": "Hide count of blocked items when the count is zero",
+            "description": "Toggles showing the counter over Privacy Badger's button in the browser toolbar when the count is zero.",
+            "type": "boolean"
+        },
         "learnInIncognito": {
             "title": "Learn in Private/Incognito windows",
             "description": "Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -524,6 +524,7 @@ Badger.prototype = {
     checkForDNTPolicy: true,
     disabledSites: [],
     hideBlockedElements: true,
+    hideZeroCount: false,
     isFirstRun: true,
     learnInIncognito: false,
     migrationLevel: 0,
@@ -643,6 +644,11 @@ Badger.prototype = {
 
       let count = self.getTrackerCount(tab_id);
 
+      if (count === 0 && self.hideZeroCount()) {
+        chrome.browserAction.setBadgeText({tabId: tab_id, text: ""});
+        return;
+      }
+
       if (count === 0) {
         chrome.browserAction.setBadgeBackgroundColor({tabId: tab_id, color: "#00cc00"});
       } else {
@@ -714,6 +720,13 @@ Badger.prototype = {
    */
   showCounter: function() {
     return this.getSettings().getItem("showCounter");
+  },
+
+  /**
+   * Check if we should hide the counter on the icon when the count is zero
+   */
+  hideZeroCount: function() {
+    return this.getSettings().getItem("hideZeroCount");
   },
 
   /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -106,6 +106,9 @@ function loadOptions() {
   $("#removeAllData").button("option", "icons", {primary: "ui-icon-closethick"});
   $("#show_counter_checkbox").on("click", updateShowCounter);
   $("#show_counter_checkbox").prop("checked", OPTIONS_DATA.showCounter);
+  $("#hide_zero_count_checkbox")
+    .on("click", updateHideZeroCount)
+    .prop("checked", OPTIONS_DATA.hideZeroCount);
   $("#replace-widgets-checkbox")
     .on("click", updateWidgetReplacement)
     .prop("checked", OPTIONS_DATA.isWidgetReplacementEnabled);
@@ -354,6 +357,28 @@ function updateShowCounter() {
   chrome.runtime.sendMessage({
     type: "updateSettings",
     data: { showCounter }
+  }, () => {
+    // Refresh display for each tab's PB badge.
+    chrome.tabs.query({}, function(tabs) {
+      tabs.forEach(function(tab) {
+        chrome.runtime.sendMessage({
+          type: "updateBadge",
+          tab_id: tab.id
+        });
+      });
+    });
+  });
+}
+
+/**
+ * Update setting for whether or not to hide counter on Privacy Badger badge when the count is zero.
+ */
+function updateHideZeroCount() {
+  const hideZeroCount = $("#hide_zero_count_checkbox").prop("checked");
+
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: { hideZeroCount }
   }, () => {
     // Refresh display for each tab's PB badge.
     chrome.tabs.query({}, function(tabs) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -731,6 +731,7 @@ function dispatcher(request, sender, sendResponse) {
   } else if (request.type == "getOptionsData") {
     sendResponse({
       disabledSites: badger.getDisabledSites(),
+      hideZeroCount: badger.hideZeroCount(),
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),
       isLearnInIncognitoEnabled: badger.isLearnInIncognitoEnabled(),

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -80,7 +80,7 @@ function setTextDirection() {
     document.body.appendChild(css);
 
     // fix margins
-    ['#settings-suffix', '#check-dnt-policy-row'].forEach((selector) => {
+    ['#settings-suffix', '#hide-zero-count-row', '#check-dnt-policy-row'].forEach((selector) => {
       swap_css_property(selector, "margin-left", "margin-right");
     });
     ['#whitelistForm > div > div > div'].forEach((selector) => {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -149,7 +149,7 @@ header, #tabs {
     margin: 12px 0;
 }
 
-#check-dnt-policy-row {
+#hide-zero-count-row, #check-dnt-policy-row {
     margin-left: 25px;
 }
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -158,6 +158,12 @@
           <span class="i18n_show_counter_checkbox"></span>
         </label>
       </div>
+      <div class="checkbox" id="hide-zero-count-row">
+        <label>
+          <input type="checkbox" id="hide_zero_count_checkbox">
+          <span class="i18n_options_hide_zero_count_checkbox"></span>
+        </label>
+      </div>
       <div class="checkbox">
         <label>
           <input type="checkbox" id="replace-widgets-checkbox">


### PR DESCRIPTION
This PR adds the `Hide if the tracker count is zero` option to `Show count of trackers`.

Personally, I prefer as little noise as possible from extensions. I think only showing the count when greater than zero is less distracting, and it's faster to see if any trackers have been detected.