### PR TITLE
Style remaining popup buttons

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -79,7 +79,7 @@ function showNagMaybe() {
     });
   } else if (POPUP_DATA.criticalError) {
     $('#instruction-text').hide();
-    $('#error-text').show().find('a').attr('id', 'firstRun').css('padding', '5px');
+    $('#error-text').show().find('a').attr('id', 'critical-error-link').css('padding', '5px');
     $('#error-message').text(POPUP_DATA.criticalError);
     _showNag();
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -334,11 +334,12 @@ function deactivateOnSite() {
  */
 function share() {
   $("#share_overlay").toggleClass('active');
-  let shareMessage = chrome.i18n.getMessage("share_base_message");
+  let share_msg = chrome.i18n.getMessage("share_base_message");
 
-  //Only add language about found trackers if we actually found trackers (but regardless of whether we are actually blocking them).
+  // only add language about found trackers if we actually found trackers
+  // (but regardless of whether we are actually blocking them)
   if (POPUP_DATA.noTabData) {
-    $("#share_output").val(shareMessage);
+    $("#share_output").val(share_msg);
     return;
   }
 
@@ -349,7 +350,7 @@ function share() {
   }
 
   if (!originsArr.length) {
-    $("#share_output").val(shareMessage);
+    $("#share_output").val(share_msg);
     return;
   }
 
@@ -365,13 +366,13 @@ function share() {
   }
 
   if (tracking.length) {
-    shareMessage += "\n\n" + chrome.i18n.getMessage("share_tracker_header", [tracking.length, POPUP_DATA.tabHost]) + "\n\n";
-
-    for (let i=0; i < tracking.length; i++) {
-      shareMessage += tracking[i] + "\n";
-    }
+    share_msg += "\n\n";
+    share_msg += chrome.i18n.getMessage(
+      "share_tracker_header", [tracking.length, POPUP_DATA.tabHost]);
+    share_msg += "\n\n";
+    share_msg += tracking.join("\n");
   }
-  $("#share_output").val(shareMessage);
+  $("#share_output").val(share_msg);
 }
 
 /**

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -52,7 +52,7 @@ function showNagMaybe() {
       e.preventDefault();
       _hideNag();
     });
-    $("#firstRun").on("click", function() {
+    $("#firstRun").on("click", function () {
       // If there is a firstRun.html tab, switch to the tab.
       // Otherwise, create a new tab
       chrome.tabs.query({url: firstRunUrl}, function (tabs) {
@@ -66,6 +66,7 @@ function showNagMaybe() {
           });
         }
         _hideNag();
+        window.close();
       });
     });
   }
@@ -192,6 +193,8 @@ function openOptionsPage() {
       delete tabProps.openerTabId;
       chrome.tabs.create(tabProps);
     }
+
+    window.close();
   });
 }
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -119,13 +119,13 @@ function init() {
   $("#error").on("click", function() {
     overlay.toggleClass('active');
   });
-  $("#report_cancel").on("click", function() {
+  $("#report-cancel").on("click", function() {
     clearSavedErrorText();
     closeOverlay();
   });
-  $("#report_button").on("click", function() {
+  $("#report-button").on("click", function() {
     $(this).prop("disabled", true);
-    $("#report_cancel").prop("disabled", true);
+    $("#report-cancel").prop("disabled", true);
     send_error($("#error_input").val());
   });
   $("#report_close").on("click", function (e) {
@@ -162,7 +162,7 @@ function init() {
     e.preventDefault();
     shareOverlay.toggleClass('active', false);
   });
-  $("#copy_button").on("click", function() {
+  $("#copy-button").on("click", function() {
     $("#share_output").select();
     document.execCommand('copy');
     $(this).text(chrome.i18n.getMessage("copy_button_copied"));
@@ -280,8 +280,8 @@ function send_error(message) {
       clearSavedErrorText();
 
       setTimeout(function() {
-        $("#report_button").prop("disabled", false);
-        $("#report_cancel").prop("disabled", false);
+        $("#report-button").prop("disabled", false);
+        $("#report-cancel").prop("disabled", false);
         $("#report_success").toggleClass("hidden", true);
         closeOverlay();
       }, 3000);
@@ -291,8 +291,8 @@ function send_error(message) {
       $("#report_fail").toggleClass("hidden");
 
       setTimeout(function() {
-        $("#report_button").prop("disabled", false);
-        $("#report_cancel").prop("disabled", false);
+        $("#report-button").prop("disabled", false);
+        $("#report-cancel").prop("disabled", false);
         $("#report_fail").toggleClass("hidden", true);
       }, 3000);
     });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -48,7 +48,10 @@ function showNagMaybe() {
     nag.show();
     outer.show();
     // Attach event listeners
-    $('#fittslaw').on("click", _hideNag);
+    $('#fittslaw').on("click", function (e) {
+      e.preventDefault();
+      _hideNag();
+    });
     $("#firstRun").on("click", function() {
       // If there is a firstRun.html tab, switch to the tab.
       // Otherwise, create a new tab
@@ -124,7 +127,8 @@ function init() {
     $("#report_cancel").prop("disabled", true);
     send_error($("#error_input").val());
   });
-  $("#report_close").on("click", function() {
+  $("#report_close").on("click", function (e) {
+    e.preventDefault();
     clearSavedErrorText();
     closeOverlay();
   });
@@ -140,8 +144,8 @@ function init() {
     browser.runtime.getBrowserInfo().then(function (info) {
       if (info.name == "Firefox") {
         $("#options").on("click", function (e) {
-          openOptionsPage();
           e.preventDefault();
+          openOptionsPage();
         });
       }
     });
@@ -150,10 +154,11 @@ function init() {
   let shareOverlay = $("#share_overlay");
 
   $("#share").on("click", function (e) {
-    share();
     e.preventDefault();
+    share();
   });
-  $("#share_close").on("click", function() {
+  $("#share_close").on("click", function (e) {
+    e.preventDefault();
     shareOverlay.toggleClass('active', false);
   });
   $("#copy_button").on("click", function() {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -175,18 +175,13 @@ font-size: 16px;
 
 #firstRun {
   color: #EC9329;
-  text-align: center;
-  border-radius: 3px;
-  margin: 5px 0;
   border: 2px solid #EC9329;
-  height: 68px;
-  padding-top: 24px;
   font-weight: bold;
   font-size: 14px;
+  width: 100%;
 }
 
 #firstRun:hover {
-  cursor: pointer;
   text-decoration: underline;
   background-color: #EC9329;
   color: #333;
@@ -358,8 +353,6 @@ div.overlay.active {
   font-weight: bold;
 }
 #report_button, #report_cancel {
-  cursor: pointer;
-  margin: 2% 2% 0 0;
 }
 #report_success {
   color: green;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -173,7 +173,7 @@ font-size: 16px;
     min-height: 70px;
 }
 
-#firstRun {
+#firstRun, #critical-error-link {
   color: #EC9329;
   border: 2px solid #EC9329;
   font-weight: bold;
@@ -181,7 +181,11 @@ font-size: 16px;
   width: 100%;
 }
 
-#firstRun:hover {
+#critical-error-link {
+    border-radius: 3px;
+}
+
+#firstRun:hover, #critical-error-link:hover {
   text-decoration: underline;
   background-color: #EC9329;
   color: #333;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -246,7 +246,6 @@ font-size: 16px;
   position: relative;
   float: right;
   padding: 0 0 10px 0;
-  cursor: pointer;
 }
 #options, #share, #help {
     float: right;
@@ -375,15 +374,11 @@ div.overlay.active {
   border: 0;
   font-size: 1.2em;
   margin: 0 25;
-  cursor: pointer;
   color: #ccc;
 }
 .overlay_close:before {
   content: '[X]';
   margin: 5px;
-}
-.overlay_close:hover {
-  text-decoration: underline;
 }
 #share_output {
   display: block;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -244,7 +244,7 @@ font-size: 16px;
 #fittslaw {
   position: relative;
   float: right;
-  padding: 0 0 10px 0;
+  margin-bottom: 10px;
 }
 #options, #share, #help {
     float: right;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -282,7 +282,7 @@ font-size: 16px;
     font-size: 12px;
 }
 
-#siteControls {
+#siteControls, #report-controls {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
@@ -356,8 +356,6 @@ div.overlay.active {
   margin: 1% 0;
   font-weight: bold;
 }
-#report_button, #report_cancel {
-}
 #report_success {
   color: green;
 }
@@ -381,11 +379,6 @@ div.overlay.active {
   display: block;
   width: 98%;
   height: 60%;
-}
-#copy_button {
-  cursor: pointer;
-  margin: 2% 2% 0 0;
-  width: 9em;
 }
 #dnt-compliant {
   float: left;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -343,8 +343,8 @@ div.overlay.active {
   opacity: 1;
 }
 #error_input {
-  display: block;
-  width: 70%;
+    display: block;
+    width: 98%;
 }
 .overlay_title {
   display: inline-block;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -75,8 +75,8 @@
     <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
     <button id="report_button" class="i18n_report_button pbButton"></button>
     <button id="report_cancel" class="i18n_report_cancel pbButton"></button>
-    <span id="report_success" class="i18n_report_success hidden"></span>
-    <span id="report_fail" class="i18n_report_fail hidden"></span>
+    <span id="report_success" class="i18n_report_success" style="display:none"></span>
+    <span id="report_fail" class="i18n_report_fail" style="display:none"></span>
     <br><br>
     <p id="report_terms" class="i18n_report_terms"></p>
   </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -58,9 +58,9 @@
     <div id="instruction-text">
         <p class="i18n_intro_text"></p>
         <br>
-        <div id="firstRun">
+        <button id="firstRun" class="pbButton">
           <p class="i18n_first_run_text"></p>
-        </div>
+        </button>
     </div>
     <div id="error-text" style="display:none">
         <p><span class="i18n_extension_error_text"></span></p>
@@ -73,8 +73,8 @@
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
-    <button id="report_button" class="i18n_report_button"></button>
-    <button id="report_cancel" class="i18n_report_cancel"></button>
+    <button id="report_button" class="i18n_report_button pbButton"></button>
+    <button id="report_cancel" class="i18n_report_cancel pbButton"></button>
     <span id="report_success" class="i18n_report_success hidden"></span>
     <span id="report_fail" class="i18n_report_fail hidden"></span>
     <br><br>
@@ -84,7 +84,7 @@
     <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
     <a href="" id="share_close" class="i18n_report_close overlay_close"></a>
     <textarea id="share_output" name="share_output"></textarea>
-    <button id="copy_button" class="i18n_copy_button_initial"></button>
+    <button id="copy_button" class="i18n_copy_button_initial pbButton"></button>
   </div>
 
 <div id='privacyBadgerHeader'>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -73,8 +73,10 @@
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
-    <button id="report_button" class="i18n_report_button pbButton"></button>
-    <button id="report_cancel" class="i18n_report_cancel pbButton"></button>
+    <div id="report-controls">
+      <button id="report-button" class="i18n_report_button pbButton"></button>
+      <button id="report-cancel" class="i18n_report_cancel pbButton"></button>
+    </div>
     <span id="report_success" class="i18n_report_success" style="display:none"></span>
     <span id="report_fail" class="i18n_report_fail" style="display:none"></span>
     <br><br>
@@ -84,7 +86,7 @@
     <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
     <a href="" id="share_close" class="i18n_report_close overlay_close"></a>
     <textarea id="share_output" name="share_output"></textarea>
-    <button id="copy_button" class="i18n_copy_button_initial pbButton"></button>
+    <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
   </div>
 
 <div id='privacyBadgerHeader'>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -51,7 +51,7 @@
   </div>
   <div id="instruction">
     <img id="instruction-logo" src="/icons/badger-48.png" srcset="/icons/badger-128.png 2x" width="48" alt="">
-    <a href="" id="fittslaw"><svg width="30" height="30" fill="white">
+    <a href="" id="fittslaw"><svg width="26" height="22" fill="white">
       <line x1="5" y1="5" x2="20" y2="20" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
       <line x1="5" y1="20" x2="20" y2="5" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
     </svg></a>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -72,7 +72,7 @@
     <a href="" id="report_close" class="i18n_report_close overlay_close"></a>
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
-    <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
+    <textarea id="error_input" name="error_input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
     <div id="report-controls">
       <button id="report-button" class="i18n_report_button pbButton"></button>
       <button id="report-cancel" class="i18n_report_cancel pbButton"></button>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -51,10 +51,10 @@
   </div>
   <div id="instruction">
     <img id="instruction-logo" src="/icons/badger-48.png" srcset="/icons/badger-128.png 2x" width="48" alt="">
-    <svg id="fittslaw" width="30" height="30" fill="white">
+    <a href="" id="fittslaw"><svg width="30" height="30" fill="white">
       <line x1="5" y1="5" x2="20" y2="20" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
       <line x1="5" y1="20" x2="20" y2="5" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
-    </svg>
+    </svg></a>
     <div id="instruction-text">
         <p class="i18n_intro_text"></p>
         <br>
@@ -69,7 +69,7 @@
   </div>
   <div id="overlay" class="overlay">
     <h1 id="report_title" class="i18n_report_title overlay_title"></h1>
-    <span id="report_close" class="i18n_report_close overlay_close"></span>
+    <a href="" id="report_close" class="i18n_report_close overlay_close"></a>
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" placeholder="i18n_error_input"></textarea>
@@ -82,7 +82,7 @@
   </div>
   <div id="share_overlay" class="overlay">
     <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
-    <span id="share_close" class="i18n_report_close overlay_close"></span>
+    <a href="" id="share_close" class="i18n_report_close overlay_close"></a>
     <textarea id="share_output" name="share_output"></textarea>
     <button id="copy_button" class="i18n_copy_button_initial"></button>
   </div>

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -11,7 +11,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
-from pbtest import retry_until
 from window_utils import switch_to_window_with_url
 
 
@@ -107,12 +106,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.driver.find_element_by_id("firstRun").click()
 
         # Look for first run page and return if found.
-        for window in self.driver.window_handles:
-            self.driver.switch_to.window(window)
-            if self.driver.current_url == self.first_run_url:
-                return
-
-        self.fail("First run comic not opened after clicking link in popup overlay")
+        switch_to_window_with_url(self.driver, self.first_run_url)
 
     def test_help_button(self):
         """Ensure first run page is opened when help button is clicked."""
@@ -126,28 +120,13 @@ class PopupTest(pbtest.PBSeleniumTest):
             self.fail("First run comic not opened in new window")
 
         # Look for first run page and return if found.
-        for window in self.driver.window_handles:
-            self.driver.switch_to.window(window)
-            if self.driver.current_url == self.first_run_url:
-                return
-
-        self.fail("First run comic not opened after clicking help button on popup")
+        switch_to_window_with_url(self.driver, self.first_run_url)
 
     def test_options_button(self):
         """Ensure options page is opened when button is clicked."""
         self.open_popup()
-
         self.driver.find_element_by_id("options").click()
-
-        # Look for options page and return if found.
-        def options_page_was_opened():
-            for window in self.driver.window_handles:
-                self.driver.switch_to.window(window)
-                if self.driver.current_url == self.options_url:
-                    return True
-        # options page is opened asynchronously in Firefox
-        if not retry_until(options_page_was_opened, msg="Retrying options page lookup ..."):
-            self.fail("Options page not opened after clicking options button on popup")
+        switch_to_window_with_url(self.driver, self.options_url)
 
     @pbtest.repeat_if_failed(5)
     def test_trackers_link(self):

--- a/tests/selenium/window_utils.py
+++ b/tests/selenium/window_utils.py
@@ -13,16 +13,15 @@ import time
 from selenium.common.exceptions import NoSuchWindowException
 
 
-def switch_to_window_with_url(driver, url, max_tries=20):
+def switch_to_window_with_url(driver, url, max_tries=5):
     """Point the driver to the first window that matches this url."""
 
     for _ in range(max_tries):
-        windows = get_windows_with_url(driver, url)
-
-        if windows:
-            # if multiple tabs point at this url, switch to the first one
+        for w in driver.window_handles:
             try:
-                driver.switch_to.window(windows[0])
+                driver.switch_to.window(w)
+                if driver.current_url != url:
+                    continue
             except NoSuchWindowException:
                 pass
             else:
@@ -30,7 +29,7 @@ def switch_to_window_with_url(driver, url, max_tries=20):
 
         time.sleep(1)
 
-    raise Exception("was not able to find window for url " + url)
+    raise Exception("Failed to find window for " + url)
 
 
 def refresh_window_with_url(driver, url, max_tries=20):


### PR DESCRIPTION
Styled:
- "Submit Error" / "Cancel" buttons on the "Did Privacy Badger break this site?" (broken site report) overlay
- "Copy to clipboard" button on the Share overlay

Updated to inherit from standard Badger button styles:
- Welcome page link on the reminder overlay
- "Tell us" link on the critical error overlay

Overlay close links (in the upper right) are now keyboard-navigable:
- The SVG "X" on the new user welcome page reminder overlay
- The "[X] close" links on the Share/broken site report overlays

This does not fix keyboard navigation issues described in https://github.com/EFForg/privacybadger/pull/2629#issuecomment-646101693.