### PR TITLE
Add "samesite" to cookie attributes

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -335,6 +335,7 @@ function parseCookie(str, opts) {
     "httponly",
     "max-age",
     "path",
+    "samesite",
     "secure",
   ];
 

--- a/src/tests/tests/heuristic.js
+++ b/src/tests/tests/heuristic.js
@@ -151,6 +151,7 @@ QUnit.test("CloudFlare cookies should get ignored", (assert) => {
     '__cfduid=d3c728f97e01b1ab6969828f24b42ab111493693758',
     '__cfduid=d9758e8613dd4acbba3248dde15e74f8d1493774432; expires=Thu, 03-May-18 01:20:32 GMT; path=/; domain=.medium.com; HttpOnly',
     '__cfduid=de8a1734f91060dba20e2833705018b911493771353; expires=Thu, 03-May-18 02:25:53 GMT; path=/; domain=.fightforthefuture.org; HttpOnly',
+    '__cfduid=d712bcfe8e20469cc4b9129a4ab89b7501576598707; expires=Thu, 16-Jan-20 16:05:07 GMT; path=/; domain=.githack.com; HttpOnly; SameSite=Lax',
   ];
 
   let details = JSON.parse(JSON.stringify(chromeDetails));

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -296,6 +296,25 @@ QUnit.test("cookie parsing", function (assert) {
     "duplicate names #3"
   );
 
+  // SameSite attribute
+  let SAMESITE_COOKIE = 'abc=123; path=/; domain=.githack.com; HttpOnly; SameSite=Lax';
+  assert.deepEqual(
+    utils.parseCookie(SAMESITE_COOKIE),
+    {
+      abc: '123',
+      SameSite: 'Lax',
+      path: '/',
+      domain: '.githack.com',
+      HttpOnly: '',
+    },
+    "SameSite is parsed"
+  );
+  assert.deepEqual(
+    utils.parseCookie(SAMESITE_COOKIE, { skipAttributes: true }),
+    { abc: '123' },
+    "SameSite is ignored when ignoring attributes"
+  );
+
 });
 
 QUnit.test("cookie parsing (legacy Firefox add-on)", function (assert) {

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -50,6 +50,8 @@ class SupercookieTest(pbtest.PBSeleniumTest):
 
 
     def test_should_detect_ls_of_third_party_frame(self):
+        self.assertFalse(self.get_snitch_map_for("githack.com"))
+
         self.load_url(
             "https://efforg.github.io/privacybadger-test-fixtures/html/"
             "localstorage.html"
@@ -67,6 +69,7 @@ class SupercookieTest(pbtest.PBSeleniumTest):
         )
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):
+        self.assertFalse(self.get_snitch_map_for("githack.com"))
         self.load_url(
             "https://efforg.github.io/privacybadger-test-fixtures/html/"
             "localstorage_low_entropy.html"


### PR DESCRIPTION
This fixes cookies that would otherwise be low entropy getting flagged solely due to SameSite being present.