### PR TITLE
Hide/collapse blocked frames

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -178,6 +178,13 @@ Badger.prototype = {
    * Per-tab data that gets cleaned up on tab closing looks like:
       tabData = {
         <tab_id>: {
+          blockedFrameUrls: {
+            <parent_frame_id>: [
+              {String} blocked frame URL,
+              ...
+            ],
+            ...
+          },
           fpData: {
             <script_origin>: {
               canvas: {
@@ -369,6 +376,7 @@ Badger.prototype = {
 
     if (!self.tabData.hasOwnProperty(tabId)) {
       self.tabData[tabId] = {
+        blockedFrameUrls: {},
         frames: {},
         origins: {}
       };

--- a/src/js/contentscripts/collapser.js
+++ b/src/js/contentscripts/collapser.js
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Privacy Badger <https://www.eff.org/privacybadger>
+ * Copyright (C) 2020 Electronic Frontier Foundation
+ *
+ * Privacy Badger is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * Privacy Badger is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
+function hideFrame(url) {
+  let sel = "iframe[src='" + CSS.escape(url) + "']";
+  let el = document.querySelector(sel);
+  if (el) { // el could have gotten replaced since the lookup
+    el.style.setProperty("display", "none", "important");
+  }
+}
+
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (request.hideFrame) {
+    hideFrame(request.url);
+    sendResponse(true);
+  }
+});
+
+// check the page for any frames that were blocked before we got here
+chrome.runtime.sendMessage({
+  type: "getBlockedFrameUrls"
+}, function (frameUrls) {
+  if (!frameUrls) {
+    return;
+  }
+  for (let url of frameUrls) {
+    hideFrame(url);
+  }
+});
+
+}());

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -121,13 +121,13 @@ function createReplacementElement(widget, trackerElem, callback) {
 
 function _createReplacementElementCallback(widget, trackerElem, callback) {
   if (widget.replacementButton.buttonUrl) {
-    _createButtonReplacement(widget, trackerElem, callback);
+    _createButtonReplacement(widget, callback);
   } else {
     _createWidgetReplacement(widget, trackerElem, callback);
   }
 }
 
-function _createButtonReplacement(widget, trackerElem, callback) {
+function _createButtonReplacement(widget, callback) {
   let buttonData = widget.replacementButton,
     button_type = buttonData.type;
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -117,12 +117,6 @@ function onBeforeRequest(details) {
     }, 0);
   }
 
-  if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
-    return {
-      redirectUrl: 'about:blank'
-    };
-  }
-
   return {cancel: true};
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -117,47 +117,9 @@ function onBeforeRequest(details) {
     }, 0);
   }
 
-  if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
+  if (type == 'sub_frame') {
     setTimeout(function () {
-      // don't hide widget frames
-      if (badger.isWidgetReplacementEnabled()) {
-        let exceptions = badger.getSettings().getItem('widgetReplacementExceptions');
-        for (let widget of badger.widgetList) {
-          if (exceptions.includes(widget.name)) {
-            continue;
-          }
-          for (let domain of widget.domains) {
-            if (domain == request_host) {
-              return;
-            } else if (domain[0] == "*") {
-              if (request_host.endsWith(domain.slice(1))) {
-                return;
-              }
-            }
-          }
-        }
-      }
-
-      let parent_id = details.parentFrameId;
-      chrome.tabs.sendMessage(tab_id, {
-        hideFrame: true,
-        url
-      }, {
-        frameId: parent_id
-      }, function (response) {
-        if (response) {
-          // content script was ready and received our message
-          return;
-        }
-        // content script was not ready
-        if (chrome.runtime.lastError) {
-          // ignore
-        }
-        if (!badger.tabData[tab_id].blockedFrameUrls.hasOwnProperty(parent_id)) {
-          badger.tabData[tab_id].blockedFrameUrls[parent_id] = [];
-        }
-        badger.tabData[tab_id].blockedFrameUrls[parent_id].push(url);
-      });
+      hideBlockedFrame(tab_id, details.parentFrameId, url, request_host);
     }, 0);
   }
 
@@ -390,6 +352,59 @@ function onNavigate(details) {
 }
 
 /******** Utility Functions **********/
+
+/**
+ * Messages collapser.js content script to hide blocked frames.
+ */
+function hideBlockedFrame(tab_id, parent_frame_id, frame_url, frame_host) {
+  // don't hide if hiding is disabled
+  if (!badger.getSettings().getItem('hideBlockedElements')) {
+    return;
+  }
+
+  // don't hide widget frames
+  if (badger.isWidgetReplacementEnabled()) {
+    let exceptions = badger.getSettings().getItem('widgetReplacementExceptions');
+    for (let widget of badger.widgetList) {
+      if (exceptions.includes(widget.name)) {
+        continue;
+      }
+      for (let domain of widget.domains) {
+        if (domain == frame_host) {
+          return;
+        } else if (domain[0] == "*") { // leading wildcard domain
+          if (frame_host.endsWith(domain.slice(1))) {
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  // message content script
+  chrome.tabs.sendMessage(tab_id, {
+    hideFrame: true,
+    url: frame_url
+  }, {
+    frameId: parent_frame_id
+  }, function (response) {
+    if (response) {
+      // content script was ready and received our message
+      return;
+    }
+    // content script was not ready
+    if (chrome.runtime.lastError) {
+      // ignore
+    }
+    // record frame_url and parent_frame_id
+    // for when content script becomes ready
+    let tabData = badger.tabData[tab_id];
+    if (!tabData.blockedFrameUrls.hasOwnProperty(parent_frame_id)) {
+      tabData.blockedFrameUrls[parent_frame_id] = [];
+    }
+    tabData.blockedFrameUrls[parent_frame_id].push(frame_url);
+  });
+}
 
 /**
  * Gets the host name for a given tab id

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -119,6 +119,25 @@ function onBeforeRequest(details) {
 
   if (type == 'sub_frame' && badger.getSettings().getItem('hideBlockedElements')) {
     setTimeout(function () {
+      // don't hide widget frames
+      if (badger.isWidgetReplacementEnabled()) {
+        let exceptions = badger.getSettings().getItem('widgetReplacementExceptions');
+        for (let widget of badger.widgetList) {
+          if (exceptions.includes(widget.name)) {
+            continue;
+          }
+          for (let domain of widget.domains) {
+            if (domain == request_host) {
+              return;
+            } else if (domain[0] == "*") {
+              if (request_host.endsWith(domain.slice(1))) {
+                return;
+              }
+            }
+          }
+        }
+      }
+
       let parent_id = details.parentFrameId;
       chrome.tabs.sendMessage(tab_id, {
         hideFrame: true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -478,6 +478,7 @@
     },
     {
       "js": [
+        "js/contentscripts/collapser.js",
         "js/contentscripts/socialwidgets.js",
         "js/contentscripts/supercookie.js"
       ],


### PR DESCRIPTION
Part of #442. Fixes a browser crash in Chrome made more visible by #2653. Follows up on #1766.

To test, disable element hiding (run `badger.getSettings().setItem("hideBlockedElements", false)` on the bg. page), and find pages where Privacy Badger's blocking produces "Requests to the server have been blocked by an extension" frames. Re-enabling element hiding and reloading the page should hide/collapse such frames.