### PR TITLE
Disable on localhosts

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -930,10 +930,10 @@ Badger.prototype = {
    * and if tab_id is for an incognito window,
    * is learning in incognito windows enabled?
    */
-  isLearningEnabled(tab_id) {
+  isLearningEnabled(tab_id, tab_host) {
     return (
       this.getSettings().getItem("learnLocally") &&
-      incognito.learningEnabled(tab_id)
+      incognito.learningEnabled(tab_id, tab_host)
     );
   },
 

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -122,6 +122,11 @@ HeuristicBlocker.prototype = {
 
     let tab_origin = self.tabOrigins[details.tabId];
 
+    // ignore localhosts
+    if (window.isPrivateDomain(tab_origin)) {
+      return {};
+    }
+
     // ignore first-party requests
     if (!tab_origin || !utils.isThirdPartyDomain(request_origin, tab_origin)) {
       return {};

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -105,7 +105,7 @@ HeuristicBlocker.prototype = {
    */
   heuristicBlockingAccounting: function (details, check_for_cookie_share) {
     // ignore requests that are outside a tabbed window
-    if (details.tabId < 0 || !badger.isLearningEnabled(details.tabId)) {
+    if (details.tabId < 0 || !badger.isLearningEnabled(details.tabId, details.url)) {
       return {};
     }
 
@@ -121,11 +121,6 @@ HeuristicBlocker.prototype = {
     }
 
     let tab_origin = self.tabOrigins[details.tabId];
-
-    // ignore localhosts
-    if (window.isPrivateDomain(tab_origin)) {
-      return {};
-    }
 
     // ignore first-party requests
     if (!tab_origin || !utils.isThirdPartyDomain(request_origin, tab_origin)) {

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -25,7 +25,7 @@ function startListeners() {
   chrome.tabs.onRemoved.addListener(onRemovedListener);
 }
 
-function learningEnabled(tab_id) {
+function learningEnabled(tab_id, tab_host) {
   if (badger.getSettings().getItem("learnInIncognito")) {
     // treat all pages as if they're not incognito
     return true;
@@ -33,6 +33,10 @@ function learningEnabled(tab_id) {
   // if we don't have incognito data for whatever reason,
   // default to disabled
   if (!tabs.hasOwnProperty(tab_id)) {
+    return false;
+  }
+  // if tab host is a localhost or any private domain, default to disabled
+  if (window.isPrivateDomain(tab_host)) {
     return false;
   }
   // else, do not learn in incognito tabs

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -110,7 +110,7 @@ function onBeforeRequest(details) {
   });
 
   // if this is a heuristically- (not user-) blocked domain
-  if (action == constants.BLOCK && incognito.learningEnabled(tab_id)) {
+  if (action == constants.BLOCK && incognito.learningEnabled(tab_id, tab_host)) {
     // check for DNT policy asynchronously
     setTimeout(function () {
       badger.checkForDNTPolicy(request_host);
@@ -966,7 +966,7 @@ function dispatcher(request, sender, sendResponse) {
       frame_host = window.extractHostFromURL(request.frameUrl);
 
     sendResponse(frame_host &&
-      badger.isLearningEnabled(sender.tab.id) &&
+      badger.isLearningEnabled(sender.tab.id, tab_host) &&
       badger.isPrivacyBadgerEnabled(tab_host) &&
       utils.isThirdPartyDomain(frame_host, tab_host));
 
@@ -977,7 +977,7 @@ function dispatcher(request, sender, sendResponse) {
     let tab_host = window.extractHostFromURL(sender.tab.url);
 
     sendResponse(
-      badger.isLearningEnabled(sender.tab.id) &&
+      badger.isLearningEnabled(sender.tab.id, tab_host) &&
       badger.isPrivacyBadgerEnabled(tab_host));
 
     break;

--- a/src/tests/tests/tabData.js
+++ b/src/tests/tests/tabData.js
@@ -38,6 +38,14 @@ function() {
     },
   });
 
+  QUnit.test("learning is disabled on localhost", function (assert) {
+    const LOCALSITE = "localhost";
+
+    assert.notOk(
+      badger.isLearningEnabled(this.tabId, LOCALSITE), "learning is disabled on localhost site"
+    );
+  });
+
   QUnit.test("logging blocked domain", function (assert) {
     const DOMAIN = "example.com";
 


### PR DESCRIPTION
This fixes #817 

Instead of disabling pb entirely on localhosts, this now just removes learning capabilities when the tab origin is from a predictable localhost address.