### PR TITLE
help button in popup now links to FAQ page

### DIFF
--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -90,7 +90,7 @@
 <div id='privacyBadgerHeader'>
   <a id="options" title="i18n_popup_options_button" href='/skin/options.html' class="control-button tooltip" style="display:block" target="_blank"><img width="25" src="/icons/options.svg" alt="i18n_popup_options_button"></a>
   <a id="share" href="" title="i18n_popup_share_button" class="control-button tooltip" style="display:block" target="_blank"><img width="23" height="auto" src="/icons/share.svg" alt="i18n_popup_share_button"></a>
-  <a id="help" title="i18n_popup_help_button" href='/skin/firstRun.html' class="control-button tooltip" style="display:block" target="_blank"><img width="25" src="/icons/help.svg" alt="i18n_popup_help_button"></a>
+  <a id="help" title="i18n_popup_help_button" href='https://privacybadger.org/#faq' class="control-button tooltip" style="display:block" target="_blank"><img width="25" src="/icons/help.svg" alt="i18n_popup_help_button"></a>
   <div id='title'>
     <img src="../icons/badger-bw-noborder.svg" width="48" alt="" id="badger-header-logo">
     <div id='header-image-stack'>


### PR DESCRIPTION
Fixes #2624. Follows up on https://github.com/EFForg/privacybadger/pull/2627#issuecomment-654467536.

This PR changes the `href` of the help button in the popup to now direct the user to the FAQ page.