### PR TITLE
[MDFP] added zappn.tv to the p7s1.io MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -2821,6 +2821,7 @@ let multiDomainFirstPartiesArray = [
     "the-voice-of-germany.at",
     "the-voice-of-germany.ch",
     "the-voice-of-germany.de",
+    "zappn.tv",
 
     "p7s1.io",
   ],


### PR DESCRIPTION
additional to #2615 added `zappn.tv`, because it is the streaming platform/app of the austrian "ProSiebenSat.1 PULS 4 GmbH" (as already somehow mentioned at https://github.com/EFForg/privacybadger/pull/2572#issuecomment-606556905).

e.g. https://zappn.tv/livestream/ loads the player from `p7s1.io`.