### PR TITLE
Add jdl.cn to MDFP list for JD.com

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -2079,6 +2079,7 @@ let multiDomainFirstPartiesArray = [
     "jd.hk",
     "jd.id",
     "jd.ru",
+    "jdl.cn",
     "jdpay.com",
     "jdwl.com",
     "jdx.com",


### PR DESCRIPTION
Following #2434 #2639.
According to the WHOIS record of `jdl.cn`
> Registrant: 北京京东乾石科技有限公司
> Registrant Contact Email: jdym@jd.com
> Registration Time: 2020-05-12 09:34:05

, it is a new domain of JD.com, for its subsidiary [JD logistics](https://google.com/search?q=JD+logistics). 

`jdl.cn` relies on many resources on `jd.com` and `360buyimage.com` and hence its [package tracking page](https://www.jdl.cn/order/search?waybillCodes=VC43228561891) is broken.