### PR TITLE
More right-to-left (RTL) locale fixes

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -32,7 +32,9 @@ function setTextDirection() {
     let $els = $(selector);
     $els.each(i => {
       let $el = $($els[i]);
-      $el.css(property, $el.css(property) === from ? to : from);
+      if ($el.css(property) === from) {
+        $el.css(property, to);
+      }
     });
   }
 
@@ -87,6 +89,15 @@ function setTextDirection() {
     // fix floats
     ['.btn-silo', '.btn-silo div', '#whitelistForm > div > div > div'].forEach((selector) => {
       toggle_css_value(selector, "float", "left", "right");
+    });
+
+  // new user welcome page
+  } else if (document.location.pathname == "/skin/firstRun.html") {
+    [
+      '[id*="pb-features-"] h3,#pb-settings h3',
+      '[id*="pb-features-"] .text,[id*="pb-features-"] p,#pb-settings .text,#pb-settings p'
+    ].forEach((selector) => {
+      toggle_css_value(selector, "text-align", "left", "right");
     });
   }
 }

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -59,8 +59,10 @@ a:hover { color: #ec9329 }
     padding: 5px;
     height: 40px;
     overflow: hidden;
-    direction: ltr;
     line-height: normal;
+}
+.clicker:not(#not-yet-blocked-header):not(#non-trackers-header) {
+    direction: ltr;
 }
 .origin{
   max-width: 210px;


### PR DESCRIPTION
Domain list headers before:

![Screenshot from 2020-04-30 17-06-16](https://user-images.githubusercontent.com/794578/80759628-98084e80-8b05-11ea-9e02-06008356055f.png)

Domain list headers after:

![Screenshot from 2020-04-30 17-05-40](https://user-images.githubusercontent.com/794578/80759633-9b033f00-8b05-11ea-988b-b4700b5f2110.png)

Intro page headers/paragraphs before:

![Screenshot from 2020-04-30 17-03-41](https://user-images.githubusercontent.com/794578/80759686-b2dac300-8b05-11ea-98a6-8d22008226c8.png)

Intro page headers/paragraphs after:

![Screenshot from 2020-04-30 17-04-15](https://user-images.githubusercontent.com/794578/80759694-b5d5b380-8b05-11ea-9bf0-4d494aa50ba2.png)

As far as remaining known RTL locale bugs, all popup/options page tooltips in Firefox display incorrectly for RTL locales. This will be fixed when we restore custom tooltips to Firefox (#1814).

Follows up on #2592.