### PR TITLE
Ignore consensu.org (GDPR consent provider)

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -574,6 +574,7 @@ Badger.prototype = {
       Migrations.enableShowNonTrackingDomains,
       Migrations.forgetFirstPartySnitches,
       Migrations.forgetCloudflare,
+      Migrations.forgetConsensu,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -301,6 +301,12 @@ HeuristicBlocker.prototype = {
       firstParties = snitchMap.getItem(tracker_origin);
     }
 
+    // GDPR Consent Management Provider
+    // https://github.com/EFForg/privacybadger/pull/2245#issuecomment-545545717
+    if (tracker_origin == "consensu.org") {
+      return;
+    }
+
     if (firstParties.indexOf(page_origin) != -1) {
       return; // We already know about the presence of this tracker on the given domain
     }

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -339,6 +339,12 @@ exports.Migrations= {
     });
   },
 
+  // https://github.com/EFForg/privacybadger/pull/2245#issuecomment-545545717
+  forgetConsensu: (badger) => {
+    console.log("Forgetting consensu.org domains (GDPR consent provider) ...");
+    badger.storage.forget("consensu.org");
+  },
+
 };
 
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -421,6 +421,34 @@ BadgerPen.prototype = {
       log("Removing %s from action_map", domain);
       actionMap.deleteItem(domain);
     }
+  },
+
+  /**
+   * Removes a base domain and its subdomains from snitch and action maps.
+   * Preserves action map entries with user overrides.
+   *
+   * @param {String} base_domain
+   */
+  forget: function (base_domain) {
+    let self = this,
+      dot_base = '.' + base_domain,
+      actionMap = self.getBadgerStorageObject('action_map'),
+      actions = actionMap.getItemClones(),
+      snitchMap = self.getBadgerStorageObject('snitch_map');
+
+    if (snitchMap.getItem(base_domain)) {
+      log("Removing %s from snitch_map", base_domain);
+      badger.storage.getBadgerStorageObject("snitch_map").deleteItem(base_domain);
+    }
+
+    for (let domain in actions) {
+      if (domain == base_domain || domain.endsWith(dot_base)) {
+        if (actions[domain].userAction == "") {
+          log("Removing %s from action_map", domain);
+          actionMap.deleteItem(domain);
+        }
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Following up on https://github.com/EFForg/privacybadger/pull/2245#issuecomment-545545717

This is meant to be a medium-term solution to work around major site breakages (see error reports).

You can teach Privacy Badger to block `consensu.org` from scratch by visiting:
- https://www.buzzfeed.com/
- https://www.independent.co.uk/us
- http://www.spiegel.de/ (`consensu.org` only loads when you click the initial consent Accept button; you need to erase site data to see the consent again on subsequent loads)

The migration is to resolve breakages for existing Badger users. The short-circuit in `_recordPrevalence()` takes care of (seed) data imports.