### PR TITLE
De-emphasize not-yet-blocked domains

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -483,6 +483,10 @@
         "message": "Description",
         "description": ""
     },
+    "not_yet_blocked_header": {
+        "message": "Your Badger hasn't yet learned to block these domains",
+        "description": "Popup domain list header text; separates blocked from haven't-yet-seen-enough-to-block potential trackers."
+    },
     "non_tracker": {
         "message": "The domains below don't appear to be tracking you",
         "description": "Header text; separates tracking from non-tracking domains in the popup."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -487,6 +487,10 @@
         "message": "Your Badger hasn't yet learned to block these domains",
         "description": "Popup domain list header text; separates blocked from haven't-yet-seen-enough-to-block potential trackers."
     },
+    "options_show_not_yet_blocked": {
+        "message": "Show domains your Badger hasn't yet learned to block:",
+        "description": "Label for a checkbox on the Tracking Domains options page tab. Should match wording used in the 'not_yet_blocked_header' message."
+    },
     "non_tracker": {
         "message": "The domains below don't appear to be tracking you",
         "description": "Header text; separates tracking from non-tracking domains in the popup."

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -28,6 +28,9 @@ if (!matches || matches[1] == "Firefox") {
 }
 }());
 
+const TOOLTIP_CONF = {
+  maxWidth: 200
+};
 const USER_DATA_EXPORT_KEYS = ["action_map", "snitch_map", "settings_map"];
 
 let i18n = chrome.i18n;
