### PR TITLE
Expose privacy overrides in options

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -261,6 +261,14 @@
         "message": "General Settings",
         "description": "This is an options page tab heading."
     },
+    "options_privacy_settings": {
+        "message": "Privacy",
+        "description": "Subheading on the general settings options page."
+    },
+    "options_advanced_settings": {
+        "message": "Advanced",
+        "description": "Subheading on the general settings options page."
+    },
     "intro_next_button": {
         "message": "Take the tour",
         "description": "Intro page welcome button."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -369,6 +369,10 @@
         "message": "Send websites the \"<a href='https://www.eff.org/issues/do-not-track' target='_blank'>Do Not Track</a>\" signal",
         "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
     },
+    "options_alternateErrorPagesEnabled_checkbox": {
+        "message": "Re-enable the alternateErrorPagesEnabled Chrome Browser setting",
+        "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
+    },
     "options_domain_filter_user": {
         "message": "user-controlled",
         "description": "Dropdown control setting on the Tracking Domains options page tab."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -100,7 +100,7 @@
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "options_webrtc_setting": {
-        "message": "Prevent WebRTC from leaking local IP address *",
+        "message": "Prevent WebRTC from leaking local IP address",
         "description": "Checkbox label on the general settings page"
     },
     "intro_welcome": {
@@ -148,7 +148,7 @@
         "description": "Checkbox label on the general settings page. Should match wording used in the 'non_tracker' message."
     },
     "options_incognito_warning": {
-        "message": "** Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
+        "message": "Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
         "description": "Detailed explanation shown under checkboxes on the general settings page"
     },
     "report_button": {
@@ -174,7 +174,7 @@
         "description": "Label for a text input box on the Tracking Domains options page tab."
     },
     "options_incognito_setting": {
-        "message": "Learn in Private/Incognito windows **",
+        "message": "Learn in Private/Incognito windows",
         "description": "Checkbox label on the general settings page"
     },
     "show_counter_checkbox": {
@@ -254,7 +254,7 @@
         "description": "Part of a reminder to visit the intro page. Shown in popup until the user clicks on the reminder link or browses through the intro page."
     },
     "options_webrtc_warning": {
-        "message": "* WebRTC can leak your local IP address. Note that enabling this option may degrade performance on web conferencing apps like Google Hangouts.",
+        "message": "WebRTC can leak your local IP address. Note that enabling this option may degrade performance on web conferencing apps like Google Hangouts.",
         "description": "Detailed explanation shown under checkboxes on the general settings page"
     },
     "options_general_settings": {
@@ -370,11 +370,11 @@
         "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
     },
     "options_alternateErrorPagesEnabled_checkbox": {
-        "message": "Disable Chrome's \"alternateErrorPagesEnabled\" that help resolve navigation errors by sharing your navigation data with a third party service",
+        "message": "Disable sending web addresses to Google to show suggestions when a page can't be found",
         "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
     },
     "options_hyperlinkAuditingEnabled_checkbox": {
-        "message": "Disable \"<a href='https://www.wilderssecurity.com/threads/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk.415381/#post-2822723' target='_blank'>hyperlink auditing</a>\" trackers from observing when you click on links",
+        "message": "Disable hyperlink auditing ",
         "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
     },
     "options_domain_filter_user": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -370,11 +370,11 @@
         "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
     },
     "options_alternateErrorPagesEnabled_checkbox": {
-        "message": "Disable sending web addresses to Google to show suggestions when a page can't be found",
+        "message": "Disable sending web addresses you visit to Google to show suggestions when a page can't be found",
         "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
     },
     "options_hyperlinkAuditingEnabled_checkbox": {
-        "message": "Disable hyperlink auditing ",
+        "message": "Disable hyperlink auditing",
         "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
     },
     "options_domain_filter_user": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -374,7 +374,7 @@
         "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
     },
     "options_hyperlinkAuditingEnabled_checkbox": {
-        "message": "Disable \"<a href'https://www.wilderssecurity.com/threads/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk.415381/#post-2822723' target='_blank'>hyperlink auditing</a>\" in Chrome Browser",
+        "message": "Disable \"<a href='https://www.wilderssecurity.com/threads/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk.415381/#post-2822723' target='_blank'>hyperlink auditing</a>\" in Chrome Browser",
         "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
     },
     "options_domain_filter_user": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -370,11 +370,11 @@
         "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
     },
     "options_alternateErrorPagesEnabled_checkbox": {
-        "message": "Disable the alternateErrorPagesEnabled Chrome Browser setting",
+        "message": "Disable Chrome's \"alternateErrorPagesEnabled\" that help resolve navigation errors by sharing your navigation data with a third party service",
         "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
     },
     "options_hyperlinkAuditingEnabled_checkbox": {
-        "message": "Disable \"<a href='https://www.wilderssecurity.com/threads/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk.415381/#post-2822723' target='_blank'>hyperlink auditing</a>\" in Chrome Browser",
+        "message": "Disable \"<a href='https://www.wilderssecurity.com/threads/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk.415381/#post-2822723' target='_blank'>hyperlink auditing</a>\" trackers from observing when you click on links",
         "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
     },
     "options_domain_filter_user": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -374,7 +374,7 @@
         "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
     },
     "options_hyperlinkAuditingEnabled_checkbox": {
-        "message": "Disable hyperlink auditing in Chrome Browser",
+        "message": "Disable \"<a href'https://www.wilderssecurity.com/threads/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk.415381/#post-2822723' target='_blank'>hyperlink auditing</a>\" in Chrome Browser",
         "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
     },
     "options_domain_filter_user": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -370,8 +370,12 @@
         "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
     },
     "options_alternateErrorPagesEnabled_checkbox": {
-        "message": "Re-enable the alternateErrorPagesEnabled Chrome Browser setting",
-        "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
+        "message": "Disable the alternateErrorPagesEnabled Chrome Browser setting",
+        "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
+    },
+    "options_hyperlinkAuditingEnabled_checkbox": {
+        "message": "Disable hyperlink auditing in Chrome Browser",
+        "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
     },
     "options_domain_filter_user": {
         "message": "user-controlled",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -377,13 +377,13 @@
         "message": "Send websites the \"<a href='https://www.eff.org/issues/do-not-track' target='_blank'>Do Not Track</a>\" signal",
         "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
     },
