### PR TITLE
Add replacement widget for Google reCAPTCHA

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -73,6 +73,7 @@
             "script[src^='https://google.com/recaptcha/api.js']",
             "script[src^='https://www.google.com/recaptcha/api.js']"
         ],
+        "fallbackScriptUrl": "//google.com/recaptcha/api.js",
         "replacementButton": {
             "unblockDomains": [
                 "google.com",

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -74,7 +74,6 @@
             "script[src^='https://www.google.com/recaptcha/api.js']"
         ],
         "replacementButton": {
-            "details": "",
             "unblockDomains": [
                 "google.com",
                 "www.google.com"
@@ -118,7 +117,6 @@
             "iframe[src^='https://w.soundcloud.com/player']"
         ],
         "replacementButton": {
-            "details": "",
             "unblockDomains": [
                 "w.soundcloud.com"
             ],
@@ -132,7 +130,6 @@
             "iframe[src^='https://open.spotify.com/embed']"
         ],
         "replacementButton": {
-            "details": "",
             "unblockDomains": [
                 "open.spotify.com"
             ],
@@ -146,7 +143,6 @@
             "iframe[src^='https://streamable.com/']"
         ],
         "replacementButton": {
-            "details": "",
             "unblockDomains": [
                 "streamable.com"
             ],
@@ -175,7 +171,6 @@
             "iframe[src^='//player.vimeo.com/video/']:not([src*='background=1'])"
         ],
         "replacementButton": {
-            "details": "",
             "unblockDomains": [
                 "player.vimeo.com"
             ],
@@ -190,7 +185,6 @@
             "iframe[src^='https://www.youtube.com/embed/']"
         ],
         "replacementButton": {
-            "details": "",
             "unblockDomains": [
                 "www.youtube.com"
             ],

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -63,6 +63,26 @@
             "type": 1
         }
     },
+    "Google reCAPTCHA": {
+        "domain": "www.google.com",
+        "buttonSelectors": [
+            "div.g-recaptcha"
+        ],
+        "scriptSelectors": [
+            "script[src^='//google.com/recaptcha/api.js']",
+            "script[src^='https://google.com/recaptcha/api.js']",
+            "script[src^='https://www.google.com/recaptcha/api.js']"
+        ],
+        "replacementButton": {
+            "details": "",
+            "unblockDomains": [
+                "google.com",
+                "www.google.com"
+            ],
+            "imagePath": "badger-play.png",
+            "type": 4
+        }
+    },
     "LinkedIn": {
         "domain": "platform.linkedin.com",
         "buttonSelectors": [

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -22,9 +22,6 @@
         ],
         "replacementButton": {
             "details": "http://www.digg.com/submit?url=",
-            "unblockDomains": [
-                "www.digg.com"
-            ],
             "imagePath": "Digg.svg",
             "type": 0
         }
@@ -89,9 +86,6 @@
         ],
         "replacementButton": {
             "details": "http://www.linkedin.com/shareArticle?mini=true&url=",
-            "unblockDomains": [
-                "www.linkedin.com"
-            ],
             "imagePath": "LinkedIn.svg",
             "type": 0
         }
@@ -104,9 +98,6 @@
         ],
         "replacementButton": {
             "details": "http://pinterest.com/pin/create/button/?url=",
-            "unblockDomains": [
-                "pinterest.com"
-            ],
             "imagePath": "Pinterest.svg",
             "type": 0
         }
