### PR TITLE
Update MDFP list for Front

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -992,6 +992,7 @@ var multiDomainFirstPartiesArray = [
   ["fastmail.com", "fastmailusercontent.com"],
   ["firefox.com", "firefoxusercontent.com", "mozilla.org"],
   ["foxnews.com", "foxbusiness.com", "fncstatic.com"],
+  ["frontapp.com", "frontapplication.com"]
   [
     "gap.com",
 

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -992,7 +992,7 @@ var multiDomainFirstPartiesArray = [
   ["fastmail.com", "fastmailusercontent.com"],
   ["firefox.com", "firefoxusercontent.com", "mozilla.org"],
   ["foxnews.com", "foxbusiness.com", "fncstatic.com"],
-  ["frontapp.com", "frontapplication.com"]
+  ["frontapp.com", "frontapplication.com"],
   [
     "gap.com",
 


### PR DESCRIPTION
[Front](https://frontapp.com) app runs on https://*.frontapp.com and uses https://*.frontapplication.com to run 3rd party code.

PrivacyBadger blocks frontapplication.com preventing the 3rd party plugins to work.