### PR TITLE
Update MDFP list for Shopify

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -2339,7 +2339,15 @@ var multiDomainFirstPartiesArray = [
 
     "szn.cz",
   ],
-  ["shopify.com", "myshopify.com"],
+  [
+    "shopify.com",
+    "myshopify.com",
+    "shopifycdn.com",
+    "shopifyapps.com",
+    "shopifycloud.com",
+    "shopifyadmin.com",
+    "shopifypreview.com",
+  ],
   ["siriusxm.com", "sirius.com"],
   ["skygo.co.nz", "skytv.co.nz"],
   ["skysports.com", "skybet.com", "skyvegas.com"],


### PR DESCRIPTION
Related to #1499

We've received reports from merchants/Shopify employees visiting different sections of our application that Privacy Badger blocks some domains we used.

I added the list of our domains used in the administration section of our app.

Let me know if you think I need to add those domains to the yellow list. Some of those domains are used inside an iFrame to load Shopify apps.