@@ -157,9 +148,6 @@
         ],
         "replacementButton": {
             "details": "https://twitter.com/intent/tweet?url=",
-            "unblockDomains": [
-                "twitter.com"
-            ],
             "imagePath": "Twitter.svg",
             "type": 0
         }

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -61,7 +61,10 @@
         }
     },
     "Google reCAPTCHA": {
-        "domain": "www.google.com",
+        "domains": [
+            "google.com",
+            "www.google.com"
+        ],
         "buttonSelectors": [
             "div.g-recaptcha"
         ],

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -66,7 +66,8 @@
             "www.google.com"
         ],
         "buttonSelectors": [
-            "div.g-recaptcha"
+            "div.g-recaptcha",
+            "div#g-recaptcha"
         ],
         "scriptSelectors": [
             "script[src^='//google.com/recaptcha/api.js']",

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -82,7 +82,7 @@ function initialize() {
  * @param {Function} callback called with the replacement button element for the tracker
  */
 function createReplacementButtonImage(tracker, trackerElem, callback) {
-  var buttonData = tracker.replacementButton;
+  let buttonData = tracker.replacementButton;
 
   // already have replacement button image URI cached
   if (buttonData.buttonUrl) {
@@ -111,18 +111,15 @@ function createReplacementButtonImage(tracker, trackerElem, callback) {
 }
 
 function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
-  var buttonData = tracker.replacementButton;
+  let buttonData = tracker.replacementButton,
+    button_type = buttonData.type;
 
-  var button = document.createElement("img");
-
-  var buttonUrl = buttonData.buttonUrl;
-  var buttonType = buttonData.type;
-
-  button.setAttribute("src", buttonUrl);
+  let button = document.createElement("img");
+  button.setAttribute("src", buttonData.buttonUrl);
 
   // apply tooltip to social button replacements only;
   // no need to do this for replacement widgets
-  if (buttonType < 3) {
+  if (button_type < 3) {
     // TODO use custom tooltip to support RTL locales?
     button.setAttribute(
       "title",
@@ -139,39 +136,39 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
   button.setAttribute("style", styleAttrs.join(" !important;") + " !important");
 
   // normal button type; just open a new window when clicked
-  if (buttonType === 0) {
-    var popupUrl = buttonData.details + encodeURIComponent(window.location.href);
+  if (button_type === 0) {
+    let popup_url = buttonData.details + encodeURIComponent(window.location.href);
 
     button.addEventListener("click", function() {
-      window.open(popupUrl);
+      window.open(popup_url);
     });
 
   // in place button type; replace the existing button
   // with an iframe when clicked
-  } else if (buttonType == 1) {
-    var iframeUrl = buttonData.details + encodeURIComponent(window.location.href);
+  } else if (button_type == 1) {
+    let iframe_url = buttonData.details + encodeURIComponent(window.location.href);
 
     button.addEventListener("click", function() {
-      replaceButtonWithIframeAndUnblockTracker(button, tracker.name, iframeUrl);
+      replaceButtonWithIframeAndUnblockTracker(button, tracker.name, iframe_url);
     }, { once: true });
 
   // in place button type; replace the existing button with code
   // specified in the widgets JSON
-  } else if (buttonType == 2) {
+  } else if (button_type == 2) {
     button.addEventListener("click", function() {
       replaceButtonWithHtmlCodeAndUnblockTracker(button, tracker.name, buttonData.details);
     }, { once: true });
 
   // in-place widget type:
   // reinitialize the widget by reinserting its element's HTML
-  } else if (buttonType == 3) {
+  } else if (button_type == 3) {
     let widget = createReplacementWidget(tracker, button, trackerElem, reinitializeWidgetAndUnblockTracker);
     return callback(widget);
 
   // in-place widget type:
   // reinitialize the widget by reinserting its element's HTML
   // and activating associated scripts
-  } else if (buttonType == 4) {
+  } else if (button_type == 4) {
     let widget = createReplacementWidget(tracker, button, trackerElem, replaceWidgetAndReloadScripts);
     return callback(widget);
   }
@@ -194,7 +191,7 @@ function replaceButtonWithIframeAndUnblockTracker(button, widget_name, iframeUrl
     // executed for buttons that have already been removed; we are trying
     // to prevent replacing an already removed button
     if (button.parentNode !== null) {
-      var iframe = document.createElement("iframe");
+      let iframe = document.createElement("iframe");
 
       iframe.setAttribute("src", iframeUrl);
       iframe.setAttribute("style", "border: none !important; height: 1.5em !important;");
@@ -218,7 +215,7 @@ function replaceButtonWithHtmlCodeAndUnblockTracker(button, widget_name, html) {
     // executed for buttons that have already been removed; we are trying
     // to prevent replacing an already removed button
     if (button.parentNode !== null) {
-      var codeContainer = document.createElement("div");
+      let codeContainer = document.createElement("div");
       codeContainer.innerHTML = html;
 
       button.parentNode.replaceChild(codeContainer, button);
@@ -303,13 +300,13 @@ function reloadScripts(selectors, fallback_script_url) {
 function replaceScriptsRecurse(node) {
   if (node.nodeName && node.nodeName.toLowerCase() == 'script' &&
       node.getAttribute && node.getAttribute("type") == "text/javascript") {
-    var script = document.createElement("script");
+    let script = document.createElement("script");
     script.text = node.innerHTML;
     script.src = node.src;
     node.parentNode.replaceChild(script, node);
   } else {
-    var i = 0;
-    var children = node.childNodes;
+    let i = 0,
+      children = node.childNodes;
     while (i < children.length) {
       replaceScriptsRecurse(children[i]);
       i++;
@@ -465,9 +462,8 @@ function replaceIndividualButton(tracker) {
 
   // makes a comma separated list of CSS selectors that specify
   // buttons for the current tracker; used for document.querySelectorAll
-  var buttonSelectorsString = tracker.buttonSelectors.join(',');
-  var buttonsToReplace =
-    document.querySelectorAll(buttonSelectorsString);
+  let selector = tracker.buttonSelectors.join(','),
+    buttonsToReplace = document.querySelectorAll(selector);
 
   buttonsToReplace.forEach(function (buttonToReplace) {
     createReplacementButtonImage(tracker, buttonToReplace, function (button) {

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -327,7 +327,7 @@ function replaceScriptsRecurse(node) {
  */
 function replaceInitialTrackerButtonsHelper(widgetsToReplace) {
   widgetList.forEach(function (tracker) {
-    if (widgetsToReplace.includes(tracker.name)) {
+    if (widgetsToReplace.hasOwnProperty(tracker.name)) {
       replaceIndividualButton(tracker);
     }
   });

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -122,11 +122,15 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
 
   button.setAttribute("src", buttonUrl);
 
-  // TODO use custom tooltip to support RTL locales?
-  button.setAttribute(
-    "title",
-    TRANSLATIONS.social_tooltip_pb_has_replaced.replace("XXX", tracker.name)
-  );
+  // apply tooltip to social button replacements only;
+  // no need to do this for replacement widgets
+  if (buttonType < 3) {
+    // TODO use custom tooltip to support RTL locales?
+    button.setAttribute(
+      "title",
+      TRANSLATIONS.social_tooltip_pb_has_replaced.replace("XXX", tracker.name)
+    );
+  }
 
   let styleAttrs = [
     "border: none",

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -262,17 +262,19 @@ function replaceWidgetAndReloadScripts(name) {
 }
 
 /**
- * Replace an included script with a copy of itself to trigger a re-run.
+ * Find and replace script elements with their copies to trigger re-running.
  */
 function reloadScripts(selectors) {
   let scripts = document.querySelectorAll(selectors.join(','));
 
   scripts.forEach(function (scriptEl) {
-    let script = document.createElement("script");
-    for (let i = 0, atts = scriptEl.attributes, n = atts.length; i < n; i++) {
-      script.setAttribute(atts[i].nodeName, atts[i].nodeValue);
+    if (scriptEl.nodeName && scriptEl.nodeName.toLowerCase() == 'script') {
+      let replacement = document.createElement("script");
+      for (let i = 0, atts = scriptEl.attributes, n = atts.length; i < n; i++) {
+        replacement.setAttribute(atts[i].nodeName, atts[i].nodeValue);
+      }
+      scriptEl.parentNode.replaceChild(replacement, scriptEl);
     }
-    scriptEl.parentNode.replaceChild(script, scriptEl);
   });
 }
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -318,11 +318,12 @@ function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
 /**
  * Individually replaces tracker buttons blocked after initial check.
  */
-function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
-  if (!trackerInfo) { return; }
-  trackerInfo.forEach(function(tracker) {
-    var replaceTrackerButtons = (tracker.domain == trackerDomain);
-    if (replaceTrackerButtons) {
+function replaceSubsequentTrackerButtonsHelper(tracker_domain) {
+  if (!trackerInfo) {
+    return;
+  }
+  trackerInfo.forEach(function (tracker) {
+    if (tracker.domains.includes(tracker_domain)) {
       replaceIndividualButton(tracker);
     }
   });

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -43,10 +43,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/**
- * Widget data, read from file.
- */
-let trackerInfo;
+// widget data
+let widgetList;
 
 // cached chrome.i18n.getMessage() results
 const TRANSLATIONS = {};
@@ -59,11 +57,11 @@ const WIDGET_ELS = {};
  * Initializes the content script.
  */
 function initialize() {
-  // Get tracker info and check for initial blocks (that happened
+  // Get widget data and check for initial blocks (that happened
   // before content script was attached)
-  getTrackerData(function (trackers, trackerButtonsToReplace) {
-    trackerInfo = trackers;
-    replaceInitialTrackerButtonsHelper(trackerButtonsToReplace);
+  getTrackerData(function (widgets, widgetsToReplace) {
+    widgetList = widgets;
+    replaceInitialTrackerButtonsHelper(widgetsToReplace);
   });
 
   // Set up listener for blocks that happen after initial check
@@ -325,13 +323,11 @@ function replaceScriptsRecurse(node) {
  * Replaces all tracker buttons on the current web page with the internal
  * replacement buttons, respecting the user's blocking settings.
  *
- * @param {Object} trackerButtonsToReplace a map of tracker names to boolean
- * values saying whether those trackers' buttons should be replaced
+ * @param {Array} widgetsToReplace a list of widget names to replace
  */
-function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
-  trackerInfo.forEach(function(tracker) {
-    var replaceTrackerButtons = trackerButtonsToReplace[tracker.name];
-    if (replaceTrackerButtons) {
+function replaceInitialTrackerButtonsHelper(widgetsToReplace) {
+  widgetList.forEach(function (tracker) {
+    if (widgetsToReplace.includes(tracker.name)) {
       replaceIndividualButton(tracker);
     }
   });
@@ -341,10 +337,10 @@ function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
  * Individually replaces tracker buttons blocked after initial check.
  */
 function replaceSubsequentTrackerButtonsHelper(tracker_domain) {
-  if (!trackerInfo) {
+  if (!widgetList) {
     return;
   }
-  trackerInfo.forEach(function (tracker) {
+  widgetList.forEach(function (tracker) {
     if (tracker.domains.includes(tracker_domain)) {
       replaceIndividualButton(tracker);
     }
@@ -484,12 +480,8 @@ function replaceIndividualButton(tracker) {
  * Gets data about which tracker buttons need to be replaced from the main
  * extension and passes it to the provided callback function.
  *
- * @param {Function} callback the function to call when the tracker data is
- *                            received; the arguments passed are the folder
- *                            containing the content script, the tracker
- *                            data, and a mapping of tracker names to
- *                            whether those tracker buttons need to be
- *                            replaced
+ * @param {Function} callback the callback for when tracker data is received;
+ * takes two arguments: widget data, and a list of widget names to replace now
  */
 function getTrackerData(callback) {
   chrome.runtime.sendMessage({
@@ -499,7 +491,7 @@ function getTrackerData(callback) {
       for (const key in response.translations) {
         TRANSLATIONS[key] = response.translations[key];
       }
-      callback(response.trackers, response.trackerButtonsToReplace);
+      callback(response.widgetList, response.widgetsToReplace);
     }
   });
 }

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -277,17 +277,15 @@ function reloadScripts(selectors, fallback_script_url) {
     return;
   }
 
-  for (let i = 0; i < scripts.length; i++) {
-    let scriptEl = scripts[i];
-
+  for (let scriptEl of scripts) {
     // reinsert script elements only
     if (!scriptEl.nodeName || scriptEl.nodeName.toLowerCase() != 'script') {
       continue;
     }
 
     let replacement = document.createElement("script");
-    for (let j = 0, atts = scriptEl.attributes, n = atts.length; j < n; j++) {
-      replacement.setAttribute(atts[j].nodeName, atts[j].nodeValue);
+    for (let attr of scriptEl.attributes) {
+      replacement.setAttribute(attr.nodeName, attr.nodeValue);
     }
     scriptEl.parentNode.replaceChild(replacement, scriptEl);
     // reinsert one script and quit

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -119,7 +119,6 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
 
   var buttonUrl = buttonData.buttonUrl;
   var buttonType = buttonData.type;
-  var details = buttonData.details;
 
   button.setAttribute("src", buttonUrl);
 
@@ -139,7 +138,7 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
 
   // normal button type; just open a new window when clicked
   if (buttonType === 0) {
-    var popupUrl = details + encodeURIComponent(window.location.href);
+    var popupUrl = buttonData.details + encodeURIComponent(window.location.href);
 
     button.addEventListener("click", function() {
       window.open(popupUrl);
@@ -148,17 +147,17 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
   // in place button type; replace the existing button
   // with an iframe when clicked
   } else if (buttonType == 1) {
-    var iframeUrl = details + encodeURIComponent(window.location.href);
+    var iframeUrl = buttonData.details + encodeURIComponent(window.location.href);
 
     button.addEventListener("click", function() {
       replaceButtonWithIframeAndUnblockTracker(button, tracker.name, iframeUrl);
     }, { once: true });
 
   // in place button type; replace the existing button with code
-  // specified in the Trackers file
+  // specified in the widgets JSON
   } else if (buttonType == 2) {
     button.addEventListener("click", function() {
-      replaceButtonWithHtmlCodeAndUnblockTracker(button, tracker.name, details);
+      replaceButtonWithHtmlCodeAndUnblockTracker(button, tracker.name, buttonData.details);
     }, { once: true });
 
   // in-place widget type:

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -265,7 +265,7 @@ function replaceWidgetAndReloadScripts(name) {
  * Replace an included script with a copy of itself to trigger a re-run.
  */
 function reloadScripts(selectors) {
-  let scripts = document.querySelectorAll(selectors.toString());
+  let scripts = document.querySelectorAll(selectors.join(','));
 
   scripts.forEach(function (scriptEl) {
     let script = document.createElement("script");
@@ -444,7 +444,7 @@ function replaceIndividualButton(tracker) {
 
   // makes a comma separated list of CSS selectors that specify
   // buttons for the current tracker; used for document.querySelectorAll
-  var buttonSelectorsString = tracker.buttonSelectors.toString();
+  var buttonSelectorsString = tracker.buttonSelectors.join(',');
   var buttonsToReplace =
     document.querySelectorAll(buttonSelectorsString);
 

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -122,10 +122,17 @@ function loadWidgetsFromFile(filePath, callback) {
  * @param {Object} properties the properties of the socialwidget
  */
 function SocialWidget(name, properties) {
-  this.name = name;
+  let self = this;
 
-  for (var property in properties) {
-    this[property] = properties[property];
+  self.name = name;
+
+  for (let property in properties) {
+    self[property] = properties[property];
+  }
+
+  // standardize on "domains"
+  if (self.domain) {
+    self.domains = [self.domain];
   }
 }
 

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -45,30 +45,14 @@
 
 /* globals log:false */
 
-var utils = require('utils');
+require.scopes.widgetloader = (function () {
 
-require.scopes.widgetloader = (function() {
+let utils = require('utils');
 
-var exports = {
+let exports = {
   initializeWidgets,
   loadWidgetsFromFile,
 };
-
-/**
- * Loads a JSON file at filePath and returns the parsed object.
- *
- * @param {String} filePath the path to the JSON file, relative to the
- *                          extension's data folder
- * @param {Function} callback callback(jsonParsed)
- */
-function loadJSONFromFile(filePath, callback) {
-  getFileContents(filePath, function(jsonString) {
-    var jsonParsed = JSON.parse(jsonString);
-    Object.freeze(jsonParsed); // prevent modifications to jsonParsed
-
-    callback(jsonParsed);
-  });
-}
 
 /**
  * Returns the contents of the file at filePath.
@@ -77,9 +61,8 @@ function loadJSONFromFile(filePath, callback) {
  * @param {Function} callback callback(responseText)
  */
 function getFileContents(filePath, callback) {
-  var url = chrome.runtime.getURL(filePath);
-
-  utils.xhrRequest(url, function(err, responseText) {
+  let url = chrome.runtime.getURL(filePath);
+  utils.xhrRequest(url, function (err, responseText) {
     if (err) {
       console.error(
         "Problem fetching contents of file at",
@@ -94,14 +77,13 @@ function getFileContents(filePath, callback) {
 }
 
 /**
- * @param {String} filePath the path to the JSON file, relative to the
- *                          extension's data folder
+ * @param {String} filePath the path to the JSON file
  * @param {Function} callback callback(socialwidgets)
  * @returns {Array} array of SocialWidget objects
  */
 function loadWidgetsFromFile(filePath, callback) {
-  loadJSONFromFile(filePath, function(widgetsJson) {
-    let widgets = initializeWidgets(widgetsJson);
+  getFileContents(filePath, function (contents) {
+    let widgets = initializeWidgets(JSON.parse(contents));
     log("Initialized widgets from disk");
     callback(widgets);
   });
@@ -146,4 +128,5 @@ function SocialWidget(name, properties) {
 }
 
 return exports;
+
 }()); //require scopes

--- a/src/js/socialwidgetloader.js
+++ b/src/js/socialwidgetloader.js
@@ -49,8 +49,10 @@ var utils = require('utils');
 
 require.scopes.widgetloader = (function() {
 
-var exports = {};
-exports.loadWidgetsFromFile = loadWidgetsFromFile;
+var exports = {
+  initializeWidgets,
+  loadWidgetsFromFile,
+};
 
 /**
  * Loads a JSON file at filePath and returns the parsed object.
@@ -92,27 +94,34 @@ function getFileContents(filePath, callback) {
 }
 
 /**
- * Returns an array of SocialWidget objects that are loaded from the file at
- * filePath.
- *
  * @param {String} filePath the path to the JSON file, relative to the
  *                          extension's data folder
  * @param {Function} callback callback(socialwidgets)
+ * @returns {Array} array of SocialWidget objects
  */
 function loadWidgetsFromFile(filePath, callback) {
   loadJSONFromFile(filePath, function(widgetsJson) {
-    let widgets = [];
-
-    // loop over each widget, making a SocialWidget object
-    for (let widget_name in widgetsJson) {
-      let widgetProperties = widgetsJson[widget_name];
-      let widget = new SocialWidget(widget_name, widgetProperties);
-      widgets.push(widget);
-    }
-
+    let widgets = initializeWidgets(widgetsJson);
     log("Initialized widgets from disk");
     callback(widgets);
   });
+}
+
+/**
+ * @param {Object} widgetsJson widget data
+ * @returns {Array} array of SocialWidget objects
+ */
+function initializeWidgets(widgetsJson) {
+  let widgets = [];
+
+  // loop over each widget, making a SocialWidget object
+  for (let widget_name in widgetsJson) {
+    let widgetProperties = widgetsJson[widget_name];
+    let widget = new SocialWidget(widget_name, widgetProperties);
+    widgets.push(widget);
+  }
+
+  return widgets;
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -676,7 +676,6 @@ function dispatcher(request, sender, sendResponse) {
       "checkEnabled",
       "checkEnabledAndThirdParty",
       "checkLocation",
-      "checkReplaceButton",
       "checkWidgetReplacementEnabled",
       "fpReport",
       "getReplacementButton",
@@ -719,15 +718,6 @@ function dispatcher(request, sender, sendResponse) {
 
     let action = checkAction(sender.tab.id, frame_host);
     sendResponse(action == constants.COOKIEBLOCK || action == constants.USER_COOKIE_BLOCK);
-
-    break;
-  }
-
-  case "checkReplaceButton": {
-    if (badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) &&
-        badger.isWidgetReplacementEnabled()) {
-      sendResponse(getWidgetList(sender.tab.id));
-    }
 
     break;
   }
@@ -816,10 +806,16 @@ function dispatcher(request, sender, sendResponse) {
   }
 
   case "checkWidgetReplacementEnabled": {
-    sendResponse(
-      badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url)) &&
-      badger.isWidgetReplacementEnabled()
-    );
+    let response = false,
+      tab_host = window.extractHostFromURL(sender.tab.url);
+
+    if (badger.isPrivacyBadgerEnabled(tab_host) &&
+        badger.isWidgetReplacementEnabled()) {
+      response = getWidgetList(sender.tab.id);
+    }
+
+    sendResponse(response);
+
     break;
   }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -588,9 +588,7 @@ let getWidgetList = (function () {
       translations.rtl = RTL_LOCALES.indexOf(UI_LOCALE) > -1;
     }
 
-    for (let i = 0; i < badger.widgetList.length; i++) {
-      let widget = badger.widgetList[i];
-
+    for (let widget of badger.widgetList) {
       // replace only if the widget is not on the 'do not replace' list
       // also don't send widget data used later for dynamic replacement
       if (exceptions.includes(widget.name)) {

--- a/tests/selenium/clobbering_test.py
+++ b/tests/selenium/clobbering_test.py
@@ -7,13 +7,6 @@ import pbtest
 
 
 class ClobberingTest(pbtest.PBSeleniumTest):
-    COOKIEBLOCK_JS = (
-        "(function (domain) {"
-        "  let bg = chrome.extension.getBackgroundPage();"
-        "  bg.badger.storage.setupHeuristicAction(domain, bg.constants.COOKIEBLOCK);"
-        "}(arguments[0]));"
-    )
-
     def test_localstorage_clobbering(self):
         LOCALSTORAGE_TESTS = [
             # (test result element ID, expected stored, expected empty)
@@ -55,8 +48,7 @@ class ClobberingTest(pbtest.PBSeleniumTest):
             )
 
         # mark the frame domain for cookieblocking
-        self.load_url(self.options_url)
-        self.js(self.COOKIEBLOCK_JS, FRAME_DOMAIN)
+        self.cookieblock_domain(FRAME_DOMAIN)
 
         # now rerun and check results for various localStorage access tests
         self.load_url(FIXTURE_URL)
@@ -100,14 +92,14 @@ class ClobberingTest(pbtest.PBSeleniumTest):
         )
 
         # cookieblock the domain fetched by the fixture
-        self.load_url(self.options_url)
-        self.js(self.COOKIEBLOCK_JS, THIRD_PARTY_DOMAIN)
+        self.cookieblock_domain(THIRD_PARTY_DOMAIN)
 
         # recheck what the referrer header looks like now after cookieblocking
         verify_referrer_header(
             "https://efforg.github.io/",
             "Referrer header does not appear to be origin-only"
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -46,13 +46,6 @@ class DNTTest(pbtest.PBSeleniumTest):
 
         return headers
 
-    def disable_badger_on_site(self, url):
-        self.load_url(self.options_url)
-        self.wait_for_script("return window.OPTIONS_INITIALIZED")
-        self.find_el_by_css('a[href="#tab-whitelisted-domains"]').click()
-        self.driver.find_element_by_id('newWhitelistDomain').send_keys(url)
-        self.driver.find_element_by_css_selector('button.addButton').click()
-
     def domain_was_recorded(self, domain):
         return self.js(
             "return (Object.keys("
@@ -91,19 +84,9 @@ class DNTTest(pbtest.PBSeleniumTest):
             "privacy_badger_dnt_test_fixture.html"
         )
         DNT_DOMAIN = "www.eff.org"
-        BLOCK_DOMAIN_JS = (
-            "(function () {"
-            "chrome.extension.getBackgroundPage()."
-            "badger.storage.setupHeuristicAction("
-            "  arguments[0],"
-            "  chrome.extension.getBackgroundPage().constants.BLOCK"
-            ");"
-            "}());"
-        )
 
         # mark a DNT-compliant domain for blocking
-        self.load_url(self.options_url)
-        self.js(BLOCK_DOMAIN_JS, DNT_DOMAIN)
+        self.block_domain(DNT_DOMAIN)
 
         # visit a page that loads a resource from that DNT-compliant domain
         self.open_window()

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -414,6 +414,32 @@ class PBSeleniumTest(unittest.TestCase):
             EC.frame_to_be_available_and_switch_to_it(
                 (By.CSS_SELECTOR, selector)))
 
+    def block_domain(self, domain):
+        self.load_url(self.options_url)
+        self.js((
+            "(function (domain) {"
+            "  let bg = chrome.extension.getBackgroundPage();"
+            "  let base_domain = window.getBaseDomain(domain);"
+            "  bg.badger.heuristicBlocking.blacklistOrigin(domain, base_domain);"
+            "}(arguments[0]));"
+        ), domain)
+
+    def cookieblock_domain(self, domain):
+        self.load_url(self.options_url)
+        self.js((
+            "(function (domain) {"
+            "  let bg = chrome.extension.getBackgroundPage();"
+            "  bg.badger.storage.setupHeuristicAction(domain, bg.constants.COOKIEBLOCK);"
+            "}(arguments[0]));"
+        ), domain)
+
+    def disable_badger_on_site(self, url):
+        self.load_url(self.options_url)
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('a[href="#tab-whitelisted-domains"]').click()
+        self.driver.find_element_by_id('newWhitelistDomain').send_keys(url)
+        self.driver.find_element_by_css_selector('button.addButton').click()
+
     @property
     def logs(self):
         def strip(l):

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -249,11 +249,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         DOMAIN_ID = DOMAIN.replace(".", "-")
 
         # record the domain as cookieblocked by Badger
-        self.load_url(self.options_url)
-        self.js((
-            "chrome.extension.getBackgroundPage()"
-            ".badger.storage.setupHeuristicAction('{}', '{}');"
-        ).format(DOMAIN, "cookieblock"))
+        self.cookieblock_domain(DOMAIN)
 
         self.open_popup(origins={DOMAIN:"cookieblock"})
 

--- a/tests/selenium/surrogates_test.py
+++ b/tests/selenium/surrogates_test.py
@@ -46,11 +46,10 @@ class SurrogatesTest(pbtest.PBSeleniumTest):
         )
 
         # block ga.js (known to break the site)
-        self.load_url(self.options_url)
-        # also back up the surrogate definition before removing it
+        self.block_domain("www.google-analytics.com")
+        # back up the surrogate definition before removing it
         ga_backup = self.js(
             "let bg = chrome.extension.getBackgroundPage();"
-            "bg.badger.heuristicBlocking.blacklistOrigin('www.google-analytics.com', 'google-analytics.com');"
             "const sdb = bg.require('surrogatedb');"
             "return JSON.stringify(sdb.hostnames['www.google-analytics.com']);"
         )

--- a/tests/selenium/widgets_test.py
+++ b/tests/selenium/widgets_test.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import unittest
+
+import pbtest
+
+from selenium.common.exceptions import (
+    StaleElementReferenceException,
+    TimeoutException
+)
+from selenium.webdriver.common.keys import Keys
+
+
+class WidgetsTest(pbtest.PBSeleniumTest):
+
+    FIXTURES_URL = "https://efforg.github.io/privacybadger-test-fixtures/html/"
+    BASIC_FIXTURE_URL = FIXTURES_URL + "widget_basic.html"
+    DYNAMIC_FIXTURE_URL = FIXTURES_URL + "widget_dynamic.html"
+    THIRD_PARTY_DOMAIN = "privacybadger-tests.eff.org"
+
+    def setup_widget(self):
+        """Adds a type 3 test replacement widget to Privacy Badger."""
+
+        widget_name = "Type 3 Widget"
+
+        widgetsJson = {
+            widget_name: {
+                "domain": self.THIRD_PARTY_DOMAIN,
+                "buttonSelectors": [
+                    "iframe#pb-type3-test-widget"
+                ],
+                "replacementButton": {
+                    "unblockDomains": [
+                        self.THIRD_PARTY_DOMAIN
+                    ],
+                    "imagePath": "badger-play.png",
+                    "type": 3
+                }
+            }
+        }
+
+        # reinitialize widgets using above JSON
+        self.load_url(self.options_url)
+        self.js((
+            "(function (widgetsJson) {"
+            "  let bg = chrome.extension.getBackgroundPage();"
+            "  bg.badger.widgetList = bg.widgetLoader.initializeWidgets(widgetsJson);"
+            "}(arguments[0]));"
+        ), widgetsJson)
+
+        return widget_name
+
+    def switch_to_frame(self, selector):
+        self.wait_for_and_switch_to_frame(selector, timeout=3)
+
+    def block_domain(self, domain):
+        self.load_url(self.options_url)
+        self.js((
+            "(function (domain) {"
+            "  let bg = chrome.extension.getBackgroundPage();"
+            "  let base_domain = window.getBaseDomain(domain);"
+            "  bg.badger.heuristicBlocking.blacklistOrigin(domain, base_domain);"
+            "}(arguments[0]));"
+        ), domain)
+
+    def cookieblock_domain(self, domain):
+        self.load_url(self.options_url)
+        self.js((
+            "(function (domain) {"
+            "  let bg = chrome.extension.getBackgroundPage();"
+            "  bg.badger.storage.setupHeuristicAction(domain, bg.constants.COOKIEBLOCK);"
+            "}(arguments[0]));"
+        ), domain)
+
+    def disable_badger_on_site(self, url):
+        self.load_url(self.options_url)
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('a[href="#tab-whitelisted-domains"]').click()
+        self.driver.find_element_by_id('newWhitelistDomain').send_keys(url)
+        self.driver.find_element_by_css_selector('button.addButton').click()
+
+    def assert_widget(self):
+        try:
+            self.switch_to_frame('iframe[src]')
+        except (StaleElementReferenceException, TimeoutException):
+            self.fail("Unable to find widget frame")
+
+        try:
+            self.wait_for_text('body', "Hello world!")
+        except TimeoutException:
+            self.fail("Unable to find expected widget text")
+
+        self.driver.switch_to.default_content()
+
+    def assert_replacement(self, widget_name):
+        try:
+            self.switch_to_frame('iframe[srcdoc]')
+        except (StaleElementReferenceException, TimeoutException):
+            self.fail("Unable to find replacement frame")
+
+        try:
+            self.wait_for_text('body', (
+                "Privacy Badger has replaced this {} button"
+            ).format(widget_name))
+        except TimeoutException:
+            self.fail("Unable to find expected replacement widget text")
+
+        self.driver.switch_to.default_content()
+
+    def assert_widget_blocked(self):
+        try:
+            self.switch_to_frame('iframe[src]')
+        except TimeoutException:
+            self.fail("Widget frame should still be here")
+
+        self.assertFalse(
+            self.txt_by_css('body'), "Widget frame should be empty")
+
+        self.driver.switch_to.default_content()
+
+    def assert_no_widget(self):
+        try:
+            self.switch_to_frame('iframe[src]')
+            self.fail("Widget frame should be missing")
+        except TimeoutException:
+            pass
+        self.driver.switch_to.default_content()
+
+    def assert_no_replacement(self):
+        try:
+            self.switch_to_frame('iframe[srcdoc]')
+            self.fail("Replacement widget frame should be missing")
+        except TimeoutException:
+            pass
+        self.driver.switch_to.default_content()
+
+    def test_replacement_basic(self):
+        widget_name = self.setup_widget()
+
+        # visit the basic widget fixture
+        self.load_url(self.BASIC_FIXTURE_URL)
+        # verify the widget is present
+        self.assert_widget()
+
+        # block the test widget's domain
+        self.block_domain(self.THIRD_PARTY_DOMAIN)
+
+        # revisit the fixture
+        self.load_url(self.BASIC_FIXTURE_URL)
+        # verify the widget got replaced
+        self.assert_replacement(widget_name)
+
+    def test_replacement_dynamic(self):
+        widget_name = self.setup_widget()
+
+        # visit the dynamic widget fixture
+        self.load_url(self.DYNAMIC_FIXTURE_URL)
+        # verify the widget is initially missing
+        self.assert_no_widget()
+
+        # verify the widget shows up once you click on the trigger element
+        self.find_el_by_css('#widget-trigger').click()
+        self.assert_widget()
+
+        # block the test widget's domain
+        self.block_domain(self.THIRD_PARTY_DOMAIN)
+
+        # revisit the fixture
+        self.load_url(self.DYNAMIC_FIXTURE_URL)
+        # click on the trigger element
+        self.find_el_by_css('#widget-trigger').click()
+        # verify the widget got replaced
+        self.assert_replacement(widget_name)
+
+    def test_activation(self):
+        widget_name = self.setup_widget()
+        self.block_domain(self.THIRD_PARTY_DOMAIN)
+        self.load_url(self.BASIC_FIXTURE_URL)
+        self.assert_replacement(widget_name)
+
+        # click the "allow once" button
+        self.switch_to_frame('iframe[srcdoc]')
+        self.find_el_by_css('button').click()
+        self.driver.switch_to.default_content()
+
+        # verify the original widget is restored
+        self.assert_widget()
+
+    def test_disabling_site(self):
+        self.setup_widget()
+        self.block_domain(self.THIRD_PARTY_DOMAIN)
+
+        self.disable_badger_on_site(self.BASIC_FIXTURE_URL)
+
+        # verify basic widget is neither replaced nor blocked
+        self.load_url(self.BASIC_FIXTURE_URL)
+        self.assert_no_replacement()
+        self.assert_widget()
+
+        # verify dynamic widget is neither replaced nor blocked
+        self.load_url(self.DYNAMIC_FIXTURE_URL)
+        self.find_el_by_css('#widget-trigger').click()
+        self.assert_no_replacement()
+        self.assert_widget()
+
+    def test_disabling_all_replacement(self):
+        self.setup_widget()
+        self.block_domain(self.THIRD_PARTY_DOMAIN)
+
+        # disable widget replacement
+        self.load_url(self.options_url)
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('a[href="#tab-manage-widgets"]').click()
+        self.driver.find_element_by_id('replace-widgets-checkbox').click()
+
+        # verify basic widget is no longer replaced
+        self.load_url(self.BASIC_FIXTURE_URL)
+        self.assert_no_replacement()
+        self.assert_widget_blocked()
+
+        # verify dynamic widget is no longer replaced
+        self.load_url(self.DYNAMIC_FIXTURE_URL)
+        self.find_el_by_css('#widget-trigger').click()
+        self.assert_no_replacement()
+        self.assert_widget_blocked()
+
+    def test_disabling_replacement_for_one_widget(self):
+        widget_name = self.setup_widget()
+        self.block_domain(self.THIRD_PARTY_DOMAIN)
+
+        # add the widget to the list of exceptions
+        self.load_url(self.options_url)
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('a[href="#tab-manage-widgets"]').click()
+        self.find_el_by_css('input[type="search"]').send_keys(
+            widget_name, Keys.ENTER)
+
+        # verify basic widget is no longer replaced
+        self.load_url(self.BASIC_FIXTURE_URL)
+        self.assert_no_replacement()
+        self.assert_widget_blocked()
+
+        # verify dynamic widget is no longer replaced
+        self.load_url(self.DYNAMIC_FIXTURE_URL)
+        self.find_el_by_css('#widget-trigger').click()
+        self.assert_no_replacement()
+        self.assert_widget_blocked()
+
+    def test_no_replacement_when_cookieblocked(self):
+        self.setup_widget()
+        self.cookieblock_domain(self.THIRD_PARTY_DOMAIN)
+        self.load_url(self.BASIC_FIXTURE_URL)
+        self.assert_no_replacement()
+        self.assert_widget()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/selenium/widgets_test.py
+++ b/tests/selenium/widgets_test.py
@@ -54,32 +54,6 @@ class WidgetsTest(pbtest.PBSeleniumTest):
     def switch_to_frame(self, selector):
         self.wait_for_and_switch_to_frame(selector, timeout=3)
 
-    def block_domain(self, domain):
-        self.load_url(self.options_url)
-        self.js((
-            "(function (domain) {"
-            "  let bg = chrome.extension.getBackgroundPage();"
-            "  let base_domain = window.getBaseDomain(domain);"
-            "  bg.badger.heuristicBlocking.blacklistOrigin(domain, base_domain);"
-            "}(arguments[0]));"
-        ), domain)
-
-    def cookieblock_domain(self, domain):
-        self.load_url(self.options_url)
-        self.js((
-            "(function (domain) {"
-            "  let bg = chrome.extension.getBackgroundPage();"
-            "  bg.badger.storage.setupHeuristicAction(domain, bg.constants.COOKIEBLOCK);"
-            "}(arguments[0]));"
-        ), domain)
-
-    def disable_badger_on_site(self, url):
-        self.load_url(self.options_url)
-        self.wait_for_script("return window.OPTIONS_INITIALIZED")
-        self.find_el_by_css('a[href="#tab-whitelisted-domains"]').click()
-        self.driver.find_element_by_id('newWhitelistDomain').send_keys(url)
-        self.driver.find_element_by_css_selector('button.addButton').click()
-
     def assert_widget(self):
         try:
             self.switch_to_frame('iframe[src]')


### PR DESCRIPTION
Fixes #1542.

~~Should be rebased on #2484 to avoid replacing reCAPTCHA when it's only been cookieblocked. (Right now we ask, "would we block `google.com`?" and the answer is yes, but what we want to ask is, "did we block `google.com`?" (as opposed to `www.google.com`)~~

Parts borrowed from #2271. Should redo that PR from master after this is merged.

`www.google.com` reCAPTCHA examples (currently yellowlisted, so you have to tell your Privacy Badger to block `www.google.com` first):
- https://www.dailykos.com/users/signup
- https://2-harvest.org/contact/
- https://www.burpee.com/contactus

`google.com` reCAPTCHA examples:
- https://en.islcollective.com/create-an-account
- https://apps.nextcloud.com/signup/

Dynamically inserted (https://github.com/EFForg/privacybadger/pull/2512/commits/024fffc3278c50ca5c45f33909bdf9a40a195b09) examples:
- https://blog.0patch.com/2018/01/bringing-abandoned-equation-editor-back.html#comment-form
- https://us04web.zoom.us/signup