### PR TITLE
Only replace widgets that were actually blocked

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -7,9 +7,9 @@
         "replacementButton": {
             "details": "<!-- AddThis Button BEGIN --> <div class='addthis_toolbox addthis_default_style addthis_32x32_style'> <a class='addthis_button_preferred_1'></a> <a class='addthis_button_preferred_2'></a> <a class='addthis_button_preferred_3'></a> <a class='addthis_button_preferred_4'></a> <a class='addthis_button_compact'></a> <a class='addthis_counter addthis_bubble_style'></a> </div> <script type='text/javascript'>var addthis_config = {'data_track_addressbar':true};</script> <script type='text/javascript' src='//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-522d600d3b535ebf'></script> <!-- AddThis Button END -->",
             "unblockDomains": [
-                "http://s7.addthis.com/",
-                "http://ct1.addthis.com/",
-                "http://api-public.addthis.com/"
+                "s7.addthis.com",
+                "ct1.addthis.com",
+                "api-public.addthis.com"
             ],
             "imagePath": "AddThis.svg",
             "type": 2
@@ -23,7 +23,7 @@
         "replacementButton": {
             "details": "http://www.digg.com/submit?url=",
             "unblockDomains": [
-                "http://www.digg.com/submit?url="
+                "www.digg.com"
             ],
             "imagePath": "Digg.svg",
             "type": 0
@@ -40,8 +40,7 @@
         "replacementButton": {
             "details": "https://www.facebook.com/plugins/like.php?href=",
             "unblockDomains": [
-                "https://www.facebook.com/plugins/like.php?href=",
-                "https://www.facebook.com/v2.0/plugins/like.php?href="
+                "www.facebook.com"
             ],
             "imagePath": "FacebookLike.svg",
             "type": 1
@@ -58,8 +57,7 @@
         "replacementButton": {
             "details": "https://www.facebook.com/plugins/share_button.php?href=",
             "unblockDomains": [
-                "https://www.facebook.com/plugins/share_button.php?href=",
-                "https://www.facebook.com/v2.0/plugins/share_button.php?href="
+                "www.facebook.com"
             ],
             "imagePath": "FacebookShare.svg",
             "type": 1
@@ -73,7 +71,7 @@
         "replacementButton": {
             "details": "http://www.linkedin.com/shareArticle?mini=true&url=",
             "unblockDomains": [
-                "http://www.linkedin.com/shareArticle?mini=true&url="
+                "www.linkedin.com"
             ],
             "imagePath": "LinkedIn.svg",
             "type": 0
@@ -88,7 +86,7 @@
         "replacementButton": {
             "details": "http://pinterest.com/pin/create/button/?url=",
             "unblockDomains": [
-                "http://pinterest.com/pin/create/button/?url="
+                "pinterest.com"
             ],
             "imagePath": "Pinterest.svg",
             "type": 0
@@ -102,7 +100,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://w.soundcloud.com/"
+                "w.soundcloud.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3
@@ -116,7 +114,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://open.spotify.com/"
+                "open.spotify.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3
@@ -130,7 +128,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://streamable.com/"
+                "streamable.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3
@@ -145,7 +143,7 @@
         "replacementButton": {
             "details": "http://www.stumbleupon.com/badge/?url=",
             "unblockDomains": [
-                "http://www.stumbleupon.com/badge/?url="
+                "www.stumbleupon.com"
             ],
             "imagePath": "StumbleUpon.svg",
             "type": 0
@@ -159,7 +157,7 @@
         "replacementButton": {
             "details": "https://twitter.com/intent/tweet?url=",
             "unblockDomains": [
-                "https://twitter.com/intent/tweet?url="
+                "twitter.com"
             ],
             "imagePath": "Twitter.svg",
             "type": 0
@@ -174,7 +172,7 @@
         "replacementButton": {
             "details": "",
             "unblockDomains": [
-                "https://player.vimeo.com/"
+                "player.vimeo.com"
             ],
             "imagePath": "badger-play.png",
             "type": 3

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -529,6 +529,8 @@ function _isTabAnExtension(tabId) {
 /**
  * Provides the widget replacing content script with list of widgets to replace.
  *
+ * @param {Integer} tab_id the ID of the tab we're replacing widgets in
+ *
  * @returns {Object} dict containing the complete list of widgets
  * as well as a mapping to indicate which ones should be replaced
  */
@@ -544,7 +546,7 @@ let getWidgetBlockList = (function () {
     { key: "allow_once" },
   ];
 
-  return function () {
+  return function (tab_id) {
     // A mapping of individual SocialWidget objects to boolean values that determine
     // whether the content script should replace that tracker's button/widget
     var widgetsToReplace = {};
@@ -559,15 +561,23 @@ let getWidgetBlockList = (function () {
     }
 
     badger.widgetList.forEach(function (widget) {
-      // replace blocked widgets only
-      // and only if the widget is not on the 'do not replace' list
-      const replace = !badger.getSettings().getItem('widgetReplacementExceptions').includes(widget.name);
-      const action = badger.storage.getBestAction(widget.domain);
+      let replace = false;
 
-      widgetsToReplace[widget.name] = replace && (
-        action == constants.BLOCK ||
-        action == constants.USER_BLOCK
-      );
+      // replace only if the widget is not on the 'do not replace' list
+      if (!badger.getSettings().getItem('widgetReplacementExceptions').includes(widget.name) &&
+          badger.tabData.hasOwnProperty(tab_id) &&
+          badger.tabData[tab_id].origins.hasOwnProperty(widget.domain)) {
+
+        const action = badger.tabData[tab_id].origins[widget.domain];
+
+        // and only if it was blocked
+        replace = (
+          action == constants.BLOCK ||
+          action == constants.USER_BLOCK
+        );
+      }
+
+      widgetsToReplace[widget.name] = replace;
     });
 
     return {
@@ -679,7 +689,7 @@ function dispatcher(request, sender, sendResponse) {
 
   case "checkReplaceButton": {
     if (badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) && badger.isWidgetReplacementEnabled()) {
-      let widgetBlockList = getWidgetBlockList();
+      let widgetBlockList = getWidgetBlockList(sender.tab.id);
       sendResponse(widgetBlockList);
     }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -615,17 +615,14 @@ function isWidgetTemporaryUnblock(tabId, requestHost, frameId) {
  * corresponding replacement widget.
  *
  * @param {Integer} tabId The id of the tab
- * @param {Array} widgetUrls an array of widget urls
+ * @param {Array} domains widget domains
  */
-function unblockWidgetOnTab(tabId, widgetUrls) {
+function unblockWidgetOnTab(tabId, domains) {
   if (temporaryWidgetUnblock[tabId] === undefined) {
     temporaryWidgetUnblock[tabId] = [];
   }
-  for (let i in widgetUrls) {
-    let url = widgetUrls[i];
-    // TODO just store actual domains in the JSON in the first place
-    let host = window.extractHostFromURL(url);
-    temporaryWidgetUnblock[tabId].push(host);
+  for (let i = 0; i < domains.length; i++) {
+    temporaryWidgetUnblock[tabId].push(domains[i]);
   }
 }
 


### PR DESCRIPTION
Instead of hypothetically blocked (which doesn't account for page context, for instance).

Fixes pointless first-party replacement ([for example](https://soundcloud.com/pages/embed)).

Should follow #2267.