### PR TITLE
Improve disabled site popup ui

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -438,7 +438,7 @@ function refreshPopup() {
     $("#activate_site_btn").show();
     $("#deactivate_site_btn").hide();
     $("#disabled-site-message").show();
-    $("#title").toggleClass("disabled_site_popup");
+    $("#title").addClass("faded-bw-color-scheme");
   }
 
   // if there is any saved error text, fill the error input with it

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -438,7 +438,8 @@ function refreshPopup() {
     $("#activate_site_btn").show();
     $("#deactivate_site_btn").hide();
     $("#disabled-site-message").show();
-    $("#privacyBadgerHeader").toggleClass("disabled-site-popup");
+    $("#privacyBadgerHeader").toggleClass("disabled_site_popup");
+    $(".ui-icon-heart").attr("style", "color:#808080");
   }
 
   // if there is any saved error text, fill the error input with it

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -438,6 +438,7 @@ function refreshPopup() {
     $("#activate_site_btn").show();
     $("#deactivate_site_btn").hide();
     $("#disabled-site-message").show();
+    $("#privacyBadgerHeader").toggleClass("disabled-site-popup");
   }
 
   // if there is any saved error text, fill the error input with it

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -438,8 +438,7 @@ function refreshPopup() {
     $("#activate_site_btn").show();
     $("#deactivate_site_btn").hide();
     $("#disabled-site-message").show();
-    $("#privacyBadgerHeader").toggleClass("disabled_site_popup");
-    $(".ui-icon-heart").attr("style", "color:#808080");
+    $("#title").toggleClass("disabled_site_popup");
   }
 
   // if there is any saved error text, fill the error input with it

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -412,7 +412,7 @@ div.overlay.active {
   float: left;
 }
 .disabled_site_popup {
-    filter: grayscale(100%);
+    filter: grayscale(1) opacity(0.6);
 }
 
 .tooltipster-sidetip .tooltipster-box {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -411,7 +411,7 @@ div.overlay.active {
   font-size: 10px;
   float: left;
 }
-.disabled_site_popup {
+.faded-bw-color-scheme {
     filter: grayscale(1) opacity(0.6);
 }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -411,7 +411,7 @@ div.overlay.active {
   font-size: 10px;
   float: left;
 }
-.disabled_site_popup, img {
+.disabled_site_popup {
     filter: grayscale(100%);
 }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -411,6 +411,9 @@ div.overlay.active {
   font-size: 10px;
   float: left;
 }
+.disabled_site_popup, img {
+    filter: grayscale(100%);
+}
 
 .tooltipster-sidetip .tooltipster-box {
     color: #fcfcfc;


### PR DESCRIPTION
In recent conversation it was brought up that the popup UI could be improved on sites that Privacy Badger is disabled on. Specifically that the popup could better reflect the state of PB being "turned off."

There are a couple of proposed changes here. One is greying out just the color of the EFF logo when PB is turned off on a site:

![Screen Shot 2020-07-21 at 9 39 56 AM](https://user-images.githubusercontent.com/25778052/88088297-0a099600-cb3f-11ea-80a3-10b85245d88f.png)


And the other option greys out both the EFF logo and the little heart on the donate button:

![Screen Shot 2020-07-21 at 10 39 26 AM](https://user-images.githubusercontent.com/25778052/88088366-1ee62980-cb3f-11ea-9f54-a16307169fff.png)


I'm of no hard opinion either way, but figured I'd present both options here. What's not considered in either of these options is whether or not to also remove the hover effect that changes the border color on the buttons to orange. Is that worth adding as well?

@ghostwords @andresbase 