### PR TITLE
Cancel requests before Badger is ready

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -51,6 +51,10 @@ function onBeforeRequest(details) {
     type = details.type,
     url = details.url;
 
+  if (utils.isRestrictedUrl(url)) {
+    return {};
+  }
+
   if (type == "main_frame") {
     forgetTab(tab_id);
     badger.recordFrame(tab_id, frame_id, url);
@@ -68,7 +72,7 @@ function onBeforeRequest(details) {
     return {cancel: true};
   }
 
-  if (_isTabChromeInternal(tab_id)) {
+  if (tab_id < 0) {
     return {};
   }
 
@@ -142,8 +146,8 @@ function onBeforeSendHeaders(details) {
     type = details.type,
     url = details.url;
 
-  if (_isTabChromeInternal(tab_id)) {
-    // DNT policy requests: strip cookies
+  if (tab_id < 0 || utils.isRestrictedUrl(url)) {
+    // strip cookies from DNT policy requests
     if (type == "xmlhttprequest" && url.endsWith("/.well-known/dnt-policy.txt")) {
       // remove Cookie headers
       let newHeaders = [];
@@ -158,6 +162,7 @@ function onBeforeSendHeaders(details) {
       };
     }
 
+    // ignore otherwise
     return {};
   }
 
@@ -240,8 +245,8 @@ function onHeadersReceived(details) {
   var tab_id = details.tabId,
     url = details.url;
 
-  if (_isTabChromeInternal(tab_id)) {
-    // DNT policy responses: strip cookies, reject redirects
+  if (tab_id < 0 || utils.isRestrictedUrl(url)) {
+    // strip cookies, reject redirects from DNT policy responses
     if (details.type == "xmlhttprequest" && url.endsWith("/.well-known/dnt-policy.txt")) {
       // if it's a redirect, cancel it
       if (details.statusCode >= 300 && details.statusCode < 400) {
@@ -263,6 +268,7 @@ function onHeadersReceived(details) {
       };
     }
 
+    // ignore otherwise
     return {};
   }
 
@@ -514,26 +520,6 @@ function checkAction(tabId, requestHost, frameId) {
 }
 
 /**
- * Checks if the tab is chrome internal
- *
- * @param {Integer} tabId Id of the tab to test
- * @returns {boolean} Returns true if the tab is chrome internal
- * @private
- */
-function _isTabChromeInternal(tabId) {
-  if (tabId < 0) {
-    return true;
-  }
-
-  let frameData = badger.getFrameData(tabId);
-  if (!frameData || !frameData.url.startsWith("http")) {
-    return true;
-  }
-
-  return false;
-}
-
-/**
  * Checks if the tab is a chrome-extension tab
  *
  * @param {Integer} tabId Id of the tab to test
@@ -678,11 +664,6 @@ function dispatcher(request, sender, sendResponse) {
 
   case "checkLocation": {
     if (!badger.isPrivacyBadgerEnabled(window.extractHostFromURL(sender.tab.url))) {
-      return sendResponse();
-    }
-
-    // Ignore requests from internal Chrome tabs.
-    if (_isTabChromeInternal(sender.tab.id)) {
       return sendResponse();
     }
 

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -320,8 +320,10 @@ class PBSeleniumTest(unittest.TestCase):
                     # wait for Badger's storage, listeners, ...
                     self.load_url(self.options_url)
                     self.wait_for_script(
-                        "return chrome.extension.getBackgroundPage()."
-                        "badger.INITIALIZED"
+                        "return ("
+                        "  chrome.extension &&"
+                        "  chrome.extension.getBackgroundPage().badger.INITIALIZED"
+                        ");"
                     )
                     driver.close()
                     if driver.window_handles:


### PR DESCRIPTION
Fixes #1845. Part two of #2438.

This sets up an early `chrome.onBeforeRequest` listener to cancel all requests before Badger is done initializing, and reloads any tabs containing cancelled requests when Badger is ready.

Should guarantee catching all requests on startup in Firefox thanks to a ["persistent" listener](https://github.com/mdn/sprints/issues/1015), and should catch more requests on startup in Chrome thanks to initializing a blocking listener faster.

Needs more testing (perhaps with mitmproxy) and resolution for https://github.com/EFForg/privacybadger/pull/2438#pullrequestreview-308216140 and https://github.com/EFForg/privacybadger/pull/2438#pullrequestreview-310135758