@@ -78,6 +81,7 @@ function loadOptions() {
   $("#trackingDomainSearch").on("input", filterTrackingDomains);
   $("#tracking-domains-type-filter").on("change", filterTrackingDomains);
   $("#tracking-domains-status-filter").on("change", filterTrackingDomains);
+  $("#tracking-domains-show-not-yet-blocked").on("change", filterTrackingDomains);
 
   // Add event listeners for origins container.
   $(function () {
@@ -518,7 +522,7 @@ function revertDomainControl(e) {
  */
 function reloadTrackingDomainsTab() {
   // Check to see if any tracking domains have been found before continuing.
-  var allTrackingDomains = getOriginsArray(OPTIONS_DATA.origins);
+  var allTrackingDomains = getOriginsArray(OPTIONS_DATA.origins, null, null, null, true);
   if (!allTrackingDomains || allTrackingDomains.length === 0) {
     // leave out number of trackers and slider instructions message if no sliders will be displayed
     $("#options_domain_list_trackers").hide();
@@ -530,7 +534,7 @@ function reloadTrackingDomainsTab() {
     $("#tracking-domains-div").hide();
 
     // activate tooltips
-    $('.tooltip').tooltipster();
+    $('.tooltip').tooltipster(TOOLTIP_CONF);
 
     return;
   }
@@ -561,7 +565,7 @@ function reloadTrackingDomainsTab() {
   $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
 
   // activate tooltips
-  $('.tooltip').tooltipster();
+  $('.tooltip').tooltipster(TOOLTIP_CONF);
 
   // Display tracking domains.
   showTrackingDomains(
@@ -569,7 +573,8 @@ function reloadTrackingDomainsTab() {
       OPTIONS_DATA.origins,
       $("#trackingDomainSearch").val(),
       $('#tracking-domains-type-filter').val(),
-      $('#tracking-domains-status-filter').val()
+      $('#tracking-domains-status-filter').val(),
+      $('#tracking-domains-show-not-yet-blocked').prop('checked')
     )
   );
 }
@@ -604,7 +609,8 @@ function filterTrackingDomains() {
       OPTIONS_DATA.origins,
       searchText,
       $typeFilter.val(),
-      $statusFilter.val()
+      $statusFilter.val(),
+      $('#tracking-domains-show-not-yet-blocked').prop('checked')
     );
     showTrackingDomains(filteredOrigins);
   }, timeToWait);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -501,27 +501,44 @@ function refreshPopup() {
     return;
   }
 
-  var printable = [];
-  var nonTracking = [];
+  let printable = [];
+  let unblockedTrackers = [];
+  let nonTracking = [];
   originsArr = htmlUtils.sortDomains(originsArr);
 
   for (let i=0; i < originsArr.length; i++) {
-    var origin = originsArr[i];
-    var action = origins[origin];
+    let origin = originsArr[i];
+    let action = origins[origin];
 
     if (action == constants.NO_TRACKING) {
       nonTracking.push(origin);
-      continue;
+    } else if (action == constants.ALLOW) {
+      unblockedTrackers.push(origin);
+    } else {
+      printable.push(
+        htmlUtils.getOriginHtml(origin, action, action == constants.DNT)
+      );
     }
-
-    printable.push(
-      htmlUtils.getOriginHtml(origin, action, action == constants.DNT)
-    );
   }
 
-  if (POPUP_DATA.showNonTrackingDomains && nonTracking.length > 0) {
+  if (unblockedTrackers.length) {
     printable.push(
-      '<div class="clicker tooltip" id="nonTrackers" title="' +
+      '<div class="clicker tooltip" id="not-yet-blocked-header" title="' +
+      chrome.i18n.getMessage("intro_not_an_adblocker_paragraph") +
+      '" data-tooltipster=\'{"side":"top"}\'>' +
+      chrome.i18n.getMessage("not_yet_blocked_header") +
+      '</div>'
+    );
+    unblockedTrackers.forEach(domain => {
+      printable.push(
+        htmlUtils.getOriginHtml(domain, constants.ALLOW, false)
+      );
+    });
+  }
+
+  if (POPUP_DATA.showNonTrackingDomains && nonTracking.length) {
+    printable.push(
+      '<div class="clicker tooltip" id="non-trackers-header" title="' +
       chrome.i18n.getMessage("non_tracker_tip") +
       '" data-tooltipster=\'{"side":"top"}\'>' +
       chrome.i18n.getMessage("non_tracker") +

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -24,10 +24,12 @@ require.scopes.optionslib = (function () {
  * @param {String} [filter_text] Text to filter origins with.
  * @param {String} [type_filter] Type: user-controlled/DNT-compliant
  * @param {String} [status_filter] Status: blocked/cookieblocked/allowed
+ * @param {Boolean} [show_not_yet_blocked] Whether to show domains your Badger
+ * hasn't yet learned to block.
  *
  * @return {Array} The array of origins.
  */
-function getOriginsArray(origins, filter_text, type_filter, status_filter) {
+function getOriginsArray(origins, filter_text, type_filter, status_filter, show_not_yet_blocked) {
   // Make sure filter_text is lower case for case-insensitive matching.
   if (filter_text) {
     filter_text = filter_text.toLowerCase();
@@ -41,6 +43,13 @@ function getOriginsArray(origins, filter_text, type_filter, status_filter) {
    */
   function matchesFormFilters(origin) {
     const value = origins[origin];
+
+    if (!show_not_yet_blocked) {
+      // hide the not-yet-seen-on-enough-sites potential trackers
+      if (value == "allow") {
+        return false;
+      }
+    }
 
     // filter by type
     if (type_filter) {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -118,7 +118,7 @@ header, #tabs {
 }
 
 #tracking-domains-filters li {
-    margin: 5px 0;
+    margin: 10px 0;
 
     display: flex;
     flex-wrap: wrap;
@@ -132,6 +132,10 @@ header, #tabs {
 
 #tracking-domains-filters > li > label + * {
     flex: 1 0 200px; /* at least this wide or wrap */
+}
+
+#tracking-domains-filters > li > label + input[type=checkbox] {
+    flex: none;
 }
 
 .clickerContainer {

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -122,6 +122,13 @@
                       <option value="allow" class="i18n_options_domain_filter_allow"></option>
                   </select>
               </li>
+              <li>
+                <label for="tracking-domains-show-not-yet-blocked">
+                  <span class="i18n_options_show_not_yet_blocked"></span>
+                  <span class="ui-icon ui-icon-info tooltip" title="i18n_intro_not_an_adblocker_paragraph"></span>
+                </label>
+                <input type="checkbox" id="tracking-domains-show-not-yet-blocked">
+              </li>
           </ul>
           <div id="blockedResources"></div>
       </div>

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -299,7 +299,7 @@ font-size: 16px;
   border: 2px solid #F06A0A;
 }
 
-#nonTrackers {
+#not-yet-blocked-header, #non-trackers-header {
   text-align: center;
   color: #f9f9f9;
   background: #555;

--- a/src/tests/tests/options.js
+++ b/src/tests/tests/options.js
@@ -10,9 +10,19 @@ QUnit.test("getOriginsArray", (assert) => {
     "blocked.org": "block",
     "alsoblocked.org": "block",
     "cookieblocked.biz": "cookieblock",
-    "userAllowed.net": "user_allow",
+    "UserAllowed.net": "user_allow",
+    "uuuserblocked.nyc": "user_block",
     "dntDomain.co.uk": "dnt",
+    "another.allowed.domain.example": "allow",
   };
+  const originsSansAllowed = _.reduce(
+    origins, (memo, val, key) => {
+      if (val != "allow") {
+        memo[key] = val;
+      }
+      return memo;
+    }, {}
+  );
 
   const tests = [
     {
@@ -21,19 +31,24 @@ QUnit.test("getOriginsArray", (assert) => {
       expected: []
     },
     {
-      msg: "No filters",
+      msg: "No filters (allowed domains are filtered out)",
       args: [origins,],
+      expected: Object.keys(originsSansAllowed)
+    },
+    {
+      msg: "Not-yet-blocked domains are shown",
+      args: [origins, null, null, null, true],
       expected: Object.keys(origins)
     },
     {
       msg: "Type filter",
       args: [origins, "", "user"],
-      expected: ["userAllowed.net"]
+      expected: ["UserAllowed.net", "uuuserblocked.nyc"]
     },
     {
       msg: "Status filter",
       args: [origins, "", "", "allow"],
-      expected: ["allowed.com", "userAllowed.net", "dntDomain.co.uk"]
+      expected: ["UserAllowed.net", "dntDomain.co.uk"]
     },
     {
       msg: "Text filter",
@@ -41,9 +56,9 @@ QUnit.test("getOriginsArray", (assert) => {
       expected: ["blocked.org", "alsoblocked.org"]
     },
     {
-      msg: "Text filter case sensitivity",
-      args: [origins, "ALLowed"],
-      expected: ["allowed.com", "userAllowed.net"]
+      msg: "Text filter and domain case insensitivity",
+      args: [origins, "uSER"],
+      expected: ["UserAllowed.net", "uuuserblocked.nyc"]
     },
     {
       msg: "Text filter with extra space",
@@ -54,16 +69,16 @@ QUnit.test("getOriginsArray", (assert) => {
       msg: "Negative text filter",
       args: [origins, "-.org"],
       expected: [
-        "allowed.com",
         "cookieblocked.biz",
-        "userAllowed.net",
+        "UserAllowed.net",
+        "uuuserblocked.nyc",
         "dntDomain.co.uk",
       ]
     },
     {
       msg: "Multiple negative text filter",
       args: [origins, "-.net -cookie -.co.uk"],
-      expected: ["allowed.com", "blocked.org", "alsoblocked.org"]
+      expected: ["blocked.org", "alsoblocked.org", "uuuserblocked.nyc"]
     },
     {
       msg: "Multiple text filters",
@@ -72,8 +87,8 @@ QUnit.test("getOriginsArray", (assert) => {
     },
     {
       msg: "All filters together",
-      args: [origins, ".net", "user", "allow"],
-      expected: ["userAllowed.net"]
+      args: [origins, ".net", "user", "allow", true],
+      expected: ["UserAllowed.net"]
     },
   ];
 

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -267,6 +267,8 @@ class OptionsTest(pbtest.PBSeleniumTest):
 
         self.load_options_page()
         self.select_domain_list_tab()
+        if original_action == "allow":
+            self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
 
         # Change user preferences
         self.user_overwrite("pbtest.org", overwrite_action)
@@ -317,6 +319,8 @@ class OptionsTest(pbtest.PBSeleniumTest):
 
         self.load_options_page()
         self.select_domain_list_tab()
+        self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
+        time.sleep(1) # wait for domains to rerender
 
         # Scroll until the first generated origin is added to the html
         self.scroll_to_bottom()
@@ -346,6 +350,8 @@ class OptionsTest(pbtest.PBSeleniumTest):
         # Re-open the tab
         self.load_options_page()
         self.select_domain_list_tab()
+        self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
+        time.sleep(1) # wait for domains to rerender
         self.scroll_to_bottom()
         self.scroll_to_bottom()
         self.scroll_to_origin('pbtest50-generated.org')


### PR DESCRIPTION
Fixes #2477, helps with #2021.

Helps with "how do I block all domains?" (https://github.com/EFForg/privacybadger/issues/1422#issuecomment-348229277, https://github.com/EFForg/privacybadger/issues/2248#issuecomment-448274011).

Follows up on #1804, #2359.

- [x] Hide not-yet-blocked domains in the Tracking Domains list on the options page by default. User-allowed/DNT domains should be unaffected.
- [x] Add a domain list filter to restore not-yet-blocked domains
- [x] Move not-yet-blocked domains in the popup into their own section, just like the one for non-tracking domains

Popup (not-yet-blocked domains in own section):
![Screenshot from 2019-11-14 18:31:24](https://user-images.githubusercontent.com/794578/68904854-fdf64a80-070c-11ea-996f-58cba2f352c5.png)

Options (not-yet-blocked domains hidden by default):
![Screenshot from 2019-11-14 18:31:05](https://user-images.githubusercontent.com/794578/68904856-00f13b00-070d-11ea-8196-14ac82160031.png)