### PR TITLE
add steemitimages.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -582,6 +582,7 @@ staticflickr.com
 steampowered.com
 store.akamai.steamstatic.com
 steamusercontent.com
+steemitimages.com
 stripe.com
 stripecdn.com
 surveygizmo.com


### PR DESCRIPTION
From:
https://steemit.com/
https://steem.buzz/
and so on.