### PR TITLE
[MDFP] added domains of austrian channels from prosiebensat1.com

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -2474,6 +2474,8 @@ var multiDomainFirstPartiesArray = [
     "prosiebensat1.de",
     "prosiebensat1.com",
 
+    "atv.at",
+    "atv2.at",
     "galileo.tv",
     "kabeleins.at",
     "kabeleins.ch",
@@ -2487,6 +2489,8 @@ var multiDomainFirstPartiesArray = [
     "prosiebenmaxx.at",
     "prosiebenmaxx.ch",
     "prosiebenmaxx.de",
+    "puls24.at",
+    "puls4.com",
     "puls8.ch",
     "ran.de",
     "sat1.at",


### PR DESCRIPTION
added domains of austrian channels from prosiebensat1.com as you can [see at wikipedia](https://en.wikipedia.org/wiki/ProSiebenSat.1_Media#Divisions), additionally to #2572 & #2573.

similar to #2570 `component.player.p7s1.io` & `config.player.p7s1.io` is needed for the player on...
- https://www.atv.at/livestream
- https://www.atv2.at/livestream
- https://news.puls24.at/
- https://www.puls4.com/live-551