### PR TITLE
Add immobilienscout24.de domains to MDFP

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -324,6 +324,8 @@ imgfarm.com
 imgspice.com
 imgur.com
 imgix.net
+static-immobilienscout24.de
+www.static-immobilienscout24.de
 imshopping.com
 inergizedigital.com
 inq.com

--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -324,8 +324,6 @@ imgfarm.com
 imgspice.com
 imgur.com
 imgix.net
-static-immobilienscout24.de
-www.static-immobilienscout24.de
 imshopping.com
 inergizedigital.com
 inq.com

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1528,6 +1528,10 @@ var multiDomainFirstPartiesArray = [
     "tribunaexpresso.pt",
     "volantesic.pt",
   ],
+  [
+    "immobilienscout24.de",
+    "static-immobilienscout24.de",
+  ],
   ["independent.co.uk", "indy100.com"],
   [
     "jd.com",


### PR DESCRIPTION
The page immobilienscout24.de relys on static assets served by the
related static hosts. Because of this I would like to request adding
these domains to the yellowlist.