### PR TITLE
Override more browser privacy settings

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -249,21 +249,14 @@ Badger.prototype = {
     }
 
     if (chrome.privacy.websites) {
-      _set_override(
-        "hyperlinkAuditingEnabled",
-        chrome.privacy.websites.hyperlinkAuditingEnabled,
-        false
-      );
-      _set_override(
-        "thirdPartyCookiesAllowed",
-        chrome.privacy.websites.thirdPartyCookiesAllowed,
-        false
-      );
-      _set_override(
-        "referrersEnabled",
-        chrome.privacy.websites.referrersEnabled,
-        false
-      );
+      let privacy_settings = ["hyperlinkAuditingEnabled", "thirdPartyCookiesAllowed", "referrersEnabled"];
+      privacy_settings.forEach((setting) => {
+        _set_override(
+          setting,
+          chrome.privacy.websites[setting],
+          false
+        );
+      });
     }
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -254,6 +254,16 @@ Badger.prototype = {
         chrome.privacy.websites.hyperlinkAuditingEnabled,
         false
       );
+      _set_override(
+        "thirdPartyCookiesAllowed",
+        chrome.privacy.websites.thirdPartyCookiesAllowed,
+        false
+      );
+      _set_override(
+        "referrersEnabled",
+        chrome.privacy.websites.referrersEnabled,
+        false
+      );
     }
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -248,6 +248,7 @@ Badger.prototype = {
       );
     }
 
+    // set relevant settings on privacy.websites api to false
     if (chrome.privacy.websites) {
       let privacy_settings = ["hyperlinkAuditingEnabled", "thirdPartyCookiesAllowed", "referrersEnabled"];
       privacy_settings.forEach((setting) => {
@@ -257,6 +258,12 @@ Badger.prototype = {
           false
         );
       });
+      // firefox only
+      _set_override(
+        "resistFingerprinting",
+        chrome.privacy.websites.resistFingerprinting,
+        true
+      );
     }
   },
 


### PR DESCRIPTION
Fixes #1897 and is related to #740. 

This PR adds a few more privacy settings to be overridden by PB on the different respective APIs. Browser support for these spans across Firefox, Chrome, Opera, and Edge.

this toggles the `thirdPartyCookiesAllowed` and `referrersEnabled` settings to false, and the Firefox only setting `resistFingerprinting` to true.

I also added a bit of optimization to the way that PB flips the different `chrome.privacy.websites` settings to false. it was getting a little repetitive.

As of now, it doesn't give the user the option to toggle these override settings through the PB options page... is that a piece of functionality we want to add, or should we keep that hands off and override these by default? On the one hand, I see how giving the option is good for power users, but on the other hand, I think overriding by default lends itself to the "hands-off" approach we are trying to steer more towards lately.