### PR TITLE
Remove "sliders let you control" text

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -370,7 +370,7 @@
         "description": ""
     },
     "popup_instructions": {
-        "message": "Privacy Badger detected $COUNT$ potential $TRACKER_LINK_START$trackers$TRACKER_LINK_END$ on this page. These sliders let you control how Privacy Badger handles each one. You shouldn't need to adjust the sliders unless something is broken.",
+        "message": "Privacy Badger detected $COUNT$ potential $TRACKER_LINK_START$trackers$TRACKER_LINK_END$ on this page. You shouldn't need to adjust the sliders unless something is broken.",
         "description": "Popup message that shows the number of trackers. This particular message is used when that number is greater than one.",
         "placeholders": {
             "count": {
@@ -395,7 +395,7 @@
         "description": ""
     },
     "options_domain_list_one_tracker": {
-        "message": "Privacy Badger has detected one potential <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domain</a> so far. The slider lets you control how Privacy Badger handles it.",
+        "message": "Privacy Badger has detected one potential <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domain</a> so far.",
         "description": "Shown on the Tracking Domains options page tab when Privacy Badger learned of exactly one tracker so far."
     },
     "tooltip_allow": {
@@ -407,7 +407,7 @@
         "description": "Button in the popup."
     },
     "popup_instructions_one_tracker": {
-        "message": "Privacy Badger detected a potential <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracker</a> on this page. The slider lets you control how Privacy Badger handles it. You shouldn't need to adjust the slider unless something is broken.",
+        "message": "Privacy Badger detected a potential <a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracker</a> on this page. You shouldn't need to adjust the slider unless something is broken.",
         "description": "Text shown in the popup when there is exactly one tracker on the page."
     },
     "domain_slider_allow_tooltip": {
@@ -419,7 +419,7 @@
         "description": "Intro page paragraph."
     },
     "options_domain_list_trackers": {
-        "message": "Privacy Badger has detected $COUNT$ potential $TRACKER_LINK_START$tracking domains$TRACKER_LINK_END$ so far. These sliders let you control how Privacy Badger handles each tracker.",
+        "message": "Privacy Badger has detected $COUNT$ potential $TRACKER_LINK_START$tracking domains$TRACKER_LINK_END$ so far.",
         "description": "Message under the Tracking Domains tab on the options page. Shown after Privacy Badger learned about more than one tracker.",
         "placeholders": {
             "count": {

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -150,7 +150,7 @@ class OptionsTest(pbtest.PBSeleniumTest):
         # check tracker count
         self.assertEqual(
             self.driver.find_element_by_id("options_domain_list_trackers").text,
-            "Privacy Badger has detected 2 potential tracking domains so far. These sliders let you control how Privacy Badger handles each tracker.",
+            "Privacy Badger has detected 2 potential tracking domains so far.",
             "Origin tracker count should be 2 after adding origin"
         )
 
@@ -243,7 +243,7 @@ class OptionsTest(pbtest.PBSeleniumTest):
         # make sure only two trackers are displayed now
         self.assertEqual(
             self.driver.find_element_by_id("options_domain_list_trackers").text,
-            "Privacy Badger has detected 2 potential tracking domains so far. These sliders let you control how Privacy Badger handles each tracker.",
+            "Privacy Badger has detected 2 potential tracking domains so far.",
             "Origin tracker count should be 2 after clearing and adding origins"
         )
 


### PR DESCRIPTION
This removes the various versions of the "sliders let you control" text from popup and options pages, as we want to keep de-emphasizing slider use (#1675, https://github.com/EFForg/privacybadger/issues/1422#issuecomment-348229277). Might help with #2021. Follows up on #1804.

Should help with #1077/#1113/#2463 as there is now less text taking up space in the popup.

### Popup before:
![Screenshot from 2019-10-11 12:23:17](https://user-images.githubusercontent.com/794578/66668148-87a08d00-ec22-11e9-8e6b-6570a2611120.png)

### Popup after:
![Screenshot from 2019-10-11 12:24:16](https://user-images.githubusercontent.com/794578/66668154-8ec79b00-ec22-11e9-943e-e7a82d1f363a.png)

### Options before:
![Screenshot from 2019-10-11 12:22:36](https://user-images.githubusercontent.com/794578/66667973-398b8980-ec22-11e9-991c-aaa45faeee10.png)

### Options after:
![Screenshot from 2019-10-11 12:23:50](https://user-images.githubusercontent.com/794578/66667980-3c867a00-ec22-11e9-925b-c34c67e93530.png)