### PR TITLE
Allow LinkBlanker Extension and PB to Operate Together on Google Search Results

### DIFF
--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -18,9 +18,18 @@ function cleanLink(a) {
   }
   a.rel = "noreferrer noopener";
 
-  // block event listeners on the link
-  a.addEventListener("click", function (e) { e.stopImmediatePropagation(); }, true);
-  a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
+  // hacky way to see if LinkBlanker extension is installed, and if so, let that take priority in bubbling process
+  let linkBlankerUrl = 'chrome-extension://lkafdfakakndhpcpccjnclopfncckhfn/img/icon-enabled.svg';
+
+  // must use old school action here bc native fetch requires the http or https prefix
+  let xmlHttp = new XMLHttpRequest();
+  xmlHttp.open("GET", linkBlankerUrl, false);
+  xmlHttp.send(null);
+  if (!xmlHttp.status || xmlHttp.status !== 200) {
+    // block event listeners on the link
+    a.addEventListener("click", function (e) { e.stopImmediatePropagation(); }, true);
+    a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
+  }
 }
 
 // TODO race condition; fix waiting on https://crbug.com/478183


### PR DESCRIPTION
Fixes #2543 by removing the two lines of code that block event listeners on links in Google domains. I believe that link tracking protection would still be in place, as the attributes are still being pared down to only the bare essentials. The Link Blanker extension, or any other extension that relies on event listeners to modify attributes on links (perhaps accessibility focused ones) would then continue to work as expected even with Privacy Badger installed.