### PR TITLE
Add dark mode styles

### DIFF
--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -68,6 +68,9 @@ p, #settingsForm {
 #allowlist-form {
     margin: 20px 0 0;
 }
+#allowlist-select {
+    width: 100%;
+}
 
 #pbInstructions {
   margin-bottom: 20px;
@@ -213,4 +216,31 @@ p, #settingsForm {
 }
 #tabs .ui-tabs-nav li a:focus {
     outline: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    hr {
+        background-color: #aaa;
+    }
+
+    #tabs .ui-widget-header {
+        border-bottom: 1px solid #aaa;
+    }
+    #tabs .ui-tabs-nav .ui-state-hover a,
+    #tabs .ui-tabs-nav .ui-state-active a {
+        color: #ddd;
+    }
+
+    .ui-widget-content, .ui-widget-content a, #tracking-domains-filters {
+        color: #ddd;
+    }
+
+    #settings-suffix {
+        color: #aaa;
+    }
+
+    input[type=text], select {
+        background-color: #333;
+        color: #ddd;
+    }
 }

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -150,7 +150,7 @@
         </div>
         <div style="clear: both; overflow: hidden">
           <div style="float: left; max-width: 420px; width: 100%; margin-right: 10px; padding-top: 5px">
-            <select id="allowlist-select" size="10" multiple style="width: 100%; background: white;"></select>
+            <select id="allowlist-select" size="10" multiple></select>
           </div>
           <div style="float:left; padding-top: 5px">
             <button id="remove-disabled-site"><span class="i18n_remove_button"></span></button>

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -453,3 +453,39 @@ div.overlay.active {
         margin-right: 0px;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    body, .pbButton, .key, #privacyBadgerHeader h2, #instruction, #pbInstructions, #special-browser-page, #disabled-site-message {
+        background-color: #333;
+        color: #ddd;
+    }
+
+    #pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_one_tracker):not(#options_domain_list_no_trackers) a {
+        color: #ddd;
+    }
+
+    #fittslaw svg line {
+        stroke: #fff !important;
+    }
+    #fittslaw svg:hover line {
+        stroke: #ec9329 !important;
+    }
+    #instruction-outer {
+        background-color: #fff;
+    }
+
+    .clickerContainer {
+        background-color: #666;
+    }
+    .clicker {
+        border-top: 1px solid #aaa;
+    }
+    .origin {
+        color: #ddd;
+    }
+
+    textarea {
+        background-color: #333;
+        color: #ddd;
+    }
+}


### PR DESCRIPTION
Fixes #2630.

TODO new user welcome page, dark mode options/share/help SVGs, misc. tweaks, screenshots

To test in Firefox, visit `about:config` and add the `ui.systemUsesDarkTheme` flag set to 1.