### PR TITLE
Added LocationIQ map tiles to yellow list

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -786,3 +786,6 @@ zombaio.com
 zope.net
 zopim.com
 zvents.com
+locationiq.com
+locationiq.org
+unwiredlabs.com


### PR DESCRIPTION
We received reports of our map tiles being blocked from users on locationiq.com, .org and unwiredlabs.com
We serve over 100k developers, are not an advertising business, have a clear privacy policy, are GDPR compliant & do not track other than Google Analytics.

These map tiles are served as files and do not have any tracking capabilities.