### PR TITLE
Add clear message in popup on disabled pages

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -202,7 +202,7 @@
         "description": "This is an options page tab heading."
     },
     "popup_enable_for_site": {
-        "message": "Enable Privacy Badger for This Site",
+        "message": "Enable Privacy Badger for this site",
         "description": ""
     },
     "options_domain_type_filter": {
@@ -407,7 +407,7 @@
         "description": ""
     },
     "popup_disable_for_site": {
-        "message": "Disable Privacy Badger for This Site",
+        "message": "Disable Privacy Badger for this site",
         "description": "Button in the popup."
     },
     "popup_instructions_one_tracker": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -603,6 +603,10 @@
         "message": "Privacy Badger doesn't work on special pages like this one. Try browsing somewhere else.",
         "description": "Shown in the popup for special browser pages such as the New Tab page and 'about:' pages."
     },
+    "popup_disabled_site_header": {
+        "message": "Privacy Badger is disabled on this site",
+        "description": "Shown in the popup on disabled sites."
+    },
     "options_widget_replacement_tab": {
         "message": "Widget Replacement",
         "description": "Options page tab heading"

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -467,6 +467,7 @@ function refreshPopup() {
     $("#blockedResourcesContainer").hide();
     $("#activate_site_btn").show();
     $("#deactivate_site_btn").hide();
+    $("#disabled-site-message").show();
   }
 
   // if there is any saved error text, fill the error input with it

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -262,13 +262,13 @@ font-size: 16px;
   padding-top: 7px;
   cursor: pointer;
 }
-#pbInstructions, #special-browser-page {
+#pbInstructions, #special-browser-page, #disabled-site-message {
     color: #505050;
     font-size: 16px;
     margin: 0;
     padding-top: 10px;
 }
-#special-browser-page {
+#special-browser-page, #disabled-site-message {
     text-align: center;
     margin: 45px 0;
     padding: 0;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -118,6 +118,10 @@
     <p><span class="i18n_popup_special_page_paragraph"></span></p>
 </div>
 
+<div id="disabled-site-message" style="display:none">
+    <p><b><span class="i18n_popup_disabled_site_header"></span></b></p>
+</div>
+
 <div id="siteControls">
     <button id="deactivate_site_btn" class="pbButton"><span class="i18n_popup_disable_for_site"></span></button>
     <button id="activate_site_btn" class="pbButton" style="display:none"> <span class="i18n_popup_enable_for_site"></span></button>


### PR DESCRIPTION
Currently the popup on disabled pages has no clear messaging about what's going on on that page, as well as some messed up spacing with the footer options buttons. These changes add some clear messaging to the popup when the user is on a domain they've disabled PB for, in the style of the messaging that's displayed on special pages.

Here's what the popup currently looks like on disabled pages:
<img width="433" alt="Screen Shot 2019-11-19 at 3 48 04 PM" src="https://user-images.githubusercontent.com/25778052/69196726-23f06600-0ae4-11ea-872d-544ddd2fd1a6.png">

And here's what it looks like with these proposed changes:
<img width="439" alt="Screen Shot 2019-11-19 at 3 48 52 PM" src="https://user-images.githubusercontent.com/25778052/69196739-2d79ce00-0ae4-11ea-9ed2-4d8f4718fcba.png">
