### PR TITLE
Improve message used in widget placeholders

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -516,12 +516,22 @@
         "description": ""
     },
     "social_tooltip_pb_has_replaced": {
-        "message": "Privacy Badger has replaced this $BUTTON$ button.",
-        "description": "Tooltip shown over a replaced social button. For example, \"... replaced this Facebook Like button.\"",
+        "message": "Privacy Badger has replaced this $BUTTON$ button",
+        "description": "Tooltip shown over a replaced social button. For example, \"Privacy Badger has replaced this Facebook Like button\". See also the widget_placeholder_pb_has_replaced message.",
         "placeholders": {
             "button": {
                 "content": "$1",
                 "example": "Facebook Like"
+            }
+        }
+    },
+    "widget_placeholder_pb_has_replaced": {
+        "message": "Privacy Badger has replaced this $WIDGET$ widget",
+        "description": "Text shown inside a replaced widget's placeholder. For example, \"Privacy Badger has replaced this Google reCAPTCHA widget\". See also the social_tooltip_pb_has_replaced message.",
+        "placeholders": {
+            "widget": {
+                "content": "$1",
+                "example": "Google reCAPTCHA"
             }
         }
     },

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -390,7 +390,7 @@ function createReplacementWidget(tracker, icon, elToReplace, activationFn) {
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
   textDiv.appendChild(document.createTextNode(
-    TRANSLATIONS.social_tooltip_pb_has_replaced.replace("XXX", name)));
+    TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)));
   widgetDiv.appendChild(textDiv);
 
   let buttonDiv = document.createElement('div');

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -564,6 +564,10 @@ let getWidgetList = (function () {
       key: "social_tooltip_pb_has_replaced",
       placeholders: ["XXX"]
     },
+    {
+      key: "widget_placeholder_pb_has_replaced",
+      placeholders: ["XXX"]
+    },
     { key: "allow_once" },
   ];
 

--- a/tests/selenium/widgets_test.py
+++ b/tests/selenium/widgets_test.py
@@ -116,7 +116,7 @@ class WidgetsTest(pbtest.PBSeleniumTest):
 
         try:
             self.wait_for_text('body', (
-                "Privacy Badger has replaced this {} button"
+                "Privacy Badger has replaced this {} widget"
             ).format(widget_name))
         except TimeoutException:
             self.fail("Unable to find expected replacement widget text")


### PR DESCRIPTION
This updates the message used inside widget placeholders:

```diff
-Privacy Badger has replaced this $BUTTON$ button.
+Privacy Badger has replaced this $WIDGET$ widget
```

Where `$WIDGET$` is one of "Google reCAPTCHA", "SoundCloud", "Spotify Player", "Streamable Player", "Vimeo", "YouTube".