### PR TITLE
Improve display of "no trackers detected" in popup

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -491,7 +491,7 @@ function refreshPopup() {
 
     if (POPUP_DATA.showNonTrackingDomains) {
       // show the "no third party resources on this site" message
-      $("#blockedResources").html(chrome.i18n.getMessage("popup_blocked"));
+      $("#no-third-parties").show();
     }
 
     // activate tooltips
@@ -550,6 +550,9 @@ function refreshPopup() {
         htmlUtils.getOriginHtml(nonTracking[i], constants.NO_TRACKING, false)
       );
     }
+
+    // reduce margin if we have non-tracking domains to show
+    $("#instructions_no_trackers").css("margin", "10px 0");
   }
 
   if (printable.length) {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -268,10 +268,16 @@ font-size: 16px;
     margin: 0;
     padding-top: 10px;
 }
-#special-browser-page, #disabled-site-message {
+#instructions_no_trackers, #special-browser-page, #disabled-site-message {
     text-align: center;
     margin: 45px 0;
     padding: 0;
+}
+#instructions_no_trackers, #no-third-parties {
+    display: block;
+}
+#no-third-parties {
+    font-size: 12px;
 }
 
 .pbButton{

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -107,7 +107,10 @@
   <p id="pbInstructions">
     <span id="instructions-many-trackers"></span>
     <span id="instructions_one_tracker" class="i18n_popup_instructions_one_tracker" style="display:none"></span>
-    <span id="instructions_no_trackers" class="i18n_popup_instructions_no_trackers" style="display:none"></span>
+    <span id="instructions_no_trackers" style="display:none">
+      <span class="i18n_popup_instructions_no_trackers"></span>
+      <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
+    </span>
   </p>
   <div class="spacer"></div>
   <div id="blockedResources"></div>


### PR DESCRIPTION
Before:
![Screenshot from 2019-12-05 10:27:58](https://user-images.githubusercontent.com/794578/70249622-a3b83a80-174a-11ea-856e-ef50fb151122.png)

After:
![Screenshot from 2019-12-05 10:27:03](https://user-images.githubusercontent.com/794578/70249625-a6b32b00-174a-11ea-9a9e-1ea1128c3695.png)


Follows up on #2510 and #2451.