### PR TITLE
Add migration to forget __cfduid-linked domains

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -573,6 +573,7 @@ Badger.prototype = {
       Migrations.resetWebRTCIPHandlingPolicy,
       Migrations.enableShowNonTrackingDomains,
       Migrations.forgetFirstPartySnitches,
+      Migrations.forgetCloudflare,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -313,8 +313,8 @@ exports.Migrations= {
       let cfduidFirstParties = new Set();
 
       cookies.forEach(function (cookie) {
-        // remove the leading dot
-        cfduidFirstParties.add(cookie.domain.slice(1));
+        // get the base domain (also removes the leading dot)
+        cfduidFirstParties.add(window.getBaseDomain(cookie.domain));
       });
 
       for (let domain in snitchClones) {

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -292,6 +292,54 @@ exports.Migrations= {
     badger.mergeUserData(data, true);
   },
 
+  forgetCloudflare: function (badger) {
+    console.log("Forgetting Cloudflare domains ...");
+
+    let actionMap = badger.storage.getBadgerStorageObject("action_map"),
+      actionClones = actionMap.getItemClones(),
+      snitchMap = badger.storage.getBadgerStorageObject("snitch_map"),
+      snitchClones = snitchMap.getItemClones(),
+      correctedSites = {};
+
+    let config = {
+      name: '__cfduid'
+    };
+    if (badger.firstPartyDomainPotentiallyRequired) {
+      config.firstPartyDomain = null;
+    }
+
+    chrome.cookies.getAll(config, function (cookies) {
+      // assume there is no other tracking for these domains
+      let cfduidFirstParties = new Set();
+
+      cookies.forEach(function (cookie) {
+        // remove the leading dot
+        cfduidFirstParties.add(cookie.domain.slice(1));
+      });
+
+      for (let domain in snitchClones) {
+        let newSnitches = snitchClones[domain].filter(
+          item => !cfduidFirstParties.has(item));
+
+        if (newSnitches.length) {
+          correctedSites[domain] = newSnitches;
+        }
+      }
+
+      // clear existing maps and then use mergeUserData to rebuild them
+      actionMap.updateObject({});
+      snitchMap.updateObject({});
+
+      const data = {
+        snitch_map: correctedSites,
+        action_map: actionClones
+      };
+
+      // pass in boolean 2nd parameter to flag that it's run in a migration, preventing infinite loop
+      badger.mergeUserData(data, true);
+    });
+  },
+
 };
 
 


### PR DESCRIPTION
Fixes #1538, fixes #2530.

Follows up on 775ff3e69eb952e83b3da54cdfa2a851ed4cc7cf.

This migration gets all "__cfduid" cookies and collects their site (first-party) domains. It then goes through each tracking domain in `snitch_map` and throws away any site domain entries that are found in the "__cfduid" site domains list. It then rebuilds action and snitch maps.

Since we only seem to have site domains for the "__cfduid" cookies, we can't differentiate between Cloudflare and non-Cloudflare tracking domains, so this may end up removing non-Cloudflare tracking domains (that were seen on the same site domains as Cloudflare tracking domains). This should be OK as there shouldn't be too many, and Privacy Badgers will automatically relearn to block them.