### PR TITLE
Add a new domain to the MDFP list for Google

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -1593,6 +1593,7 @@ let multiDomainFirstPartiesArray = [
     "www.googleapis.com",
 
     "nest.com",
+    "codingcompetitions.withgoogle.com",
     "nestpowerproject.withgoogle.com",
   ],
   ["www.gov.uk", "cabinet-office.gov.uk", "publishing.service.gov.uk"],


### PR DESCRIPTION
`codingcompetitions.withgoogle.com` needs to access cookies on `google.com` so that to sign in Google accounts. 