### PR TITLE
Preserve name and length when overwriting JavaScript methods

### DIFF
--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -23,7 +23,7 @@ function getPageScript() {
   return "(" + function (NAVIGATOR, OBJECT) {
 
     OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "doNotTrack", {
-      get: () => {
+      get: function doNotTrack() {
         return "1";
       }
     });


### PR DESCRIPTION
Helps with #2497.