### PR TITLE
Add a few Dynamic Yield domains to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -163,6 +163,13 @@ dl.dropboxusercontent.com
 dudamobile.com
 dumpert.nl
 duosecurity.com
+cdn.dynamicyield.com
+cdn-eu.dynamicyield.com
+rcom.dynamicyield.com
+rcom-eu.dynamicyield.com
+static.dynamicyield.com
+st.dynamicyield.com
+st-eu.dynamicyield.com
 ebay.com
 ebayimg.com
 ebayrtm.com


### PR DESCRIPTION
Fixes #2472, fixes #1218.

Dynamic Yield is used to power shopping all over the Web.

- All of [`dynamicyield.com` is classified as "essential" by Ghostery](https://whotracks.me/trackers/dynamic_yield.html).
- Disconnect blocks (and Firefox cookie-blocks) [just the two "px" subdomains](https://github.com/disconnectme/disconnect-tracking-protection/blob/b75f0d3bd94eb13d4180aff120dfbb86829b3219/services.json#L2650-L2657).

