### PR TITLE
color change when hover on trackers link in popup

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -280,6 +280,9 @@ font-size: 16px;
     font-size: 18px;
     font-family: "Chunk-Five", serif;
 }
+#pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_one_tracker):not(#options_domain_list_no_trackers) a:hover {
+    color: #ec9329
+}
 #instructions_no_trackers, #special-browser-page, #disabled-site-message {
     text-align: center;
     margin: 45px 0;


### PR DESCRIPTION
I noticed that #2600 had a change originally proposed in the PR to make the trackers link change to the PB signature orange when hovered, but that change got lost in one of the later commits when the css selectors got changed. 

<img width="431" alt="Screen Shot 2020-05-17 at 8 41 06 PM" src="https://user-images.githubusercontent.com/25778052/82172825-2c9ddb00-9880-11ea-8edf-f4286280076e.png">
<img width="432" alt="Screen Shot 2020-05-17 at 8 41 41 PM" src="https://user-images.githubusercontent.com/25778052/82172829-2dcf0800-9880-11ea-9123-f42fae69555e.png">

What do the badgers want? Orange tracker links. When do they want them? When the links are hovered.
