### PR TITLE
Update MDFP list for Discord

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -721,6 +721,7 @@ var multiDomainFirstPartiesArray = [
     "directferries.xyz",
   ],
   ["discountbank.co.il", "telebank.co.il"],
+  ["discord.com", "discordapp.com"],
   ["discover.com", "discovercard.com"],
   [
     "dpgmediagroup.com",

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -721,7 +721,7 @@ var multiDomainFirstPartiesArray = [
     "directferries.xyz",
   ],
   ["discountbank.co.il", "telebank.co.il"],
-  ["discord.com", "discordapp.com"],
+  ["discord.com", "discordapp.com", "discordapp.net"],
   ["discover.com", "discovercard.com"],
   [
     "dpgmediagroup.com",


### PR DESCRIPTION
Discord has recently moved its parts of its website from `discordapp.com` to `discord.com`.

We've received reports that our CDN (which remains at `cdn.discordapp.com`), among other things, may be blocked by Privacy Badger on `discord.com`. (https://www.reddit.com/r/discordapp/comments/gdhc83/discord_has_changed_its_domain_to_discordcom/fpherje?utm_source=share&utm_medium=web2x)

Let me know if you need to change something else as well.
