### PR TITLE
Re-enable Tooltipster tooltips on Firefox

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -17,17 +17,6 @@
 
 window.OPTIONS_INITIALIZED = false;
 
-// TODO hack: disable Tooltipster tooltips on Firefox to avoid unresponsive script warnings
-(function () {
-const matches = navigator.userAgent.match(
-  // from https://gist.github.com/ticky/3909462
-  /(MSIE|(?!Gecko.+)Firefox|(?!AppleWebKit.+Chrome.+)Safari|(?!AppleWebKit.+)Chrome|AppleWebKit(?!.+Chrome|.+Safari)|Gecko(?!.+Firefox))(?: |\/)([\d.apre]+)/
-);
-if (!matches || matches[1] == "Firefox") {
-  $.fn.tooltipster = function () {};
-}
-}());
-
 const TOOLTIP_CONF = {
   maxWidth: 200
 };

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -26,18 +26,6 @@ var htmlUtils = require("htmlutils").htmlUtils;
 
 let POPUP_DATA = {};
 
-// TODO hack: disable Tooltipster tooltips on Firefox
-// to avoid hangs on pages with enough domains to produce a scrollbar
-(function () {
-const matches = navigator.userAgent.match(
-  // from https://gist.github.com/ticky/3909462
-  /(MSIE|(?!Gecko.+)Firefox|(?!AppleWebKit.+Chrome.+)Safari|(?!AppleWebKit.+)Chrome|AppleWebKit(?!.+Chrome|.+Safari)|Gecko(?!.+Firefox))(?: |\/)([\d.apre]+)/
-);
-if (!matches || matches[1] == "Firefox") {
-  $.fn.tooltipster = function () {};
-}
-}());
-
 /* if they aint seen the comic*/
 function showNagMaybe() {
   var nag = $("#instruction");


### PR DESCRIPTION
Fixes #1814.

Following up on https://github.com/EFForg/privacybadger/pull/2629#issuecomment-646095710.