### PR TITLE
Add Riot Games domains

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1908,9 +1908,14 @@ var multiDomainFirstPartiesArray = [
     "riotgames.com",
 
     "leagueoflegends.com",
+    "lolesports.com",
+    "lolstatic.com",
+    "lolusercontent.com",
+
     "playruneterra.com",
+
     "riotcdn.net",
-    "rdatasrv.net"
+    "rdatasrv.net",
   ],
   [
     "rtl.nl",

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1905,6 +1905,14 @@ var multiDomainFirstPartiesArray = [
     "thomsonreuters.ru",
   ],
   [
+    "riotgames.com",
+
+    "leagueoflegends.com",
+    "playruneterra.com",
+    "riotcdn.net",
+    "rdatasrv.net"
+  ],
+  [
     "rtl.nl",
 
     "bright.nl",


### PR DESCRIPTION
We've received reports from players visiting the page for our newly announced game, playruneterra.com, that Privacy Badger is flagging our beta sign-up flow as cross-site tracking.

This adds MDFP rules for Riot Games domains. 