-    "options_alternateErrorPagesEnabled_checkbox": {
+    "options_disable_google_nav_error_service": {
         "message": "Disable sending web addresses you visit to Google to show suggestions when a page can't be found",
-        "description": "Checkbox label for enabling/disabling the alternateErrorPagesEnabled option, found on the general settings page"
+        "description": "Checkbox label found on the general settings page"
     },
-    "options_hyperlinkAuditingEnabled_checkbox": {
+    "options_disable_hyperlink_auditing": {
         "message": "Disable hyperlink auditing",
-        "description": "Checkbox label for enabling/disabling the hyperlinkAuditingEnabled option, found on the general settings page"
+        "description": "Checkbox label found on the general settings page"
     },
     "options_domain_filter_user": {
         "message": "user-controlled",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -652,9 +652,11 @@ Badger.prototype = {
    * Default Privacy Badger settings
    */
   defaultSettings: {
+    alternateErrorPagesEnabled: false,
     checkForDNTPolicy: true,
     disabledSites: [],
     hideBlockedElements: true,
+    hyperlinkAuditingEnabled: false,
     isFirstRun: true,
     learnInIncognito: false,
     migrationLevel: 0,
@@ -841,6 +843,14 @@ Badger.prototype = {
 
   isCheckingDNTPolicyEnabled: function() {
     return this.getSettings().getItem("checkForDNTPolicy");
+  },
+
+  isAlternateErrorPagesEnabled: function() {
+    return this.getSettings().getItem("alternateErrorPagesEnabled")
+  },
+
+  isHyperlinkAuditingEnabled: function() {
+    return this.getSettings().getItem("hyperlinkAuditingEnabled")
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -858,6 +858,13 @@ Badger.prototype = {
   },
 
   /**
+  * Check if Re-enable alternateErrorPagesEnabled option is selected
+  */
+  isAlternateErrorPagesEnabled: function() {
+    return this.getSettings().getItem("alternateErrorPagesEnabled")
+  },
+
+  /**
    * Add an origin to the disabled sites list
    *
    * @param {String} origin The origin to disable the PB for

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -39,8 +39,6 @@ function Badger() {
   let self = this;
 
   self.webRTCAvailable = checkWebRTCBrowserSupport();
-  self.alternateErrorPagesAvailable = checkAlternateErrorPagesSupport();
-  self.hyperlinkAuditingAvailable = checkHyperlinkAuditingSupport();
   self.firstPartyDomainPotentiallyRequired = testCookiesFirstPartyDomain();
   self.setPrivacyOverrides();
 
@@ -144,24 +142,6 @@ function Badger() {
     }
 
     return available;
-  }
-
-  // checks for availability of alternateErrorPagesEnabled option on browser
-  function checkAlternateErrorPagesSupport() {
-    if (!chrome.privacy.services.alternateErrorPagesEnabled) {
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  // checks for availability of hyperlinkAuditingEnabled option on browser
-  function checkHyperlinkAuditingSupport() {
-    if (!chrome.privacy.websites.hyperlinkAuditingEnabled) {
-      return false;
-    } else {
-      return true;
-    }
   }
 
   /**
@@ -863,14 +843,6 @@ Badger.prototype = {
 
   isCheckingDNTPolicyEnabled: function() {
     return this.getSettings().getItem("checkForDNTPolicy");
-  },
-
-  isAlternateErrorPagesEnabled: function() {
-    return this.getSettings().getItem("alternateErrorPagesEnabled");
-  },
-
-  isHyperlinkAuditingEnabled: function() {
-    return this.getSettings().getItem("hyperlinkAuditingEnabled");
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -40,7 +40,6 @@ function Badger() {
 
   self.webRTCAvailable = checkWebRTCBrowserSupport();
   self.firstPartyDomainPotentiallyRequired = testCookiesFirstPartyDomain();
-  self.setPrivacyOverrides();
 
   self.widgetList = [];
   widgetLoader.loadWidgetsFromFile("data/socialwidgets.json", (response) => {
@@ -110,6 +109,8 @@ function Badger() {
     });
     // set up periodic fetching of hashes from eff.org
     setInterval(self.updateDntPolicyHashes.bind(self), utils.oneDay() * 4);
+
+    self.setPrivacyOverrides();
 
     self.showFirstRunPage();
   });
@@ -240,7 +241,10 @@ Badger.prototype = {
       });
     }
 
-    if (chrome.privacy.services) {
+    // check against the settings storage values for browser privacy settings
+    let settings = this.getSettings();
+
+    if (chrome.privacy.services && !settings.getItem("alternateErrorPagesEnabled")) {
       _set_override(
         "alternateErrorPagesEnabled",
         chrome.privacy.services.alternateErrorPagesEnabled,
@@ -248,7 +252,7 @@ Badger.prototype = {
       );
     }
 
-    if (chrome.privacy.websites) {
+    if (chrome.privacy.websites && !settings.getItem("hyperlinkAuditingEnabled")) {
       _set_override(
         "hyperlinkAuditingEnabled",
         chrome.privacy.websites.hyperlinkAuditingEnabled,

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -39,6 +39,8 @@ function Badger() {
   let self = this;
 
   self.webRTCAvailable = checkWebRTCBrowserSupport();
+  self.alternateErrorPagesAvailable = checkAlternateErrorPagesSupport();
+  self.hyperlinkAuditingAvailable = checkHyperlinkAuditingSupport();
   self.firstPartyDomainPotentiallyRequired = testCookiesFirstPartyDomain();
   self.setPrivacyOverrides();
 
@@ -142,6 +144,24 @@ function Badger() {
     }
 
     return available;
+  }
+
+  // checks for availability of alternateErrorPagesEnabled option on browser
+  function checkAlternateErrorPagesSupport() {
+    if (!chrome.privacy.services.alternateErrorPagesEnabled) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  // checks for availability of hyperlinkAuditingEnabled option on browser
+  function checkHyperlinkAuditingSupport() {
+    if (!chrome.privacy.websites.hyperlinkAuditingEnabled) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -858,13 +858,6 @@ Badger.prototype = {
   },
 
   /**
-  * Check if Re-enable alternateErrorPagesEnabled option is selected
-  */
-  isAlternateErrorPagesEnabled: function() {
-    return this.getSettings().getItem("alternateErrorPagesEnabled")
-  },
-
-  /**
    * Add an origin to the disabled sites list
    *
    * @param {String} origin The origin to disable the PB for

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -244,7 +244,7 @@ Badger.prototype = {
     // check against the settings storage values for browser privacy settings
     let settings = this.getSettings();
 
-    if (chrome.privacy.services && !settings.getItem("alternateErrorPagesEnabled")) {
+    if (chrome.privacy.services && settings.getItem("disableGoogleNavErrorService")) {
       _set_override(
         "alternateErrorPagesEnabled",
         chrome.privacy.services.alternateErrorPagesEnabled,
@@ -252,7 +252,7 @@ Badger.prototype = {
       );
     }
 
-    if (chrome.privacy.websites && !settings.getItem("hyperlinkAuditingEnabled")) {
+    if (chrome.privacy.websites && settings.getItem("disableHyperlinkAuditing")) {
       _set_override(
         "hyperlinkAuditingEnabled",
         chrome.privacy.websites.hyperlinkAuditingEnabled,
@@ -656,11 +656,11 @@ Badger.prototype = {
    * Default Privacy Badger settings
    */
   defaultSettings: {
-    alternateErrorPagesEnabled: false,
     checkForDNTPolicy: true,
     disabledSites: [],
+    disableGoogleNavErrorService: true,
+    disableHyperlinkAuditing: true,
     hideBlockedElements: true,
-    hyperlinkAuditingEnabled: false,
     isFirstRun: true,
     learnInIncognito: false,
     migrationLevel: 0,

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -48,6 +48,10 @@ function Badger() {
 
   self.storage = new pbStorage.BadgerPen(async function (thisStorage) {
     self.initializeDefaultSettings();
+    // Privacy Badger settings are now fully ready
+
+    self.setPrivacyOverrides();
+
     self.heuristicBlocking = new HeuristicBlocking.HeuristicBlocker(thisStorage);
 
     // TODO there are async migrations
@@ -109,8 +113,6 @@ function Badger() {
     });
     // set up periodic fetching of hashes from eff.org
     setInterval(self.updateDntPolicyHashes.bind(self), utils.oneDay() * 4);
-
-    self.setPrivacyOverrides();
 
     self.showFirstRunPage();
   });
@@ -217,6 +219,8 @@ Badger.prototype = {
       return;
     }
 
+    let self = this;
+
     /**
      * Sets a browser setting if Privacy Badger is allowed to set it.
      */
@@ -241,23 +245,24 @@ Badger.prototype = {
       });
     }
 
-    // check against the settings storage values for browser privacy settings
-    let settings = this.getSettings();
-
-    if (chrome.privacy.services && settings.getItem("disableGoogleNavErrorService")) {
-      _set_override(
-        "alternateErrorPagesEnabled",
-        chrome.privacy.services.alternateErrorPagesEnabled,
-        false
-      );
+    if (self.getSettings().getItem("disableGoogleNavErrorService")) {
+      if (chrome.privacy.services) {
+        _set_override(
+          "alternateErrorPagesEnabled",
+          chrome.privacy.services.alternateErrorPagesEnabled,
+          false
+        );
+      }
     }
 
-    if (chrome.privacy.websites && settings.getItem("disableHyperlinkAuditing")) {
-      _set_override(
-        "hyperlinkAuditingEnabled",
-        chrome.privacy.websites.hyperlinkAuditingEnabled,
-        false
-      );
+    if (self.getSettings().getItem("disableHyperlinkAuditing")) {
+      if (chrome.privacy.websites) {
+        _set_override(
+          "hyperlinkAuditingEnabled",
+          chrome.privacy.websites.hyperlinkAuditingEnabled,
+          false
+        );
+      }
     }
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -846,11 +846,11 @@ Badger.prototype = {
   },
 
   isAlternateErrorPagesEnabled: function() {
-    return this.getSettings().getItem("alternateErrorPagesEnabled")
+    return this.getSettings().getItem("alternateErrorPagesEnabled");
   },
 
   isHyperlinkAuditingEnabled: function() {
-    return this.getSettings().getItem("hyperlinkAuditingEnabled")
+    return this.getSettings().getItem("hyperlinkAuditingEnabled");
   },
 
   /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -114,8 +114,8 @@ function loadOptions() {
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
-  $("#alternateErrorPagesEnabled_checkbox").on("click", toggleAlternateErrorPagesSetting);
-  $("#hyperlinkAuditingEnabled_checkbox").on("click", toggleHyperlinkAuditingSetting);
+  $("#alternateErrorPagesEnabled_checkbox").on("click", overrideAlternateErrorPagesSetting);
+  $("#hyperlinkAuditingEnabled_checkbox").on("click", overrideHyperlinkAuditingSetting);
 
   // only show the alternateErrorPagesEnabled checkbox if browser supports it
   if (chrome.privacy.services.alternateErrorPagesEnabled) {
@@ -744,51 +744,43 @@ function toggleWebRTCIPProtection() {
   });
 }
 
-// handles toggling the alternateErrorPagesEnabled setting
-function toggleAlternateErrorPagesSetting() {
-  let cps = chrome.privacy.services;
+// handles overriding the alternateErrorPagesEnabled setting
+function overrideAlternateErrorPagesSetting() {
+  const disableGoogleNavErrorService = $("#alternateErrorPagesEnabled_checkbox").prop("checked");
 
-  if ($("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
-    chrome.runtime.sendMessage({
-      type: "updateSettings",
-      data: { disableGoogleNavErrorService: true }
-    });
+  // update Badger settings so that we know to reapply the browser setting on startup
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: { disableGoogleNavErrorService }
+  });
 
-    cps.alternateErrorPagesEnabled.set({
+  // update the browser setting
+  if (disableGoogleNavErrorService) {
+    chrome.privacy.services.alternateErrorPagesEnabled.set({
       value: false
     });
-  } else if (!$("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
-    chrome.runtime.sendMessage({
-      type: "updateSettings",
-      data: { disableGoogleNavErrorService: false }
-    });
-
-    // badger relinquishes control of this setting
-    cps.alternateErrorPagesEnabled.clear({});
+  } else {
+    chrome.privacy.services.alternateErrorPagesEnabled.clear({});
   }
 }
 
-// handles toggling the hyperlinkAuditingEnabled setting
-function toggleHyperlinkAuditingSetting() {
-  let cpw = chrome.privacy.websites;
+// handles overriding the hyperlinkAuditingEnabled setting
+function overrideHyperlinkAuditingSetting() {
+  const disableHyperlinkAuditing = $("#hyperlinkAuditingEnabled_checkbox").prop("checked");
 
-  if ($("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
-    chrome.runtime.sendMessage({
-      type: "updateSettings",
-      data: { disableHyperlinkAuditing: true }
-    });
+  // update Badger settings so that we know to reapply the browser setting on startup
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: { disableHyperlinkAuditing }
+  });
 
-    cpw.hyperlinkAuditingEnabled.set({
+  // update the browser setting
+  if (disableHyperlinkAuditing) {
+    chrome.privacy.websites.hyperlinkAuditingEnabled.set({
       value: false
     });
-  } else if (!$("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
-    chrome.runtime.sendMessage({
-      type: "updateSettings",
-      data: { disableHyperlinkAuditing: false }
-    });
-
-    // badger relinquishes control of this setting
-    cpw.hyperlinkAuditingEnabled.clear({});
+  } else {
+    chrome.privacy.websites.hyperlinkAuditingEnabled.clear({});
   }
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -114,21 +114,21 @@ function loadOptions() {
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
-  $("#disable-google-nav-error-service-checkbox").on("click", overrideAlternateErrorPagesSetting);
-  $("#disable-hyperlink-auditing-checkbox").on("click", overrideHyperlinkAuditingSetting);
 
   // only show the alternateErrorPagesEnabled override if browser supports it
   if (chrome.privacy && chrome.privacy.services && chrome.privacy.services.alternateErrorPagesEnabled) {
     $("#disable-google-nav-error-service").show();
-    // check the select box if the user preference is already set for pb to disable alternateErrorPages
-    $('#disable-google-nav-error-service-checkbox').prop("checked", OPTIONS_DATA.disableGoogleNavErrorService);
+    $('#disable-google-nav-error-service-checkbox')
+      .prop("checked", OPTIONS_DATA.disableGoogleNavErrorService)
+      .on("click", overrideAlternateErrorPagesSetting);
   }
 
   // only show the hyperlinkAuditingEnabled override if browser supports it
   if (chrome.privacy && chrome.privacy.websites && chrome.privacy.websites.hyperlinkAuditingEnabled) {
     $("#disable-hyperlink-auditing").show();
-    // check the select box if the user preference is already set for privacy badger to disable hyperlinkAuditing
-    $("#disable-hyperlink-auditing-checkbox").prop("checked", OPTIONS_DATA.disableHyperlinkAuditing);
+    $("#disable-hyperlink-auditing-checkbox")
+      .prop("checked", OPTIONS_DATA.disableHyperlinkAuditing)
+      .on("click", overrideHyperlinkAuditingSetting);
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {
@@ -746,16 +746,18 @@ function toggleWebRTCIPProtection() {
 
 // handles overriding the alternateErrorPagesEnabled setting
 function overrideAlternateErrorPagesSetting() {
-  const disableGoogleNavErrorService = $("#disable-google-nav-error-service-checkbox").prop("checked");
+  const checked = $("#disable-google-nav-error-service-checkbox").prop("checked");
 
   // update Badger settings so that we know to reapply the browser setting on startup
   chrome.runtime.sendMessage({
     type: "updateSettings",
-    data: { disableGoogleNavErrorService }
+    data: {
+      disableGoogleNavErrorService: checked
+    }
   });
 
   // update the browser setting
-  if (disableGoogleNavErrorService) {
+  if (checked) {
     chrome.privacy.services.alternateErrorPagesEnabled.set({
       value: false
     });
@@ -766,16 +768,18 @@ function overrideAlternateErrorPagesSetting() {
 
 // handles overriding the hyperlinkAuditingEnabled setting
 function overrideHyperlinkAuditingSetting() {
-  const disableHyperlinkAuditing = $("#disable-hyperlink-auditing-checkbox").prop("checked");
+  const checked = $("#disable-hyperlink-auditing-checkbox").prop("checked");
 
   // update Badger settings so that we know to reapply the browser setting on startup
   chrome.runtime.sendMessage({
     type: "updateSettings",
-    data: { disableHyperlinkAuditing }
+    data: {
+      disableHyperlinkAuditing: checked
+    }
   });
 
   // update the browser setting
-  if (disableHyperlinkAuditing) {
+  if (checked) {
     chrome.privacy.websites.hyperlinkAuditingEnabled.set({
       value: false
     });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -121,24 +121,16 @@ function loadOptions() {
   $("#alternateErrorPagesEnabled").hide();
   if (chrome.privacy.services.alternateErrorPagesEnabled) {
     $("#alternateErrorPagesEnabled").show();
-    // check the select box if it is already disabled in the browser
-    chrome.privacy.services.alternateErrorPagesEnabled.get({}, result => {
-      if (result.value == false) {
-        $('#alternateErrorPagesEnabled_checkbox').prop("checked", true);
-      }
-    });
+    // check the select box if the user preference is already set for pb to disable alternateErrorPages
+    $('#alternateErrorPagesEnabled_checkbox').prop("checked", !OPTIONS_DATA.alternateErrorPagesEnabled);
   }
 
   // hide the hyperlinkAuditingEnabled checkbox by default, only show if browser supports it
   $("#hyperlinkAuditingEnabled").hide();
   if (chrome.privacy.websites.hyperlinkAuditingEnabled) {
     $("#hyperlinkAuditingEnabled").show();
-    // check the select box if it is already disabled in the browser
-    chrome.privacy.websites.hyperlinkAuditingEnabled.get({}, result => {
-      if (result.value == false) {
-        $('#hyperlinkAuditingEnabled_checkbox').prop("checked", true);
-      }
-    });
+    // check the select box if the user preference is already set for privacy badger to disable hyperlinkAuditing
+    $("#hyperlinkAuditingEnabled_checkbox").prop("checked", !OPTIONS_DATA.hyperlinkAuditingEnabled);
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {
@@ -782,10 +774,8 @@ function toggleAlternateErrorPagesSetting() {
       data: { alternateErrorPagesEnabled: true }
     });
 
-    // if they are resetting the value to false after the badger initialization phase
-    cps.alternateErrorPagesEnabled.set({
-      value: true
-    });
+    // badger relinquishes control of this setting
+    cps.alternateErrorPagesEnabled.clear({});
   }
 }
 
@@ -808,10 +798,8 @@ function toggleHyperlinkAuditingSetting() {
       data: { hyperlinkAuditingEnabled: true }
     });
 
-    // if they are resetting the value to false after the badger initialization phase
-    cpw.hyperlinkAuditingEnabled.set({
-      value: true
-    });
+    // badger relinquishes control of this setting
+    cpw.hyperlinkAuditingEnabled.clear({});
   }
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -120,13 +120,27 @@ function loadOptions() {
   $("#hyperlinkAuditingEnabled_checkbox").prop("checked", OPTIONS_DATA.isHyperlinkAuditingEnabled);
 
   // only show the alternateErrorPagesEnabled checkbox if browser supports it
-  if (!(chrome.privacy.services.alternateErrorPagesEnabled)) {
+  if (!OPTIONS_DATA.alternateErrorPagesAvailable) {
     $("#alternateErrorPagesEnabled").hide();
+  } else {
+    // check the select box if it is already disabled in the browser
+    chrome.privacy.services.alternateErrorPagesEnabled.get({}, result => {
+      if (result.value == false) {
+        $('#alternateErrorPagesEnabled_checkbox').prop("checked", true);
+      }
+    })
   }
 
   // only show the hyperlinkAuditingEnabled checkbox if browser supports it
-  if (!(chrome.privacy.websites.hyperlinkAuditingEnabled)) {
+  if (!OPTIONS_DATA.hyperlinkAuditingAvailable) {
     $("#hyperlinkAuditingEnabled").hide();
+  } else {
+    // check the select box if it is already disabled in the browser
+    chrome.privacy.websites.hyperlinkAuditingEnabled.get({}, result => {
+      if (result.value == false) {
+        $('#hyperlinkAuditingEnabled_checkbox').prop("checked", true);
+      }
+    })
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -117,16 +117,14 @@ function loadOptions() {
   $("#alternateErrorPagesEnabled_checkbox").on("click", toggleAlternateErrorPagesSetting);
   $("#hyperlinkAuditingEnabled_checkbox").on("click", toggleHyperlinkAuditingSetting);
 
-  // hide the alternateErrorPagesEnabled checkbox by default, only show if browser supports it
-  $("#alternateErrorPagesEnabled").hide();
+  // only show the alternateErrorPagesEnabled checkbox if browser supports it
   if (chrome.privacy.services.alternateErrorPagesEnabled) {
     $("#alternateErrorPagesEnabled").show();
     // check the select box if the user preference is already set for pb to disable alternateErrorPages
     $('#alternateErrorPagesEnabled_checkbox').prop("checked", !OPTIONS_DATA.alternateErrorPagesEnabled);
   }
 
-  // hide the hyperlinkAuditingEnabled checkbox by default, only show if browser supports it
-  $("#hyperlinkAuditingEnabled").hide();
+  // only show the hyperlinkAuditingEnabled checkbox if browser supports it
   if (chrome.privacy.websites.hyperlinkAuditingEnabled) {
     $("#hyperlinkAuditingEnabled").show();
     // check the select box if the user preference is already set for privacy badger to disable hyperlinkAuditing
@@ -134,6 +132,7 @@ function loadOptions() {
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {
+    $("#webRTCToggle").show();
     $("#toggle_webrtc_mode").on("click", toggleWebRTCIPProtection);
 
     chrome.privacy.network.webRTCIPHandlingPolicy.get({}, result => {
@@ -147,10 +146,6 @@ function loadOptions() {
         $("#toggle_webrtc_mode").prop("checked", true);
       }
     });
-
-  } else {
-    // Hide WebRTC-related settings for non-supporting browsers
-    $("#webRTCToggle").hide();
   }
 
   $("#learn-in-incognito-checkbox")

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -115,14 +115,12 @@ function loadOptions() {
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
   $("#alternateErrorPagesEnabled_checkbox").on("click", toggleAlternateErrorPagesSetting);
-  $("#alternateErrorPagesEnabled_checkbox").prop("checked", OPTIONS_DATA.isAlternateErrorPagesEnabled);
   $("#hyperlinkAuditingEnabled_checkbox").on("click", toggleHyperlinkAuditingSetting);
-  $("#hyperlinkAuditingEnabled_checkbox").prop("checked", OPTIONS_DATA.isHyperlinkAuditingEnabled);
 
-  // only show the alternateErrorPagesEnabled checkbox if browser supports it
-  if (!OPTIONS_DATA.alternateErrorPagesAvailable) {
-    $("#alternateErrorPagesEnabled").hide();
-  } else {
+  // hide the alternateErrorPagesEnabled checkbox by default, only show if browser supports it
+  $("#alternateErrorPagesEnabled").hide();
+  if (chrome.privacy.services.alternateErrorPagesEnabled) {
+    $("#alternateErrorPagesEnabled").show();
     // check the select box if it is already disabled in the browser
     chrome.privacy.services.alternateErrorPagesEnabled.get({}, result => {
       if (result.value == false) {
@@ -131,10 +129,10 @@ function loadOptions() {
     });
   }
 
-  // only show the hyperlinkAuditingEnabled checkbox if browser supports it
-  if (!OPTIONS_DATA.hyperlinkAuditingAvailable) {
-    $("#hyperlinkAuditingEnabled").hide();
-  } else {
+  // hide the hyperlinkAuditingEnabled checkbox by default, only show if browser supports it
+  $("#hyperlinkAuditingEnabled").hide();
+  if (chrome.privacy.websites.hyperlinkAuditingEnabled) {
+    $("#hyperlinkAuditingEnabled").show();
     // check the select box if it is already disabled in the browser
     chrome.privacy.websites.hyperlinkAuditingEnabled.get({}, result => {
       if (result.value == false) {
@@ -767,36 +765,38 @@ function toggleWebRTCIPProtection() {
 
 // handles toggling the alternateErrorPagesEnabled setting
 function toggleAlternateErrorPagesSetting() {
-  // ensure this is only attempting to be set on supportive browsers
-  if (!OPTIONS_DATA.alternateErrorPagesAvailable) {
-    return;
-  }
-
   let cps = chrome.privacy.services;
 
-  // whatever the current setting is at, reverse it
-  cps.alternateErrorPagesEnabled.get({}, result => {
-    cps.alternateErrorPagesEnabled.set({
-      value: !result.value
+  if ($("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
+    cps.alternateErrorPagesEnabled.clear({});
+    chrome.runtime.sendMessage({
+      type: "updateSettings",
+      data: { alternateErrorPagesEnabled: true }
     });
-  });
+  } else {
+    chrome.runtime.sendMessage({
+      type: "updateSettings",
+      data: { alternateErrorPagesEnabled: false }
+    });
+  }
 }
 
 // handles toggling the hyperlinkAuditingEnabled setting
 function toggleHyperlinkAuditingSetting() {
-  // ensure this is only attempting to be set on supportive browsers
-  if (!OPTIONS_DATA.hyperlinkAuditingAvailable) {
-    return;
-  }
-
   let cpw = chrome.privacy.websites;
 
-  //whatever the current setting is at, reverse it
-  cpw.hyperlinkAuditingEnabled.get({}, result => {
-    cpw.hyperlinkAuditingEnabled.set({
-      value: !result.value
+  if ($("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
+    cpw.hyperlinkAuditingEnabled.clear({});
+    chrome.runtime.sendMessage({
+      type: "updateSettings",
+      data: { hyperlinkAuditingEnabled: true }
     });
-  });
+  } else {
+    chrome.runtime.sendMessage({
+      type: "updateSettings",
+      data: { hyperlinkAuditingEnabled: false }
+    });
+  }
 }
 
 /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -151,7 +151,6 @@ function loadOptions() {
   } else {
     // Hide WebRTC-related settings for non-supporting browsers
     $("#webRTCToggle").hide();
-    $("#webrtc-warning").hide();
   }
 
   $("#learn-in-incognito-checkbox")

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -114,6 +114,13 @@ function loadOptions() {
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
+  $("#alternateErrorPagesEnabled_checkbox").on("click", updateAlternateErrorPagesEnabledOption);
+  $("#alternateErrorPagesEnabled_checkbox").prop("checked", OPTIONS_DATA.isAlternateErrorPagesEnabled);
+
+  // only show the alternateErrorPagesEnabled checkbox if browser supports it
+  if (!(chrome.privacy.services.alternateErrorPagesEnabled)) {
+    $("#alternateErrorPagesEnabled").hide();
+  }
 
   if (OPTIONS_DATA.webRTCAvailable) {
     $("#toggle_webrtc_mode").on("click", toggleWebRTCIPProtection);
@@ -448,6 +455,15 @@ function updateCheckingDNTPolicy() {
     data: {
       checkForDNTPolicy: enabled
     }
+  });
+}
+
+function updateAlternateErrorPagesEnabledOption() {
+  const alternateErrorPagesEnabled = $("#alternateErrorPagesEnabled_checkbox").prop("checked");
+
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: { alternateErrorPagesEnabled }
   });
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -114,21 +114,21 @@ function loadOptions() {
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
-  $("#alternateErrorPagesEnabled_checkbox").on("click", overrideAlternateErrorPagesSetting);
-  $("#hyperlinkAuditingEnabled_checkbox").on("click", overrideHyperlinkAuditingSetting);
+  $("#disable-google-nav-error-service-checkbox").on("click", overrideAlternateErrorPagesSetting);
+  $("#disable-hyperlink-auditing-checkbox").on("click", overrideHyperlinkAuditingSetting);
 
   // only show the alternateErrorPagesEnabled checkbox if browser supports it
   if (chrome.privacy.services.alternateErrorPagesEnabled) {
-    $("#alternateErrorPagesEnabled").show();
+    $("#disable-google-nav-error-service").show();
     // check the select box if the user preference is already set for pb to disable alternateErrorPages
-    $('#alternateErrorPagesEnabled_checkbox').prop("checked", OPTIONS_DATA.disableGoogleNavErrorService);
+    $('#disable-google-nav-error-service-checkbox').prop("checked", OPTIONS_DATA.disableGoogleNavErrorService);
   }
 
   // only show the hyperlinkAuditingEnabled checkbox if browser supports it
   if (chrome.privacy.websites.hyperlinkAuditingEnabled) {
-    $("#hyperlinkAuditingEnabled").show();
+    $("#disable-hyperlink-auditing").show();
     // check the select box if the user preference is already set for privacy badger to disable hyperlinkAuditing
-    $("#hyperlinkAuditingEnabled_checkbox").prop("checked", OPTIONS_DATA.disableHyperlinkAuditing);
+    $("#disable-hyperlink-auditing-checkbox").prop("checked", OPTIONS_DATA.disableHyperlinkAuditing);
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {
@@ -746,7 +746,7 @@ function toggleWebRTCIPProtection() {
 
 // handles overriding the alternateErrorPagesEnabled setting
 function overrideAlternateErrorPagesSetting() {
-  const disableGoogleNavErrorService = $("#alternateErrorPagesEnabled_checkbox").prop("checked");
+  const disableGoogleNavErrorService = $("#disable-google-nav-error-service-checkbox").prop("checked");
 
   // update Badger settings so that we know to reapply the browser setting on startup
   chrome.runtime.sendMessage({
@@ -766,7 +766,7 @@ function overrideAlternateErrorPagesSetting() {
 
 // handles overriding the hyperlinkAuditingEnabled setting
 function overrideHyperlinkAuditingSetting() {
-  const disableHyperlinkAuditing = $("#hyperlinkAuditingEnabled_checkbox").prop("checked");
+  const disableHyperlinkAuditing = $("#disable-hyperlink-auditing-checkbox").prop("checked");
 
   // update Badger settings so that we know to reapply the browser setting on startup
   chrome.runtime.sendMessage({

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -122,6 +122,11 @@ function loadOptions() {
     $("#alternateErrorPagesEnabled").hide();
   }
 
+  // only show the hyperlinkAuditingEnabled checkbox if browser supports it
+  if (!(chrome.privacy.websites.hyperlinkAuditingEnabled)) {
+    $("#hyperlinkAuditingEnabled").hide();
+  }
+
   if (OPTIONS_DATA.webRTCAvailable) {
     $("#toggle_webrtc_mode").on("click", toggleWebRTCIPProtection);
 
@@ -463,7 +468,20 @@ function updateAlternateErrorPagesEnabledOption() {
 
   chrome.runtime.sendMessage({
     type: "updateSettings",
-    data: { alternateErrorPagesEnabled }
+    data: {
+      alternateErrorPagesEnabled: enabled
+    }
+  });
+}
+
+function updateHyperlinkAuditingEnabled() {
+  const enabled = $("#hyperlinkAuditingEnabled_checkbox").prop("checked");
+
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: {
+      hyperlinkAuditingEnabled: enabled
+    }
   });
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -117,15 +117,15 @@ function loadOptions() {
   $("#disable-google-nav-error-service-checkbox").on("click", overrideAlternateErrorPagesSetting);
   $("#disable-hyperlink-auditing-checkbox").on("click", overrideHyperlinkAuditingSetting);
 
-  // only show the alternateErrorPagesEnabled checkbox if browser supports it
-  if (chrome.privacy.services.alternateErrorPagesEnabled) {
+  // only show the alternateErrorPagesEnabled override if browser supports it
+  if (chrome.privacy && chrome.privacy.services && chrome.privacy.services.alternateErrorPagesEnabled) {
     $("#disable-google-nav-error-service").show();
     // check the select box if the user preference is already set for pb to disable alternateErrorPages
     $('#disable-google-nav-error-service-checkbox').prop("checked", OPTIONS_DATA.disableGoogleNavErrorService);
   }
 
-  // only show the hyperlinkAuditingEnabled checkbox if browser supports it
-  if (chrome.privacy.websites.hyperlinkAuditingEnabled) {
+  // only show the hyperlinkAuditingEnabled override if browser supports it
+  if (chrome.privacy && chrome.privacy.websites && chrome.privacy.websites.hyperlinkAuditingEnabled) {
     $("#disable-hyperlink-auditing").show();
     // check the select box if the user preference is already set for privacy badger to disable hyperlinkAuditing
     $("#disable-hyperlink-auditing-checkbox").prop("checked", OPTIONS_DATA.disableHyperlinkAuditing);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -117,6 +117,7 @@ function loadOptions() {
 
   // only show the alternateErrorPagesEnabled override if browser supports it
   if (chrome.privacy && chrome.privacy.services && chrome.privacy.services.alternateErrorPagesEnabled) {
+    $("#privacy-settings-header").show();
     $("#disable-google-nav-error-service").show();
     $('#disable-google-nav-error-service-checkbox')
       .prop("checked", OPTIONS_DATA.disableGoogleNavErrorService)
@@ -125,6 +126,7 @@ function loadOptions() {
 
   // only show the hyperlinkAuditingEnabled override if browser supports it
   if (chrome.privacy && chrome.privacy.websites && chrome.privacy.websites.hyperlinkAuditingEnabled) {
+    $("#privacy-settings-header").show();
     $("#disable-hyperlink-auditing").show();
     $("#disable-hyperlink-auditing-checkbox")
       .prop("checked", OPTIONS_DATA.disableHyperlinkAuditing)

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -768,15 +768,23 @@ function toggleAlternateErrorPagesSetting() {
   let cps = chrome.privacy.services;
 
   if ($("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
-    cps.alternateErrorPagesEnabled.clear({});
+    chrome.runtime.sendMessage({
+      type: "updateSettings",
+      data: { alternateErrorPagesEnabled: false }
+    });
+
+    cps.alternateErrorPagesEnabled.set({
+      value: false
+    });
+  } else if (!$("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
     chrome.runtime.sendMessage({
       type: "updateSettings",
       data: { alternateErrorPagesEnabled: true }
     });
-  } else {
-    chrome.runtime.sendMessage({
-      type: "updateSettings",
-      data: { alternateErrorPagesEnabled: false }
+
+    // if they are resetting the value to false after the badger initialization phase
+    cps.alternateErrorPagesEnabled.set({
+      value: true
     });
   }
 }
@@ -786,15 +794,23 @@ function toggleHyperlinkAuditingSetting() {
   let cpw = chrome.privacy.websites;
 
   if ($("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
-    cpw.hyperlinkAuditingEnabled.clear({});
+    chrome.runtime.sendMessage({
+      type: "updateSettings",
+      data: { hyperlinkAuditingEnabled: false }
+    });
+
+    cpw.hyperlinkAuditingEnabled.set({
+      value: false
+    });
+  } else if (!$("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
     chrome.runtime.sendMessage({
       type: "updateSettings",
       data: { hyperlinkAuditingEnabled: true }
     });
-  } else {
-    chrome.runtime.sendMessage({
-      type: "updateSettings",
-      data: { hyperlinkAuditingEnabled: false }
+
+    // if they are resetting the value to false after the badger initialization phase
+    cpw.hyperlinkAuditingEnabled.set({
+      value: true
     });
   }
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -114,9 +114,9 @@ function loadOptions() {
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
-  $("#alternateErrorPagesEnabled_checkbox").on("click", updateAlternateErrorPagesEnabled);
+  $("#alternateErrorPagesEnabled_checkbox").on("click", toggleAlternateErrorPagesSetting);
   $("#alternateErrorPagesEnabled_checkbox").prop("checked", OPTIONS_DATA.isAlternateErrorPagesEnabled);
-  $("#hyperlinkAuditingEnabled_checkbox").on("click", updateHyperlinkAuditingEnabled);
+  $("#hyperlinkAuditingEnabled_checkbox").on("click", toggleHyperlinkAuditingSetting);
   $("#hyperlinkAuditingEnabled_checkbox").prop("checked", OPTIONS_DATA.isHyperlinkAuditingEnabled);
 
   // only show the alternateErrorPagesEnabled checkbox if browser supports it
@@ -479,28 +479,6 @@ function updateCheckingDNTPolicy() {
   });
 }
 
-function updateAlternateErrorPagesEnabled() {
-  const enabled = $("#alternateErrorPagesEnabled_checkbox").prop("checked");
-
-  chrome.runtime.sendMessage({
-    type: "updateSettings",
-    data: {
-      alternateErrorPagesEnabled: enabled
-    }
-  });
-}
-
-function updateHyperlinkAuditingEnabled() {
-  const enabled = $("#hyperlinkAuditingEnabled_checkbox").prop("checked");
-
-  chrome.runtime.sendMessage({
-    type: "updateSettings",
-    data: {
-      hyperlinkAuditingEnabled: enabled
-    }
-  });
-}
-
 function updateLearnInIncognito() {
   const learnInIncognito = $("#learn-in-incognito-checkbox").prop("checked");
 
@@ -784,6 +762,40 @@ function toggleWebRTCIPProtection() {
         value: 'default_public_interface_only'
       });
     }
+  });
+}
+
+// handles toggling the alternateErrorPagesEnabled setting
+function toggleAlternateErrorPagesSetting() {
+  // ensure this is only attempting to be set on supportive browsers
+  if (!OPTIONS_DATA.alternateErrorPagesAvailable) {
+    return;
+  }
+
+  let cps = chrome.privacy.services;
+
+  // whatever the current setting is at, reverse it
+  cps.alternateErrorPagesEnabled.get({}, result => {
+    cps.alternateErrorPagesEnabled.set({
+      value: !result.value
+    });
+  });
+}
+
+// handles toggling the hyperlinkAuditingEnabled setting
+function toggleHyperlinkAuditingSetting() {
+  // ensure this is only attempting to be set on supportive browsers
+  if (!OPTIONS_DATA.hyperlinkAuditingAvailable) {
+    return;
+  }
+
+  let cpw = chrome.privacy.websites;
+
+  //whatever the current setting is at, reverse it
+  cpw.hyperlinkAuditingEnabled.get({}, result => {
+    cpw.hyperlinkAuditingEnabled.set({
+      value: !result.value
+    });
   });
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -121,14 +121,14 @@ function loadOptions() {
   if (chrome.privacy.services.alternateErrorPagesEnabled) {
     $("#alternateErrorPagesEnabled").show();
     // check the select box if the user preference is already set for pb to disable alternateErrorPages
-    $('#alternateErrorPagesEnabled_checkbox').prop("checked", !OPTIONS_DATA.alternateErrorPagesEnabled);
+    $('#alternateErrorPagesEnabled_checkbox').prop("checked", OPTIONS_DATA.disableGoogleNavErrorService);
   }
 
   // only show the hyperlinkAuditingEnabled checkbox if browser supports it
   if (chrome.privacy.websites.hyperlinkAuditingEnabled) {
     $("#hyperlinkAuditingEnabled").show();
     // check the select box if the user preference is already set for privacy badger to disable hyperlinkAuditing
-    $("#hyperlinkAuditingEnabled_checkbox").prop("checked", !OPTIONS_DATA.hyperlinkAuditingEnabled);
+    $("#hyperlinkAuditingEnabled_checkbox").prop("checked", OPTIONS_DATA.disableHyperlinkAuditing);
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {
@@ -751,7 +751,7 @@ function toggleAlternateErrorPagesSetting() {
   if ($("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
     chrome.runtime.sendMessage({
       type: "updateSettings",
-      data: { alternateErrorPagesEnabled: false }
+      data: { disableGoogleNavErrorService: true }
     });
 
     cps.alternateErrorPagesEnabled.set({
@@ -760,7 +760,7 @@ function toggleAlternateErrorPagesSetting() {
   } else if (!$("#alternateErrorPagesEnabled_checkbox").prop("checked")) {
     chrome.runtime.sendMessage({
       type: "updateSettings",
-      data: { alternateErrorPagesEnabled: true }
+      data: { disableGoogleNavErrorService: false }
     });
 
     // badger relinquishes control of this setting
@@ -775,7 +775,7 @@ function toggleHyperlinkAuditingSetting() {
   if ($("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
     chrome.runtime.sendMessage({
       type: "updateSettings",
-      data: { hyperlinkAuditingEnabled: false }
+      data: { disableHyperlinkAuditing: true }
     });
 
     cpw.hyperlinkAuditingEnabled.set({
@@ -784,7 +784,7 @@ function toggleHyperlinkAuditingSetting() {
   } else if (!$("#hyperlinkAuditingEnabled_checkbox").prop("checked")) {
     chrome.runtime.sendMessage({
       type: "updateSettings",
-      data: { hyperlinkAuditingEnabled: true }
+      data: { disableHyperlinkAuditing: false }
     });
 
     // badger relinquishes control of this setting

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -136,11 +136,6 @@ function loadOptions() {
     $("#toggle_webrtc_mode").on("click", toggleWebRTCIPProtection);
 
     chrome.privacy.network.webRTCIPHandlingPolicy.get({}, result => {
-      // only enable the checkbox if pb can control webrtc ip leak protection
-      if (result.levelOfControl.endsWith("_by_this_extension")) {
-        $("#toggle_webrtc_mode").attr("disabled", false);
-      }
-
       // auto check the option box if ip leak is already protected at diff levels, via pb or another extension
       if (result.value == "default_public_interface_only" || result.value == "disable_non_proxied_udp") {
         $("#toggle_webrtc_mode").prop("checked", true);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -114,8 +114,10 @@ function loadOptions() {
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.isDNTSignalEnabled);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.isCheckingDNTPolicyEnabled).prop("disabled", !OPTIONS_DATA.isDNTSignalEnabled);
-  $("#alternateErrorPagesEnabled_checkbox").on("click", updateAlternateErrorPagesEnabledOption);
+  $("#alternateErrorPagesEnabled_checkbox").on("click", updateAlternateErrorPagesEnabled);
   $("#alternateErrorPagesEnabled_checkbox").prop("checked", OPTIONS_DATA.isAlternateErrorPagesEnabled);
+  $("#hyperlinkAuditingEnabled_checkbox").on("click", updateHyperlinkAuditingEnabled);
+  $("#hyperlinkAuditingEnabled_checkbox").prop("checked", OPTIONS_DATA.isHyperlinkAuditingEnabled);
 
   // only show the alternateErrorPagesEnabled checkbox if browser supports it
   if (!(chrome.privacy.services.alternateErrorPagesEnabled)) {
@@ -463,8 +465,8 @@ function updateCheckingDNTPolicy() {
   });
 }
 
-function updateAlternateErrorPagesEnabledOption() {
-  const alternateErrorPagesEnabled = $("#alternateErrorPagesEnabled_checkbox").prop("checked");
+function updateAlternateErrorPagesEnabled() {
+  const enabled = $("#alternateErrorPagesEnabled_checkbox").prop("checked");
 
   chrome.runtime.sendMessage({
     type: "updateSettings",

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -128,7 +128,7 @@ function loadOptions() {
       if (result.value == false) {
         $('#alternateErrorPagesEnabled_checkbox').prop("checked", true);
       }
-    })
+    });
   }
 
   // only show the hyperlinkAuditingEnabled checkbox if browser supports it
@@ -140,7 +140,7 @@ function loadOptions() {
       if (result.value == false) {
         $('#hyperlinkAuditingEnabled_checkbox').prop("checked", true);
       }
-    })
+    });
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -919,8 +919,10 @@ function dispatcher(request, sender, sendResponse) {
     }
 
     sendResponse({
+      alternateErrorPagesEnabled: badger.getSettings().getItem("alternateErrorPagesEnabled"),
       cookieblocked,
       disabledSites: badger.getDisabledSites(),
+      hyperlinkAuditingEnabled: badger.getSettings().getItem("hyperlinkAuditingEnabled"),
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),
       isLearnInIncognitoEnabled: badger.isLearnInIncognitoEnabled(),

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -919,8 +919,10 @@ function dispatcher(request, sender, sendResponse) {
     }
 
     sendResponse({
+      alternateErrorPagesAvailable: badger.alternateErrorPagesAvailable,
       cookieblocked,
       disabledSites: badger.getDisabledSites(),
+      hyperlinkAuditingAvailable: badger.hyperlinkAuditingAvailable,
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),
       isLearnInIncognitoEnabled: badger.isLearnInIncognitoEnabled(),

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -919,10 +919,7 @@ function dispatcher(request, sender, sendResponse) {
     }
 
     sendResponse({
-      alternateErrorPagesAvailable: badger.alternateErrorPagesAvailable,
-      cookieblocked,
       disabledSites: badger.getDisabledSites(),
-      hyperlinkAuditingAvailable: badger.hyperlinkAuditingAvailable,
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),
       isLearnInIncognitoEnabled: badger.isLearnInIncognitoEnabled(),

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -919,6 +919,7 @@ function dispatcher(request, sender, sendResponse) {
     }
 
     sendResponse({
+      cookieblocked,
       disabledSites: badger.getDisabledSites(),
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -919,10 +919,10 @@ function dispatcher(request, sender, sendResponse) {
     }
 
     sendResponse({
-      alternateErrorPagesEnabled: badger.getSettings().getItem("alternateErrorPagesEnabled"),
       cookieblocked,
       disabledSites: badger.getDisabledSites(),
-      hyperlinkAuditingEnabled: badger.getSettings().getItem("hyperlinkAuditingEnabled"),
+      disableGoogleNavErrorService: badger.getSettings().getItem("disableGoogleNavErrorService"),
+      disableHyperlinkAuditing: badger.getSettings().getItem("disableHyperlinkAuditing"),
       isCheckingDNTPolicyEnabled: badger.isCheckingDNTPolicyEnabled(),
       isDNTSignalEnabled: badger.isDNTSignalEnabled(),
       isLearnInIncognitoEnabled: badger.isLearnInIncognitoEnabled(),

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -101,11 +101,6 @@ function setTextDirection() {
       toggle_css_value(selector, "float", "left", "right");
     });
 
-    // fix padding
-    ['label input[type=checkbox] + span'].forEach((selector) => {
-      swap_css_property(selector, "padding-left", "padding-right");
-    });
-
   // new user welcome page
   } else if (document.location.pathname == "/skin/firstRun.html") {
     [

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -89,7 +89,7 @@ function setTextDirection() {
     document.body.appendChild(css);
 
     // fix margins
-    ['#settings-suffix', '#check-dnt-policy-row', '#hide-widgets-row'].forEach((selector) => {
+    ['#check-dnt-policy-row', '#hide-widgets-row'].forEach((selector) => {
       swap_css_property(selector, "margin-left", "margin-right");
     });
     ['#allowlist-form > div > div > div'].forEach((selector) => {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -152,17 +152,6 @@ p, #settingsForm {
     max-height: 400px; /* override popup.css */
 }
 
-#settings-suffix {
-    color: #555;
-    font-size: 12px;
-    max-width: 500px;
-    margin-left: 30px;
-}
-
-#settings-suffix div {
-    margin: 12px 0;
-}
-
 #check-dnt-policy-row {
     margin-left: 25px;
 }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -46,7 +46,7 @@ div.checkbox + div.checkbox {
 
 input[type=checkbox] {
     flex: none;
-    margin-inline-end: 0.6em;
+    margin-inline-end: 0.8em;
 }
 
 div.checkbox .ui-icon-alert {
@@ -69,7 +69,7 @@ button
 label {
     cursor: pointer;
     display: inline-flex;
-    align-items: start;
+    align-items: center;
 }
 #tracking-domains-filters label {
     display: inline;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -49,6 +49,11 @@ input[type=checkbox] {
     margin-inline-end: 0.6em;
 }
 
+div.checkbox .ui-icon-alert {
+    color: #cc0000;
+    margin-bottom: 3px;
+}
+
 td
 {
   font-size: 13px;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -49,6 +49,10 @@ input[type=checkbox] {
     margin-inline-end: 0.8em;
 }
 
+div.checkbox .ui-icon {
+    margin-inline-start: 0.2em;
+}
+
 div.checkbox .ui-icon-alert {
     color: #cc0000;
     margin-bottom: 3px;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -23,13 +23,17 @@ h3 {
     margin: 10px 0;
 }
 
-hr {
-    border: 0;
-    height: 1px;
-    background-color: #d3d3d3;
-    margin: 20px 0;
-    max-width: 700px;
-    width: 100%;
+h4 {
+    display: flex;
+    flex-direction: row;
+    margin: 30px 0 15px 0;
+d}
+h4:after {
+    content: "";
+    flex: 1 1;
+    border-bottom: 1px solid #d3d3d3;
+    margin: auto;
+    margin-inline-start: 10px;
 }
 
 div.checkbox label {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -27,7 +27,7 @@ h4 {
     display: flex;
     flex-direction: row;
     margin: 30px 0 15px 0;
-d}
+}
 h4:after {
     content: "";
     flex: 1 1;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -36,13 +36,17 @@ h4:after {
     margin-inline-start: 10px;
 }
 
-div.checkbox label {
-  min-height: 20px;
-  cursor: pointer;
+div.checkbox {
+    max-width: 550px;
 }
 
-label input[type=checkbox] + span {
-  padding-left: 0.5em;
+div.checkbox + div.checkbox {
+    margin-top: 5px;
+}
+
+input[type=checkbox] {
+    flex: none;
+    margin-inline-end: 0.6em;
 }
 
 td
@@ -58,9 +62,10 @@ button
 }
 
 label {
-  display: inline-flex;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: start;
 }
-
 #tracking-domains-filters label {
     display: inline;
 }

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -184,7 +184,7 @@
 
       <h4 class="i18n_options_privacy_settings"></h4>
 
-      <div class="checkbox" id="hyperlinkAuditingEnabled">
+      <div class="checkbox" id="hyperlinkAuditingEnabled" style="display:none">
         <label>
           <input type="checkbox" id="hyperlinkAuditingEnabled_checkbox">
           <span>
@@ -193,7 +193,7 @@
           </span>
         </label>
       </div>
-      <div class="checkbox" id="alternateErrorPagesEnabled">
+      <div class="checkbox" id="alternateErrorPagesEnabled" style="display:none">
         <label>
           <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
           <span>
@@ -211,7 +211,7 @@
           <span class="i18n_options_show_nontracking_domains_checkbox"></span>
         </label>
       </div>
-      <div class="checkbox" id="webRTCToggle">
+      <div class="checkbox" id="webRTCToggle" style="display:none">
         <label>
           <input type="checkbox" id="toggle_webrtc_mode" disabled>
           <span>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -189,7 +189,7 @@
           <input type="checkbox" id="disable-hyperlink-auditing-checkbox">
           <span>
             <span class="i18n_options_disable_hyperlink_auditing"></span>
-            <a href="https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
           </span>
         </label>
       </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -180,6 +180,12 @@
           <span class="i18n_options_dnt_policy_setting"></span>
         </label>
       </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
+          <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
+        </label>
+      </div>
 
       <hr>
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -180,7 +180,7 @@
           <span class="i18n_options_dnt_policy_setting"></span>
         </label>
       </div>
-      <div class="checkbox">
+      <div class="checkbox" id="alternateErrorPagesEnabled">
         <label>
           <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
           <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -184,15 +184,6 @@
 
       <h4 class="i18n_options_privacy_settings"></h4>
 
-      <div class="checkbox" id="alternateErrorPagesEnabled">
-        <label>
-          <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
-          <span>
-            <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
-            <a href="https://www.google.com/chrome/privacy/whitepaper.html#navtips" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
-          </span>
-        </label>
-      </div>
       <div class="checkbox" id="hyperlinkAuditingEnabled">
         <label>
           <input type="checkbox" id="hyperlinkAuditingEnabled_checkbox">
@@ -202,12 +193,12 @@
           </span>
         </label>
       </div>
-      <div class="checkbox" id="webRTCToggle">
+      <div class="checkbox" id="alternateErrorPagesEnabled">
         <label>
-          <input type="checkbox" id="toggle_webrtc_mode" disabled>
+          <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
           <span>
-            <span class="i18n_options_webrtc_setting"></span>
-            <span class="ui-icon ui-icon-alert tooltip" title="i18n_options_webrtc_warning"></span>
+            <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
+            <a href="https://www.google.com/chrome/privacy/whitepaper.html#navtips" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
           </span>
         </label>
       </div>
@@ -218,6 +209,15 @@
         <label>
           <input type="checkbox" id="show-nontracking-domains-checkbox">
           <span class="i18n_options_show_nontracking_domains_checkbox"></span>
+        </label>
+      </div>
+      <div class="checkbox" id="webRTCToggle">
+        <label>
+          <input type="checkbox" id="toggle_webrtc_mode" disabled>
+          <span>
+            <span class="i18n_options_webrtc_setting"></span>
+            <span class="ui-icon ui-icon-alert tooltip" title="i18n_options_webrtc_warning"></span>
+          </span>
         </label>
       </div>
       <div class="checkbox">

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -207,7 +207,7 @@
           <input type="checkbox" id="toggle_webrtc_mode" disabled>
           <span>
             <span class="i18n_options_webrtc_setting"></span>
-            <span class="ui-icon ui-icon-info tooltip" title="i18n_options_webrtc_warning"></span>
+            <span class="ui-icon ui-icon-alert tooltip" title="i18n_options_webrtc_warning"></span>
           </span>
         </label>
       </div>
@@ -225,7 +225,7 @@
           <input type="checkbox" id="learn-in-incognito-checkbox">
           <span>
             <span class="i18n_options_incognito_setting"></span>
-            <span class="ui-icon ui-icon-info tooltip" title="i18n_options_incognito_warning"></span>
+            <span class="ui-icon ui-icon-alert tooltip" title="i18n_options_incognito_warning"></span>
           </span>
         </label>
       </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -180,16 +180,28 @@
           <span class="i18n_options_dnt_policy_setting"></span>
         </label>
       </div>
+
+      <hr>
+
       <div class="checkbox" id="alternateErrorPagesEnabled">
         <label>
           <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
           <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
+          <a class="ui-icon ui-icon-info tooltip" href="https://www.google.com/chrome/privacy/whitepaper.html#navtips" target="_blank"></a>
         </label>
       </div>
       <div class="checkbox" id="hyperlinkAuditingEnabled">
         <label>
           <input type="checkbox" id="hyperlinkAuditingEnabled_checkbox">
           <span class="i18n_options_hyperlinkAuditingEnabled_checkbox"></span>
+          <a class="ui-icon ui-icon-info tooltip" href="https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing" target="_blank"></a>
+        </label>
+      </div>
+      <div class="checkbox" id="webRTCToggle">
+        <label>
+          <input type="checkbox" id="toggle_webrtc_mode" disabled>
+          <span class="i18n_options_webrtc_setting"></span>
+          <span class="ui-icon ui-icon-info tooltip" title="i18n_options_webrtc_warning"></span>
         </label>
       </div>
 
@@ -201,23 +213,14 @@
           <span class="i18n_options_show_nontracking_domains_checkbox"></span>
         </label>
       </div>
-      <div class="checkbox" id="webRTCToggle">
-        <label>
-          <input type="checkbox" id="toggle_webrtc_mode" disabled>
-          <span class="i18n_options_webrtc_setting"></span>
-        </label>
-      </div>
       <div class="checkbox">
         <label>
           <input type="checkbox" id="learn-in-incognito-checkbox">
           <span class="i18n_options_incognito_setting"></span>
+          <span class="ui-icon ui-icon-info tooltip" title="i18n_options_incognito_warning"></span>
         </label>
       </div>
 
-      <div id="settings-suffix">
-        <div id="webrtc-warning" class="i18n_options_webrtc_warning"></div>
-        <div id="incognito-warning" class="i18n_options_incognito_warning"></div>
-      </div>
     </form>
   </div>
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -187,22 +187,28 @@
       <div class="checkbox" id="alternateErrorPagesEnabled">
         <label>
           <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
-          <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
-          <a class="ui-icon ui-icon-info tooltip" href="https://www.google.com/chrome/privacy/whitepaper.html#navtips" target="_blank"></a>
+          <span>
+            <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
+            <a href="https://www.google.com/chrome/privacy/whitepaper.html#navtips" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
+          </span>
         </label>
       </div>
       <div class="checkbox" id="hyperlinkAuditingEnabled">
         <label>
           <input type="checkbox" id="hyperlinkAuditingEnabled_checkbox">
-          <span class="i18n_options_hyperlinkAuditingEnabled_checkbox"></span>
-          <a class="ui-icon ui-icon-info tooltip" href="https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing" target="_blank"></a>
+          <span>
+            <span class="i18n_options_hyperlinkAuditingEnabled_checkbox"></span>
+            <a href="https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
+          </span>
         </label>
       </div>
       <div class="checkbox" id="webRTCToggle">
         <label>
           <input type="checkbox" id="toggle_webrtc_mode" disabled>
-          <span class="i18n_options_webrtc_setting"></span>
-          <span class="ui-icon ui-icon-info tooltip" title="i18n_options_webrtc_warning"></span>
+          <span>
+            <span class="i18n_options_webrtc_setting"></span>
+            <span class="ui-icon ui-icon-info tooltip" title="i18n_options_webrtc_warning"></span>
+          </span>
         </label>
       </div>
 
@@ -217,8 +223,10 @@
       <div class="checkbox">
         <label>
           <input type="checkbox" id="learn-in-incognito-checkbox">
-          <span class="i18n_options_incognito_setting"></span>
-          <span class="ui-icon ui-icon-info tooltip" title="i18n_options_incognito_warning"></span>
+          <span>
+            <span class="i18n_options_incognito_setting"></span>
+            <span class="ui-icon ui-icon-info tooltip" title="i18n_options_incognito_warning"></span>
+          </span>
         </label>
       </div>
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -182,7 +182,7 @@
         </label>
       </div>
 
-      <h4 class="i18n_options_privacy_settings"></h4>
+      <h4 id="privacy-settings-header" class="i18n_options_privacy_settings" style="display:none"></h4>
 
       <div class="checkbox" id="disable-hyperlink-auditing" style="display:none">
         <label>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -186,6 +186,12 @@
           <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
         </label>
       </div>
+      <div class="checkbox" id="hyperlinkAuditingEnabled">
+        <label>
+          <input type="checkbox" id="hyperlinkAuditingEnabled_checkbox">
+          <span class="i18n_options_hyperlinkAuditingEnabled_checkbox"></span>
+        </label>
+      </div>
 
       <hr>
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -184,20 +184,20 @@
 
       <h4 class="i18n_options_privacy_settings"></h4>
 
-      <div class="checkbox" id="hyperlinkAuditingEnabled" style="display:none">
+      <div class="checkbox" id="disable-hyperlink-auditing" style="display:none">
         <label>
-          <input type="checkbox" id="hyperlinkAuditingEnabled_checkbox">
+          <input type="checkbox" id="disable-hyperlink-auditing-checkbox">
           <span>
-            <span class="i18n_options_hyperlinkAuditingEnabled_checkbox"></span>
+            <span class="i18n_options_disable_hyperlink_auditing"></span>
             <a href="https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
           </span>
         </label>
       </div>
-      <div class="checkbox" id="alternateErrorPagesEnabled" style="display:none">
+      <div class="checkbox" id="disable-google-nav-error-service" style="display:none">
         <label>
-          <input type="checkbox" id="alternateErrorPagesEnabled_checkbox">
+          <input type="checkbox" id="disable-google-nav-error-service-checkbox">
           <span>
-            <span class="i18n_options_alternateErrorPagesEnabled_checkbox"></span>
+            <span class="i18n_options_disable_google_nav_error_service"></span>
             <a href="https://www.google.com/chrome/privacy/whitepaper.html#navtips" target="_blank"><span class="ui-icon ui-icon-info"></span></a>
           </span>
         </label>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -213,7 +213,7 @@
       </div>
       <div class="checkbox" id="webRTCToggle" style="display:none">
         <label>
-          <input type="checkbox" id="toggle_webrtc_mode" disabled>
+          <input type="checkbox" id="toggle_webrtc_mode">
           <span>
             <span class="i18n_options_webrtc_setting"></span>
             <span class="ui-icon ui-icon-alert tooltip" title="i18n_options_webrtc_warning"></span>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -162,6 +162,7 @@
 
   <div id="tab-general-settings">
     <form id="settingsForm" action="#">
+
       <div class="checkbox">
         <label>
           <input type="checkbox" id="show_counter_checkbox">
@@ -181,7 +182,7 @@
         </label>
       </div>
 
-      <hr>
+      <h4 class="i18n_options_privacy_settings"></h4>
 
       <div class="checkbox" id="alternateErrorPagesEnabled">
         <label>
@@ -205,7 +206,7 @@
         </label>
       </div>
 
-      <hr>
+      <h4 class="i18n_options_advanced_settings"></h4>
 
       <div class="checkbox">
         <label>


### PR DESCRIPTION
Fixes #740. 

It exposes an option in the UI for users to control the `alternateErrorPagesEnabled` and `hyperlinkAuditingEnabled` options that PB currently overrides.