### PR TITLE
Add Singapore Press Holdings domains to MDFP list

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -3962,7 +3962,23 @@ let multiDomainFirstPartiesArray = [
     "yandex.uz",
     "ya.ru",
   ],
-  ["zaobao.com", "zaobao.sg", "zaobao.com.sg"],
+  [
+    "sph.com.sg",
+
+    "sphdigital.com",
+
+    "beritaharian.sg",
+    "businesstimes.com.sg",
+    "shinmin.sg",
+    "straitstimes.com",
+    "tabla.com.sg",
+    "tamilmurasu.com.sg",
+    "tnp.sg",
+    "wanbao.com.sg",
+    "zaobao.com",
+    "zaobao.com.sg",
+    "zaobao.sg"
+  ],
   ["zendesk.com", "zopim.com"],
   ["zhaopin.com", "zhaopin.cn"],
   ["zillow.com", "zillowstatic.com", "zillowcloud.com", "zg-api.com"],

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -3962,6 +3962,7 @@ let multiDomainFirstPartiesArray = [
     "yandex.uz",
     "ya.ru",
   ],
+  ["zaobao.com", "zaobao.sg", "zaobao.com.sg"],
   ["zendesk.com", "zopim.com"],
   ["zhaopin.com", "zhaopin.cn"],
   ["zillow.com", "zillowstatic.com", "zillowcloud.com", "zg-api.com"],


### PR DESCRIPTION
[Zaobao](https://en.wikipedia.org/wiki/Lianhe_Zaobao) is a Chinese newspaper published in Singapore. 
Zaobao.com.sg uses some assets hosted on project.zaobao.com which is blocked by the PB, resulting some images failing to load.

Debugging output:
```
**** ACTION_MAP for zaobao.com
www.zaobao.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
}
zaobao.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
}
www.zaobao.com.sg {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": /* redacted */
}
zaobao.com.sg {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0
}
project.zaobao.com {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": /* redacted */
}
zproperty.zaobao.com.sg {
  "userAction": "",
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": /* redacted */
}
**** SNITCH_MAP for zaobao.com
zaobao.com [
  "zaobao.com.sg",
  "google.com",
  "uzaobao.com"
]
zaobao.com.sg [
  "uzaobao.com",
  /* redacted */
  "bing.com"
]
```

(uzaobao.com is a third-party mirror site which is not affiliated with Zaobao.)