### PR TITLE
Add Google Link Tracking Protection for Firefox Android

### DIFF
--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -24,6 +24,9 @@ function cleanLink(a) {
   // reassign href when in firefox android
   if (a.href.startsWith(document.location.origin) && (new URL(a.href).searchParams.get('q'))) {
     let href = new URL(a.href).searchParams.get('q');
+    if (!window.isURL(href)) {
+      return;
+    }
     a.href = href;
   }
 }

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -24,9 +24,6 @@ function cleanLink(a) {
   // reassign href when in firefox android
   if (a.href.startsWith(document.location.origin) && (new URL(a.href).searchParams.get('q'))) {
     let href = new URL(a.href).searchParams.get('q');
-    if (!window.isURL(href)) {
-      return;
-    }
     a.href = href;
   }
 }

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -1,7 +1,16 @@
 /* globals findInAllFrames:false */
+
+// bool for whether or not in firefox for android
+let firefox_android = (navigator.userAgent.indexOf('Firefox') > -1 && navigator.userAgent.indexOf('Android') > -1);
+
 // In Firefox, outbound google links have the `rwt(...)` mousedown trigger.
 // In Chrome, they just have a `ping` attribute.
 let trap_link = "a[onmousedown^='return rwt(this,'], a[ping]";
+
+// Firefox Android has neither the mousedown trigger nor ping attribute
+if (firefox_android) {
+  trap_link = 'a';
+}
 
 // Remove excessive attributes and event listeners from link a
 function cleanLink(a) {
@@ -23,7 +32,7 @@ function cleanLink(a) {
   a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
 
   // reassign href when in firefox android
-  if (navigator.userAgent.indexOf('Firefox') > -1 && navigator.userAgent.indexOf('Android') > -1) {
+  if (firefox_android) {
     let href = new URL(a.href).searchParams.get('q');
     if (!window.isURL(href)) {
       return;

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -22,9 +22,9 @@ function cleanLink(a) {
   a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
 
   // reassign href when in firefox android
-  if (a.href.startsWith(document.location.origin) && (new URL(a.href).searchParams.get('q'))) {
-    let href = new URL(a.href).searchParams.get('q');
-    if (window.isURL(href)) {
+  if (a.href.startsWith(document.location.origin + "/url?q=")) {
+    let href = (new URL(a.href)).searchParams.get('q');
+    if (href && window.isURL(href)) {
       a.href = href;
     }
   }

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -30,6 +30,12 @@ function cleanLink(a) {
   }
 }
 
+function cleanAllLinks() {
+  findInAllFrames(trap_link).forEach((link) => {
+    cleanLink(link);
+  });
+}
+
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
   type: "checkEnabled"
@@ -38,9 +44,10 @@ chrome.runtime.sendMessage({
     return;
   }
 
-  // since the page is rendered all at once, no need to set up a
-  // mutationObserver or setInterval
-  findInAllFrames(trap_link).forEach((link) => {
-    cleanLink(link);
-  });
+  // since the page is rendered all at once,
+  // no need to set up a mutationObserver or setInterval
+  cleanAllLinks();
+  // there does appear to be a timing issue here though,
+  // so let's rerun after a delay
+  setTimeout(cleanAllLinks, 2000);
 });

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -21,6 +21,15 @@ function cleanLink(a) {
   // block event listeners on the link
   a.addEventListener("click", function (e) { e.stopImmediatePropagation(); }, true);
   a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
+
+  // reassign href when in firefox android
+  if (navigator.userAgent.indexOf('Firefox') > -1 && navigator.userAgent.indexOf('Android') > -1) {
+    let href = new URL(a.href).searchParams.get('q');
+    if (!window.isURL(href)) {
+      return;
+    }
+    a.href = href;
+  }
 }
 
 // TODO race condition; fix waiting on https://crbug.com/478183

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -24,10 +24,9 @@ function cleanLink(a) {
   // reassign href when in firefox android
   if (a.href.startsWith(document.location.origin) && (new URL(a.href).searchParams.get('q'))) {
     let href = new URL(a.href).searchParams.get('q');
-    if (!window.isURL(href)) {
-      return;
+    if (window.isURL(href)) {
+      a.href = href;
     }
-    a.href = href;
   }
 }
 

--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -1,16 +1,6 @@
 /* globals findInAllFrames:false */
-
-// bool for whether or not in firefox for android
-let firefox_android = (navigator.userAgent.indexOf('Firefox') > -1 && navigator.userAgent.indexOf('Android') > -1);
-
-// In Firefox, outbound google links have the `rwt(...)` mousedown trigger.
-// In Chrome, they just have a `ping` attribute.
-let trap_link = "a[onmousedown^='return rwt(this,'], a[ping]";
-
-// Firefox Android has neither the mousedown trigger nor ping attribute
-if (firefox_android) {
-  trap_link = 'a';
-}
+// Outbound Google links are different across browsers. In order here: Firefox, Chrome, Firefox Android
+let trap_link = "a[onmousedown^='return rwt(this,'], a[ping], a[href^='/url?q=']";
 
 // Remove excessive attributes and event listeners from link a
 function cleanLink(a) {
@@ -32,7 +22,7 @@ function cleanLink(a) {
   a.addEventListener("mousedown", function (e) { e.stopImmediatePropagation(); }, true);
 
   // reassign href when in firefox android
-  if (firefox_android) {
+  if (a.href.startsWith(document.location.origin) && (new URL(a.href).searchParams.get('q'))) {
     let href = new URL(a.href).searchParams.get('q');
     if (!window.isURL(href)) {
       return;

--- a/tests/selenium/google_test.py
+++ b/tests/selenium/google_test.py
@@ -37,7 +37,7 @@ class GoogleTest(pbtest.PBSeleniumTest):
         def _check_results():
             # select all anchor elements with non-empty href attributes
             SELECTOR = "a[href]:not([href=''])"
-            search_results = self.driver.find_elements_by_tag_name(SELECTOR)
+            search_results = self.driver.find_elements_by_css_selector(SELECTOR)
 
             # verify these appear to be actual search results
             hrefs = [link.get_attribute('href') for link in search_results]

--- a/tests/selenium/google_test.py
+++ b/tests/selenium/google_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import time
+import unittest
+
+import pbtest
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+class GoogleTest(pbtest.PBSeleniumTest):
+    """Tests first-party protection for Google."""
+
+    # TODO also test on a different Google CC TLD?
+    GOOGLE_SEARCH_DOMAIN = "www.google.com"
+    SEARCH_TERM = "Privacy Badger"
+    SEARCH_RESULT_URL = "https://privacybadger.org/"
+
+    def perform_google_search(self):
+        # perform a search
+        self.load_url("https://{}/".format(self.GOOGLE_SEARCH_DOMAIN))
+        qry_el = self.driver.find_element_by_name("q")
+        qry_el.send_keys(self.SEARCH_TERM)
+        qry_el.submit()
+
+        # wait for search results
+        WebDriverWait(self.driver, 10).until(
+            EC.visibility_of_any_elements_located(
+                (By.CSS_SELECTOR, "a[href*='{}']".format(self.SEARCH_RESULT_URL))))
+
+    def test_unwrapping(self):
+        self.perform_google_search()
+
+        def _check_results():
+            # select all anchor elements with non-empty href attributes
+            SELECTOR = "a[href]:not([href=''])"
+            search_results = self.driver.find_elements_by_tag_name(SELECTOR)
+
+            # verify these appear to be actual search results
+            hrefs = [link.get_attribute('href') for link in search_results]
+            self.assertIn(self.SEARCH_RESULT_URL, hrefs,
+                "At least one search result points to our homepage")
+
+            # verify that tracking attributes are missing
+            for link in search_results:
+                # only check links that point to our homepage
+                # as there is a mix of search result links and other links
+                # and not all links get cleaned
+                # and it's not clear how to select search result links only
+                href = link.get_attribute('href')
+                if self.SEARCH_RESULT_URL not in href:
+                    continue
+
+                self.assertFalse(link.get_attribute('ping'),
+                    "Tracking attribute should be missing")
+                self.assertFalse(link.get_attribute('onmousedown'),
+                    "Tracking attribute should be missing")
+
+                self.assertEqual(link.get_attribute('rel'), "noreferrer noopener")
+
+            return True
+
+        time.sleep(1)
+
+        self.assertTrue(
+            pbtest.retry_until(
+                pbtest.convert_exceptions_to_false(_check_results)),
+            "Search results still fail our checks after several attempts")
+
+    # TODO fake UA to test Firefox on Android?
+    # TODO SELECTOR = "a[href^='/url?q=']"
+    def test_no_unwrapping_when_disabled(self):
+        """Tests that Google search result links still match our selectors."""
+
+        # use the browser-appropriate selector
+        SELECTOR = "a[ping]"
+        if pbtest.shim.browser_type == "firefox":
+            SELECTOR = "a[onmousedown^='return rwt(this,']"
+
+        # turn off link unwrapping on Google
+        # so that we can test our selectors
+        self.disable_badger_on_site(self.GOOGLE_SEARCH_DOMAIN)
+
+        self.perform_google_search()
+
+        # check the results
+        search_results = self.driver.find_elements_by_css_selector(SELECTOR)
+        hrefs = [link.get_attribute('href') for link in search_results]
+        self.assertIn(self.SEARCH_RESULT_URL, hrefs,
+            "At least one search result points to our homepage")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -247,7 +247,7 @@ def if_firefox(wrapper):
     return test_catcher
 
 
-def retry_until(fun, tester=None, times=5, msg="Waiting a bit and retrying ..."):
+def retry_until(fun, tester=None, times=3, msg=None):
     """
     Execute function `fun` until either its return is truthy
     (or if `tester` is set, until the result of calling `tester` with `fun`'s return is truthy),
@@ -262,9 +262,10 @@ def retry_until(fun, tester=None, times=5, msg="Waiting a bit and retrying ...")
         elif result:
             break
 
-        if i == 0:
-            print("")
-        print(msg)
+        if msg:
+            if i == 0:
+                print("")
+            print(msg)
 
         time.sleep(2 ** i)
 

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -8,7 +8,7 @@ import time
 import unittest
 
 from contextlib import contextmanager
-from functools import wraps
+from functools import partial, wraps
 from shutil import copytree
 
 from selenium import webdriver
@@ -270,6 +270,18 @@ def retry_until(fun, tester=None, times=3, msg=None):
         time.sleep(2 ** i)
 
     return result
+
+
+def convert_exceptions_to_false(fun, silent=False):
+    def converter(fun, silent):
+        try:
+            result = fun()
+        except Exception as e:
+            if not silent:
+                print("\nCaught exception:", str(e))
+            return False
+        return result
+    return partial(converter, fun, silent)
 
 
 attempts = {} # used to count test retries


### PR DESCRIPTION
Fixes #2184 

Turns out that Google search results links are structured a bit differently in Firefox for Android, so they weren't getting unwrapped/deinstrumented properly. This change adds a couple of logical switches into the Google first party script we run so that links on Firefox Android get scrubbed and the href gets properly reassigned.
