### PR TITLE
Detects and displays on options page if user is already protected against webrtc ip leak

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -121,12 +121,15 @@ function loadOptions() {
     $("#toggle_webrtc_mode").on("click", toggleWebRTCIPProtection);
 
     chrome.privacy.network.webRTCIPHandlingPolicy.get({}, result => {
+      // only enable the checkbox if pb can control webrtc ip leak protection
       if (result.levelOfControl.endsWith("_by_this_extension")) {
         $("#toggle_webrtc_mode").attr("disabled", false);
       }
 
-      $("#toggle_webrtc_mode").prop(
-        "checked", result.value == "disable_non_proxied_udp");
+      // auto check the option box if ip leak is already protected at diff levels, via pb or another extension
+      if (result.value == "default_public_interface_only" || result.value == "disable_non_proxied_udp") {
+        $("#toggle_webrtc_mode").prop("checked", true);
+      }
     });
 
   } else {


### PR DESCRIPTION
Related to #2528. If the user is already protected against webrtc ip leakage, then the options page will reflect that. What it doesn't handle is notifying the user that they're protected via some other means than Privacy Badger (which can be misleading if they try to uncheck the box, not knowing it's controlled by some other extension or addon). Handling that would involve translations and may be beyond the scope of this pull request.