### PR TITLE
Render tracking domains list in chunks instead of on scroll

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -178,7 +178,10 @@ function loadOptions() {
   reloadDisabledSites();
   reloadTrackingDomainsTab();
 
-  $('html').css('visibility', 'visible');
+  $('html').css({
+    overflow: 'visible',
+    visibility: 'visible'
+  });
 
   window.OPTIONS_INITIALIZED = true;
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -660,6 +660,8 @@ function filterTrackingDomains() {
  * @param {Array} domains
  */
 function showTrackingDomains(domains) {
+  $('#tracking-domains-div').css('visibility', 'hidden');
+  $('#tracking-domains-loader').show();
   window.SLIDERS_DONE = false;
   domains = htmlUtils.sortDomains(domains);
 
@@ -691,6 +693,8 @@ function showTrackingDomains(domains) {
       requestAnimationFrame(renderDomains);
     } else {
       window.SLIDERS_DONE = true;
+      $('#tracking-domains-loader').hide();
+      $('#tracking-domains-div').css('visibility', 'visible');
     }
   }
 
@@ -700,6 +704,8 @@ function showTrackingDomains(domains) {
     requestAnimationFrame(renderDomains);
   } else {
     window.SLIDERS_DONE = true;
+    $('#tracking-domains-loader').hide();
+    $('#tracking-domains-div').css('visibility', 'visible');
   }
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -613,8 +613,9 @@ function reloadTrackingDomainsTab() {
  * Displays filtered list of tracking domains based on user input.
  */
 function filterTrackingDomains() {
-  const $typeFilter = $('#tracking-domains-type-filter');
-  const $statusFilter = $('#tracking-domains-status-filter');
+  const $searchFilter = $('#trackingDomainSearch'),
+    $typeFilter = $('#tracking-domains-type-filter'),
+    $statusFilter = $('#tracking-domains-status-filter');
 
   if ($typeFilter.val() == "dnt") {
     $statusFilter.prop("disabled", true).val("");
@@ -622,28 +623,35 @@ function filterTrackingDomains() {
     $statusFilter.prop("disabled", false);
   }
 
-  var initialSearchText = $('#trackingDomainSearch').val().toLowerCase();
+  let search_update = (this == $searchFilter[0]),
+    initial_search_text = $searchFilter.val().toLowerCase(),
+    time_to_wait = 0;
 
-  // Wait a short period of time and see if search text has changed.
+  // If we are here because the search filter got updated,
+  // wait a short period of time and see if search text has changed.
   // If so it means user is still typing so hold off on filtering.
-  var timeToWait = 500;
-  setTimeout(function() {
-    // Check search text.
-    var searchText = $('#trackingDomainSearch').val().toLowerCase();
-    if (searchText !== initialSearchText) {
+  if (search_update) {
+    time_to_wait = 500;
+  }
+
+  setTimeout(function () {
+    // check search text
+    let search_text = $searchFilter.val().toLowerCase();
+    if (search_text != initial_search_text) {
       return;
     }
 
-    // Show filtered origins.
-    var filteredOrigins = getOriginsArray(
+    // show filtered origins
+    let filteredOrigins = getOriginsArray(
       OPTIONS_DATA.origins,
-      searchText,
+      search_text,
       $typeFilter.val(),
       $statusFilter.val(),
       $('#tracking-domains-show-not-yet-blocked').prop('checked')
     );
     showTrackingDomains(filteredOrigins);
-  }, timeToWait);
+
+  }, time_to_wait);
 }
 
 /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -16,6 +16,7 @@
  */
 
 window.OPTIONS_INITIALIZED = false;
+window.SLIDERS_DONE = false;
 
 const TOOLTIP_CONF = {
   maxWidth: 200
@@ -646,68 +647,52 @@ function filterTrackingDomains() {
 }
 
 /**
- * Adds more origins to the blocked resources list on scroll.
+ * Renders the list of tracking domains.
  *
-*/
-function addOrigins(e) {
-  let domains = e.data;
-  if (!domains.length) {
-    return;
-  }
-
-  let el = e.target;
-  let total_height = el.scrollHeight - el.clientHeight;
-  if ((total_height - el.scrollTop) >= 400) {
-    return;
-  }
-
-  for (let i = 0; (i < 50) && (domains.length > 0); i++) {
-    let domain = domains.shift();
-    let action = getOriginAction(domain);
-    if (action) {
-      let show_breakage_warning = (
-        action == constants.USER_BLOCK &&
-        OPTIONS_DATA.cookieblocked.hasOwnProperty(domain)
-      );
-      $(el).append(htmlUtils.getOriginHtml(domain, action, show_breakage_warning));
-    }
-  }
-
-  // activate tooltips
-  $('#blockedResourcesInner .tooltip:not(.tooltipstered)').tooltipster(
-    htmlUtils.DOMAIN_TOOLTIP_CONF);
-}
-
-/**
- * Displays list of tracking domains along with toggle controls.
- * @param {Array} domains Tracking domains to display.
+ * @param {Array} domains
  */
 function showTrackingDomains(domains) {
+  window.SLIDERS_DONE = false;
   domains = htmlUtils.sortDomains(domains);
 
-  // Create HTML for the initial list of tracking domains.
-  let out = '';
-  for (let i = 0; (i < 50) && (domains.length > 0); i++) {
-    let domain = domains.shift();
+  let out = [];
+  for (let domain of domains) {
     let action = getOriginAction(domain);
     if (action) {
       let show_breakage_warning = (
         action == constants.USER_BLOCK &&
         OPTIONS_DATA.cookieblocked.hasOwnProperty(domain)
       );
-      out += htmlUtils.getOriginHtml(domain, action, show_breakage_warning);
+      out.push(htmlUtils.getOriginHtml(domain, action, show_breakage_warning));
     }
   }
 
-  // Display tracking domains.
-  $('#blockedResourcesInner').html(out);
+  function renderDomains() {
+    const CHUNK = 100;
 
-  $('#blockedResourcesInner').off("scroll");
-  $('#blockedResourcesInner').on("scroll", domains, addOrigins);
+    let $printable = $(out.splice(0, CHUNK).join(""));
 
-  // activate tooltips
-  $('#blockedResourcesInner .tooltip:not(.tooltipstered)').tooltipster(
-    htmlUtils.DOMAIN_TOOLTIP_CONF);
+    $printable.appendTo('#blockedResourcesInner');
+
+    // activate tooltips
+    // TODO disabled for performance reasons
+    //$('#blockedResourcesInner .tooltip:not(.tooltipstered)').tooltipster(
+    //  htmlUtils.DOMAIN_TOOLTIP_CONF);
+
+    if (out.length) {
+      requestAnimationFrame(renderDomains);
+    } else {
+      window.SLIDERS_DONE = true;
+    }
+  }
+
+  $('#blockedResourcesInner').empty();
+
+  if (out.length) {
+    requestAnimationFrame(renderDomains);
+  } else {
+    window.SLIDERS_DONE = true;
+  }
 }
 
 /**
@@ -760,10 +745,11 @@ function updateOrigin(origin, action, userset) {
   htmlUtils.toggleBlockedStatus($clicker, userset, show_breakage_warning);
 
   // reinitialize the domain tooltip
-  $clicker.find('.origin-inner').tooltipster('destroy');
-  $clicker.find('.origin-inner').attr(
-    'title', htmlUtils.getActionDescription(action, origin));
-  $clicker.find('.origin-inner').tooltipster(htmlUtils.DOMAIN_TOOLTIP_CONF);
+  // TODO disabled for performance reasons
+  //$clicker.find('.origin-inner').tooltipster('destroy');
+  //$clicker.find('.origin-inner').attr(
+  //  'title', htmlUtils.getActionDescription(action, origin));
+  //$clicker.find('.origin-inner').tooltipster(htmlUtils.DOMAIN_TOOLTIP_CONF);
 }
 
 /**

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -114,6 +114,19 @@ p, #settingsForm {
   width: 0;
 }
 
+#tracking-domains-loader {
+    position: absolute;
+    width: 95%;
+    height: 60vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#tracking-domains-loader .ui-icon {
+    font-size: 500%;
+}
+
 #blockedResources {
   width: 390px;
 }

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -17,7 +17,7 @@
   - along with Adblock Plus.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<html style="visibility:hidden">
+<html style="visibility:hidden; overflow:hidden">
 <head>
 <meta name="google" content="notranslate">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -92,6 +92,9 @@
         <span id="options_domain_list_one_tracker" class="i18n_options_domain_list_one_tracker" style="display:none"></span>
         <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" style="display:none"></span>
       </p>
+      <div id="tracking-domains-loader" style="display:none">
+        <div class="ui-icon ui-icon-loading-status-circle rotate"></div>
+      </div>
       <div id="tracking-domains-div">
           <ul id="tracking-domains-filters">
               <li>

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -277,8 +277,9 @@ class OptionsTest(pbtest.PBSeleniumTest):
 
         self.load_options_page()
         self.select_domain_list_tab()
-        if original_action == "allow":
-            self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
+        self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
+        # wait for sliders to finish rendering
+        self.wait_for_script("return window.SLIDERS_DONE")
 
         # Change user preferences
         self.user_overwrite("pbtest.org", overwrite_action)
@@ -286,6 +287,9 @@ class OptionsTest(pbtest.PBSeleniumTest):
         # Re-open the tab
         self.load_options_page()
         self.select_domain_list_tab()
+        self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
+        # wait for sliders to finish rendering
+        self.wait_for_script("return window.SLIDERS_DONE")
 
         # Check the user preferences for the origins are still displayed
         failure_msg = (
@@ -312,6 +316,7 @@ class OptionsTest(pbtest.PBSeleniumTest):
     def test_tracking_user_overwrite_blocked_cookieblock(self):
         self.tracking_user_overwrite('block', 'cookieblock')
 
+    # TODO do we still want this test?
     def test_tracking_user_overwrite_on_scroll(self):
         # Create a bunch of origins with random actions
         origins = {}
@@ -332,7 +337,8 @@ class OptionsTest(pbtest.PBSeleniumTest):
         self.load_options_page()
         self.select_domain_list_tab()
         self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
-        time.sleep(1) # wait for domains to rerender
+        # wait for sliders to finish rendering
+        self.wait_for_script("return window.SLIDERS_DONE")
 
         # Scroll until the first generated origin is added to the html
         self.scroll_to_bottom()
@@ -365,7 +371,8 @@ class OptionsTest(pbtest.PBSeleniumTest):
         self.load_options_page()
         self.select_domain_list_tab()
         self.find_el_by_css('#tracking-domains-show-not-yet-blocked').click()
-        time.sleep(1) # wait for domains to rerender
+        # wait for sliders to finish rendering
+        self.wait_for_script("return window.SLIDERS_DONE")
         self.scroll_to_bottom()
         self.scroll_to_bottom()
         self.scroll_to_origin('pbtest50-generated.org')


### PR DESCRIPTION
Fixes #2422.

~~Ideally we would cancel in-progress rendering in response to anything that triggers a rerender (such as updating the search term), to remove the potential for rendering the second half of the list from the previous render mixed into the list from the current render. We could also disable things that cause a rerender (just the domains list filters?) while a render is in progress. But ... is this a problem in practice? Let's do some QA to find out.~~ A spinner is shown while domains are being rendered, to prevent partial renders.

This also disables fancy tooltips for the list for performance reasons. Perhaps we could restore them by adding them in a separate asynchronous chunked loop, one that doesn't cause the browser window to hang or add seconds (!!) in some cases to list rendering.