### PR TITLE
Wait for async migrations upon extension initialization

### DIFF
--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -27,22 +27,7 @@ let exports = {};
 exports.Migrations= {
   changePrivacySettings: noop,
   migrateAbpToStorage: noop,
-
-  migrateBlockedSubdomainsToCookieblock: function(badger) {
-    setTimeout(function() {
-      console.log('MIGRATING BLOCKED SUBDOMAINS THAT ARE ON COOKIE BLOCK LIST');
-      let ylist = badger.storage.getStore('cookieblock_list');
-      badger.storage.getAllDomainsByPresumedAction(constants.BLOCK).forEach(fqdn => {
-        utils.explodeSubdomains(fqdn, true).forEach(domain => {
-          if (ylist.hasItem(domain)) {
-            console.log('moving', fqdn, 'from block to cookie block');
-            badger.storage.setupHeuristicAction(fqdn, constants.COOKIEBLOCK);
-          }
-        });
-      });
-    }, 1000 * 30);
-  },
-
+  migrateBlockedSubdomainsToCookieblock: noop,
   migrateLegacyFirefoxData: noop,
 
   migrateDntRecheckTimes: function(badger) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1179,14 +1179,16 @@ function dispatcher(request, sender, sendResponse) {
 
   case "mergeUserData": {
     // called when a user imports data exported from another Badger instance
-    badger.mergeUserData(request.data);
-    badger.blockWidgetDomains();
-    badger.setPrivacyOverrides();
-    sendResponse({
-      disabledSites: badger.getDisabledSites(),
-      origins: badger.storage.getTrackingDomains(),
+    badger.mergeUserData(request.data).then(() => {
+      badger.blockWidgetDomains();
+      badger.setPrivacyOverrides();
+      sendResponse({
+        disabledSites: badger.getDisabledSites(),
+        origins: badger.storage.getTrackingDomains(),
+      });
     });
-    break;
+    // indicate this is an async response to chrome.runtime.onMessage
+    return true;
   }
 
   case "updateSettings": {
@@ -1203,9 +1205,11 @@ function dispatcher(request, sender, sendResponse) {
   }
 
   case "setPrivacyOverrides": {
-    badger.setPrivacyOverrides();
-    sendResponse();
-    break;
+    badger.setPrivacyOverrides().then(() => {
+      sendResponse();
+    });
+    // indicate this is an async response to chrome.runtime.onMessage
+    return true;
   }
 
   case "updateBadge": {


### PR DESCRIPTION
Follows up on #2438 by gating remaining asynchronous initialization tasks behind `badger.INITIALIZED`.

~~May help avoid test failures like https://travis-ci.org/github/EFForg/privacybadger/jobs/684005771 where for some reason we don't have anything in `tabData.origins` at the time `getWidgetList()` is called. While this problem seems related to async migrations, it's not yet clear what it is exactly. It is consistently reproducible with Firefox 52 (the previous ESR version) though. Since this issue only manifests immediately following Badger initialization (waiting two seconds avoids it), it doesn't seem to be a release blocker.~~ (waiting on widget initialization happened in c8313e4b150bdc6ec3e69e62f10f09006f4ae8a1)

Should help categorically avoid bugs like #2537, where there is a race condition between two migrations or between a migration and the rest of Privacy Badger.

We should also stop running migrations upon installation.