### PR TITLE
Add RTL locale support to replacement widgets

### DIFF
--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -49,7 +49,7 @@
 let trackerInfo;
 
 // cached chrome.i18n.getMessage() results
-const TRANSLATIONS = [];
+const TRANSLATIONS = {};
 
 // references to widget page elements
 const WIDGET_ELS = {};
@@ -123,6 +123,7 @@ function _createReplacementButtonImageCallback(tracker, trackerElem, callback) {
 
   button.setAttribute("src", buttonUrl);
 
+  // TODO use custom tooltip to support RTL locales?
   button.setAttribute(
     "title",
     TRANSLATIONS.social_tooltip_pb_has_replaced.replace("XXX", tracker.name)
@@ -315,6 +316,9 @@ function createReplacementWidget(name, icon, elToReplace) {
     "width: 100%",
     "height: 100%",
   ];
+  if (TRANSLATIONS.rtl) {
+    styleAttrs.push("direction: rtl");
+  }
   widgetDiv.style = styleAttrs.join(" !important;") + " !important";
 
   // child div styles

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -555,7 +555,8 @@ function _isTabAnExtension(tabId) {
  */
 let getWidgetBlockList = (function () {
   // cached translations
-  let translations = [];
+  let translations;
+
   // inputs to chrome.i18n.getMessage()
   const widgetTranslations = [
     {
@@ -572,11 +573,16 @@ let getWidgetBlockList = (function () {
 
     // optimize translation lookups by doing them just once
     // the first time they are needed
-    if (!translations.length) {
+    if (!translations) {
       translations = widgetTranslations.reduce((memo, data) => {
         memo[data.key] = chrome.i18n.getMessage(data.key, data.placeholders);
         return memo;
       }, {});
+
+      // TODO duplicated in src/lib/i18n.js
+      const RTL_LOCALES = ['ar', 'he', 'fa'],
+        UI_LOCALE = chrome.i18n.getMessage('@@ui_locale');
+      translations.rtl = RTL_LOCALES.indexOf(UI_LOCALE) > -1;
     }
 
     badger.widgetList.forEach(function (widget) {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -38,9 +38,9 @@ function setTextDirection() {
 
   // https://www.w3.org/International/questions/qa-scripts#examples
   // https://developer.chrome.com/webstore/i18n?csw=1#localeTable
-  const RTL_LANGS = ['ar', 'he', 'fa'];
-
-  if (RTL_LANGS.indexOf(i18n.getMessage('@@ui_locale')) == -1) {
+  // TODO duplicated in src/js/webrequest.js
+  const RTL_LOCALES = ['ar', 'he', 'fa'];
+  if (RTL_LOCALES.indexOf(i18n.getMessage('@@ui_locale')) == -1) {
     return;
   }
 


### PR DESCRIPTION
This adds RTL support to the "rich" replacement widget (some examples in #2262).

Before:
![Screenshot from 2020-04-22 13-03-04](https://user-images.githubusercontent.com/794578/80011608-19266c80-849a-11ea-8e54-69c0817390bb.png)

After:
![Screenshot from 2020-04-22 13-03-30](https://user-images.githubusercontent.com/794578/80011620-1cb9f380-849a-11ea-8f31-ecdfa8876cc8.png)

Unfortunately, we can't simply set the text direction for the HTML title attribute we use to provide our tooltip for social button replacements ([ShareMeNot test page](https://sharemenot.cs.washington.edu/Test%20Installation.shtml)). RTL locale (`ar`, `he`, `fa`) translators can work around this bug for now by manually adjusting text order.