### PR TITLE
Implement global privacy control

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -374,8 +374,8 @@
         "description": ""
     },
     "options_enable_dnt_checkbox": {
-        "message": "Send websites the \"<a href='https://www.eff.org/issues/do-not-track' target='_blank'>Do Not Track</a>\" signal",
-        "description": "Checkbox label for enabling/disabling the Do Not Track signal, found on the general settings page"
+        "message": "Send websites the \"<a href='https://globalprivacycontrol.org/' target='_blank'>Global Privacy Control</a>\" and \"<a href='https://www.eff.org/issues/do-not-track' target='_blank'>Do Not Track</a>\" signals",
+        "description": "Checkbox label for enabling/disabling the Sec-GPC and DNT signals, found on the general settings page"
     },
     "options_disable_google_nav_error_service": {
         "message": "Disable sending web addresses you visit to Google. This disables suggestions for similar pages when a page can't be found.",
@@ -390,7 +390,7 @@
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "disabled_for_these_domains": {
-        "message": "<p>Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here.</p><p>If you think Privacy Badger is breaking a page, you can type that page's domain in the box below and click the \"Add domain\" button.</p><p>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.</p>",
+        "message": "<p>Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here, and it will not send the Do Not Track or Global Privacy Control signals.</p><p>If you think Privacy Badger is breaking a page, or you would like to allow a particular site to share or sell your data, you can type that page's domain in the box below and click the \"Add domain\" button.</p><p>Alternatively, when you already have the page's tab selected, you can just click on Privacy Badger's button in the browser toolbar and then click the \"Disable\" button.</p>",
         "description": ""
     },
     "popup_instructions": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -330,7 +330,7 @@
         "description": ""
     },
     "intro_beyond_ads_paragraph": {
-        "message": "Invisible tracking happens in all sorts of ways; ads are just the visible tip of the iceberg. Privacy Badger <a href='https://www.eff.org/issues/do-not-track' target='_blank'>sends the Do Not Track signal</a> to trackers telling them not to track you. If they ignore your wishes, your Badger will learn to block them—whether they are advertisers or trackers of other kinds.",
+        "message": "Invisible tracking happens in all sorts of ways; ads are just the visible tip of the iceberg. Privacy Badger sends the <a href='https://globalprivacycontrol.org/' target='_blank'>Global Privacy Control signal</a>, to opt you out of data sharing and selling, and the <a href='https://www.eff.org/issues/do-not-track' target='_blank'>Do Not Track signal</a> to tell companies not to track you. If they ignore your wishes, your Badger will learn to block them—whether they are advertisers or trackers of other kinds.",
         "description": "Intro page paragraph."
     },
     "report_close": {

--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -28,6 +28,12 @@ function getPageScript() {
       }
     });
 
+    OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "globalPrivacyControl", {
+      get: function globalPrivacyControl() {
+        return "1";
+      }
+    });
+
   // save locally to keep from getting overwritten by site code
   } + "(window.navigator, Object));";
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -165,7 +165,7 @@ function onBeforeSendHeaders(details) {
     if (badger.isPrivacyBadgerEnabled(tab_host)) {
       // Still sending Do Not Track even if HTTP and cookie blocking are disabled
       if (badger.isDNTSignalEnabled()) {
-        details.requestHeaders.push({name: "DNT", value: "1"});
+        details.requestHeaders.push({name: "DNT", value: "1"}, {name: "Sec-GPC", value: "1"});
       }
       return {requestHeaders: details.requestHeaders};
     } else {
@@ -210,7 +210,7 @@ function onBeforeSendHeaders(details) {
 
     // add DNT header
     if (badger.isDNTSignalEnabled()) {
-      newHeaders.push({name: "DNT", value: "1"});
+      newHeaders.push({name: "DNT", value: "1"}, {name: "Sec-GPC", value: "1"});
     }
 
     return {requestHeaders: newHeaders};
@@ -219,7 +219,7 @@ function onBeforeSendHeaders(details) {
   // if we are here, we're looking at a third-party request
   // that's not yet blocked or cookieblocked
   if (badger.isDNTSignalEnabled()) {
-    details.requestHeaders.push({name: "DNT", value: "1"});
+    details.requestHeaders.push({name: "DNT", value: "1"}, {name: "Sec-GPC", value: "1"});
   }
   return {requestHeaders: details.requestHeaders};
 }


### PR DESCRIPTION
This is a quick, simple implementation of sec-gpc, the upcoming do-not-sell-or-share standard for CCPA/nevada privacy/GDPR purposes. The signal looks an awful lot like DNT. 

With this PR, Sec-GPC will be sent whenever DNT is: the global checkbox in the options page that enabled DNT now enables both signals, and Privacy Badger will not send Sec-GPC to sites on the disabled list.

Like DNT, there are two ways the signal is conveyed: through a browser header ("Sec-GPC: 1"), and through a navigator property (`navigator.globalPrivacyControl = 1`). This PR sets GPC to 1 by default in both of those channels. Both are controlled by the `badger.sendDNTSignal` setting.

In the future, it might make sense to separate out DNT and GPC, but this is the simplest way I could think to implement. Most of the work that still needs to be done is around copy: we should let users know about GPC in the FAQ and the start page.