### PR TITLE
Update Facebook link selector

### DIFF
--- a/src/js/firstparties/facebook.js
+++ b/src/js/firstparties/facebook.js
@@ -2,7 +2,7 @@
 // Adapted from https://github.com/mgziminsky/FacebookTrackingRemoval
 // this should only run on facebook.com, messenger.com, and
 // facebookcorewwwi.onion
-let fb_wrapped_link = `a[href*='${document.domain.split(".").slice(-2).join(".")}/l.php?']:not([aria-label])`;
+let fb_wrapped_link = `a[href*='${document.domain.split(".").slice(-2).join(".")}/l.php?'][data-lynx-mode='async']`;
 
 // remove all attributes from a link except for class and ARIA attributes
 function cleanAttrs(elem) {


### PR DESCRIPTION
Remove old rule excluding links with the aria-label attribute (which now excludes all news feed links) and replace it with a filter for data-lynx-mode='async'. Closes #2605.