### PR TITLE
Fix Messenger photos in non-English locales

### DIFF
--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -2,7 +2,7 @@
 // Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
 // this should only run on facebook.com, messenger.com, and
 // facebookcorewwwi.onion
-let fb_wrapped_link = `a[href*='${document.domain}/l.php?']:not([aria-label='photo'])`;
+let fb_wrapped_link = `a[href*='${document.domain}/l.php?']:not([aria-label])`;
 
 // remove all attributes from a link except for class and ARIA attributes
 function cleanAttrs(elem) {


### PR DESCRIPTION
Fixes #2214. Follows up on #2307.

Can't rely on classes like `_3m31` as I'm already seeing a different random class.

Are there any `l.php` links that have an ARIA label attribute that should still be cleaned but will now be ignored?