### PR TITLE
Fix link cleaning on messenger.com

### DIFF
--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -2,7 +2,7 @@
 // Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
 // this should only run on facebook.com, messenger.com, and
 // facebookcorewwwi.onion
-let fb_wrapped_link = `a[href*='${document.domain}/l.php?']:not([aria-label])`;
+let fb_wrapped_link = `a[href*='${document.domain.split(".").slice(-2).join(".")}/l.php?']:not([aria-label])`;
 
 // remove all attributes from a link except for class and ARIA attributes
 function cleanAttrs(elem) {


### PR DESCRIPTION
Resolves: #2513

Updated wrapped link discovery (similar to [FacebookTrackingRemoval](https://github.com/mgziminsky/FacebookTrackingRemoval/commit/36eefd76a457864c580b8d63157b90c54f3935d2#diff-bd9c9dcd314f2d7df52935b3a6a4d504))