### PR TITLE
Use origin-only referrers with cookieblocked requests

### DIFF
--- a/doc/DESIGN-AND-ROADMAP.md
+++ b/doc/DESIGN-AND-ROADMAP.md
@@ -41,12 +41,14 @@ Privacy Badger:
    containing first party cookie data, or makes JavaScript fingerprinting API
    calls on 3 or more first party origins, this is deemed to be "cross site
    tracking".
-4. Typically, cross site trackers are blocked completely; Privacy Badger prevents the
-   browser from communicating with them. The exception is if the site is on
-   Privacy Badger's "yellow list" (aka the "cookie block list"), in which case
-   resources from the site are loaded, but with their (third party) cookies, as
-   well as referer header, blocked. The yellow list is routinely fetched
-   from [an EFF URL](https://www.eff.org/files/cookieblocklist_new.txt) to allow prompt fixes for breakage.
+4. Typically, cross site trackers are blocked completely; Privacy Badger
+   prevents the browser from communicating with them. The exception is if the
+   site is on Privacy Badger's "yellow list" (aka the "cookie block list"), in
+   which case resources from the site are loaded, but without access to their
+   (third party) cookies or local storage, and with the referer header either
+   trimmed down to the origin (for GET requests) or removed outright (all other
+   requests). The yellow list is routinely fetched from [an EFF URL](https://www.eff.org/files/cookieblocklist_new.txt)
+   to allow prompt fixes for breakage.
 
    Until methods for blocking them have been implemented, domains that perform
    fingerprinting or use third party supercookies should not be added to the
@@ -204,14 +206,14 @@ for themselves) are necessarily replaced.
 
 #### What are the states for domain responses?
 
-Currently domains have three states: no action, cookie block, and block.
-No action allows all requests to resolve as normal without intervention from
+Currently domains have three states: no action, cookie block, and block. No
+action allows all requests to resolve as normal without intervention from
 Privacy Badger. Cookie block allows for requests to resolve normally but will
-block cookies from being read or created, it will also block the referer header.
-Block will cause any requests from that origin to be blocked entireley; before
-even a TCP connection can be established. The user can toggle these options
-manually, which will supersede any determinations made automatically by Privacy
-Badger.
+block cookies from being read or created. Cookie block also trims or removes
+the referer header. Block will cause any requests from that origin to be
+blocked entirely; before even a TCP connection can be established. The user can
+toggle these options manually, which will supersede any determinations made
+automatically by Privacy Badger.
 
 #### What does EFFs Do Not Track policy stipulate?
 
@@ -255,16 +257,17 @@ Please see our ["high priority"-labeled issues](https://github.com/EFForg/privac
 ### How are origins and the rules for them stored?
 
 When a browser with Privacy Badger enabled makes a request to a third party, if
-the request contains a cookie or the response tries to set a cookie it gets flagged as 'tracking'.
-Origins that make tracking requests get stored in a key→value store where the keys
-are the origins making the request, and the values are the first party origins these
-requests were made on. If that list of third parties contains three or more first party
-origins the third party origin gets added to another list of known trackers.
-When Privacy Badger gets a request from an origin on the known trackers list, if it
-is not on the yellow list then Privacy Badger blocks that request. If it
-is on the yellow list then the request is allowed to resolve, but all cookie
-setting and getting parts of it are blocked, as well as referer headers. Both of
-these lists are stored on disk, and persist between browser sessions.
+the request contains a cookie or the response tries to set a cookie it gets
+flagged as 'tracking'. Origins that make tracking requests get stored in a
+key→value store where the keys are the origins making the request, and the
+values are the first party origins these requests were made on. If that list of
+third parties contains three or more first party origins the third party origin
+gets added to another list of known trackers. When Privacy Badger gets a
+request from an origin on the known trackers list, if it is not on the yellow
+list then Privacy Badger blocks that request. If it is on the yellow list then
+the request is allowed to resolve, but all cookie setting and getting parts of
+it are blocked, while the referer header is trimmed or removed. Both of these
+lists are stored on disk, and persist between browser sessions.
 
 Additionally users can manually set the desired action for any FQDN.
 These get added to their own lists, which are also stored on disk, and get checked

--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -40,6 +40,16 @@ chrome.runtime.sendMessage({
     var code = '('+ function() {
       document.__defineSetter__("cookie", function(/*value*/) { });
       document.__defineGetter__("cookie", function() { return ""; });
+
+      // trim referrer down to origin
+      let referrer = document.referrer;
+      if (referrer) {
+        referrer = referrer.slice(
+          0,
+          referrer.indexOf('/', referrer.indexOf('://') + 3)
+        ) + '/';
+      }
+      document.__defineGetter__("referrer", function () { return referrer; });
     } +')();';
 
     window.injectScript(code);

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -7,6 +7,13 @@ import pbtest
 
 
 class ClobberingTest(pbtest.PBSeleniumTest):
+    COOKIEBLOCK_JS = (
+        "(function (domain) {"
+        "  let bg = chrome.extension.getBackgroundPage();"
+        "  bg.badger.storage.setupHeuristicAction(domain, bg.constants.COOKIEBLOCK);"
+        "}(arguments[0]));"
+    )
+
     def test_localstorage_clobbering(self):
         LOCALSTORAGE_TESTS = [
             # (test result element ID, expected stored, expected empty)
@@ -25,12 +32,6 @@ class ClobberingTest(pbtest.PBSeleniumTest):
             "clobbering.html"
         )
         FRAME_DOMAIN = "githack.com"
-        COOKIEBLOCK_JS = (
-            "(function () {"
-            "let bg = chrome.extension.getBackgroundPage();"
-            "bg.badger.storage.setupHeuristicAction('%s', bg.constants.COOKIEBLOCK);"
-            "}());"
-        ) % FRAME_DOMAIN
 
         # first allow localStorage to be set
         self.load_url(FIXTURE_URL)
@@ -55,7 +56,7 @@ class ClobberingTest(pbtest.PBSeleniumTest):
 
         # mark the frame domain for cookieblocking
         self.load_url(self.options_url)
-        self.js(COOKIEBLOCK_JS)
+        self.js(self.COOKIEBLOCK_JS, FRAME_DOMAIN)
 
         # now rerun and check results for various localStorage access tests
         self.load_url(FIXTURE_URL)
@@ -76,6 +77,29 @@ class ClobberingTest(pbtest.PBSeleniumTest):
                 self.txt_by_css("#" + selector), expected,
                 "localStorage (%s) was read despite cookieblocking" % selector
             )
+
+    def test_referrer_header(self):
+        FIXTURE_URL = (
+            "https://efforg.github.io/privacybadger-test-fixtures/html/"
+            "referrer.html"
+        )
+        THIRD_PARTY_DOMAIN = "httpbin.org"
+
+        # cookieblock the domain fetched by the fixture
+        self.load_url(self.options_url)
+        self.js(self.COOKIEBLOCK_JS, THIRD_PARTY_DOMAIN)
+
+        # check the referrer header according to that domain
+        self.load_url(FIXTURE_URL)
+        self.wait_for_script(
+            "return document.getElementById('referrer').textContent != '';")
+        referrer = self.txt_by_css("#referrer")
+        self.assertEqual(referrer[0:8], "Referer=", "Unexpected page output")
+        self.assertEqual(
+            referrer[8:],
+            "https://efforg.github.io/",
+            "Referrer header does not appear to be origin-only"
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -85,18 +85,26 @@ class ClobberingTest(pbtest.PBSeleniumTest):
         )
         THIRD_PARTY_DOMAIN = "httpbin.org"
 
+        def verify_referrer_header(expected, failure_message):
+            self.load_url(FIXTURE_URL)
+            self.wait_for_script(
+                "return document.getElementById('referrer').textContent != '';")
+            referrer = self.txt_by_css("#referrer")
+            self.assertEqual(referrer[0:8], "Referer=", "Unexpected page output")
+            self.assertEqual(referrer[8:], expected, failure_message)
+
+        # verify base case
+        verify_referrer_header(
+            FIXTURE_URL,
+            "Unexpected default referrer header"
+        )
+
         # cookieblock the domain fetched by the fixture
         self.load_url(self.options_url)
         self.js(self.COOKIEBLOCK_JS, THIRD_PARTY_DOMAIN)
 
-        # check the referrer header according to that domain
-        self.load_url(FIXTURE_URL)
-        self.wait_for_script(
-            "return document.getElementById('referrer').textContent != '';")
-        referrer = self.txt_by_css("#referrer")
-        self.assertEqual(referrer[0:8], "Referer=", "Unexpected page output")
-        self.assertEqual(
-            referrer[8:],
+        # recheck what the referrer header looks like now after cookieblocking
+        verify_referrer_header(
             "https://efforg.github.io/",
             "Referrer header does not appear to be origin-only"
         )


### PR DESCRIPTION
Instead of removing the referrers entirely. This should fix yellowlisted third-party content that gates itself behind a referrer check. Non-"GET" request referrers are still removed to reduce change scope (no known non-GET breakages, no known benefit).

Fixes #188, fixes #2305, fixes #2405, Vidible videos on various sites (no GH issue, lots of error reports though, [for example](https://www.aol.com/article/news/2019/11/05/diplomat-told-that-ukraine-aid-held-up-for-corruption-probe/23853842/)).

If this goes over well, we could try expanding origin-only referrers to all third-party requests (related to #855).

### Bibliography

* [2018 Firefox breakage study](https://blog.mozilla.org/data/2018/01/26/improving-privacy-without-breaking-the-web/)

* [Referrer policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) defaults in Firefox, in regular and Private Browsing modes:
  > Gecko has a pref available in `about:config` to allow users to set their default `Referrer-Policy` — ... (See [#587523](https://bugzilla.mozilla.org/show_bug.cgi?id=587523)) `network.http.referer.defaultPolicy` and `network.http.referer.defaultPolicy.pbmode`

* [Tweaking Referrers For Privacy in Firefox](https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/)