### PR TITLE
Show Frame URL on Widget Replacement Divs

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -543,7 +543,7 @@
         }
     },
     "widget_placeholder_pb_has_replaced": {
-        "message": "Privacy Badger has replaced $START_ANCHOR_TAG$ this $WIDGET$ widget $END_ANCHOR_TAG$",
+        "message": "Privacy Badger has replaced $START_ANCHOR_TAG$this $WIDGET$ widget$END_ANCHOR_TAG$",
         "description": "Text shown inside a replaced widget's placeholder. For example, \"Privacy Badger has replaced this Google reCAPTCHA widget\". See also the social_tooltip_pb_has_replaced message.",
         "placeholders": {
             "widget": {
@@ -552,7 +552,7 @@
             },
             "start_anchor_tag": {
                 "content": "$2",
-                "example": "<a>"
+                "example": "<a href='https://vimeo.com/76979871'>"
             },
             "end_anchor_tag": {
                 "content": "$3",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -543,12 +543,20 @@
         }
     },
     "widget_placeholder_pb_has_replaced": {
-        "message": "Privacy Badger has replaced this $WIDGET$ widget",
+        "message": "Privacy Badger has replaced $START_ANCHOR_TAG$ this $WIDGET$ widget $END_ANCHOR_TAG$",
         "description": "Text shown inside a replaced widget's placeholder. For example, \"Privacy Badger has replaced this Google reCAPTCHA widget\". See also the social_tooltip_pb_has_replaced message.",
         "placeholders": {
             "widget": {
                 "content": "$1",
                 "example": "Google reCAPTCHA"
+            },
+            "start_anchor_tag": {
+                "content": "$2",
+                "example": "<a>"
+            },
+            "end_anchor_tag": {
+                "content": "$3",
+                "example": "</a>"
             }
         }
     },

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -451,12 +451,12 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     widget_link.href = elToReplace.src;
     widget_link.innerHTML = name + ' widget';
 
-    textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", ' ')
-    textDiv.appendChild(widget_link)
+    textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", ' ');
+    textDiv.appendChild(widget_link);
   } else {
     textDiv.appendChild(document.createTextNode(
       TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)));
-  };
+  }
 
   let infoIcon = document.createElement('a'),
     info_icon_id = _make_id("ico-help");

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -443,8 +443,21 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
 
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
-  textDiv.appendChild(document.createTextNode(
-    TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)));
+  // add link to replaced widget text if it has a src
+  if (elToReplace.getAttribute("src")) {
+    let widget_link = document.createElement("a");
+    widget_link.rel = "noreferrer";
+    widget_link.target = "_blank";
+    widget_link.href = elToReplace.src;
+    widget_link.innerHTML = name + ' widget';
+
+    textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", ' ')
+    textDiv.appendChild(widget_link)
+  } else {
+    textDiv.appendChild(document.createTextNode(
+      TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)));
+  };
+
   let infoIcon = document.createElement('a'),
     info_icon_id = _make_id("ico-help");
   infoIcon.id = info_icon_id;

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -445,8 +445,8 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   textDiv.style = styleAttrs.join(" !important;") + " !important";
 
   let summary = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name),
-    link_start = "start_anchor_tag",
-    link_end = "end_anchor_tag";
+    link_start = "YYY",
+    link_end = "ZZZ";
 
   // add link to replaced widget text if it has a src
   if (elToReplace.nodeName.toLowerCase() == 'iframe' && elToReplace.src) {

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -460,7 +460,6 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     widgetLink.textContent = link_text;
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
-    widgetLink.id = ("widgetLink");
     widgetLink.href = elToReplace.src;
 
     let firstNode = document.createElement("span");
@@ -468,13 +467,6 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
 
     let secondNode = document.createElement("span");
     secondNode.textContent = text_after;
-
-    let widgetLinkStyles = [
-      "color: #ec9329",
-      "text-decoration: none"
-    ];
-
-    widgetLink.style = widgetLinkStyles.join(" !important;") + " !important";
 
     // package up one solid html chunk and append that to the replaced widget text node
     wrapperDiv.appendChild(firstNode);
@@ -622,6 +614,13 @@ html, body {
   width: 1em;
 }
 #${info_icon_id}:hover:before {
+  color: #ec9329;
+}
+a {
+  text-decoration: underline;
+  color: black;
+}
+a:hover {
   color: #ec9329;
 }
   `.trim();

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -450,24 +450,24 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     let wrapperDiv = document.createElement("div");
 
     // construct the widget link
-    let localeText = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)
+    let localeText = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name);
 
-    let node1Text = localeText.slice(0, localeText.indexOf('start_anchor_tag'))
-    let node2Text = localeText.slice(localeText.indexOf('end_anchor_tag') + 14, localeText.length)
-    let widgetLinkText = localeText.slice(localeText.indexOf('start_anchor_tag') + 16, localeText.indexOf('end_anchor_tag'))
+    let node1Text = localeText.slice(0, localeText.indexOf('start_anchor_tag'));
+    let node2Text = localeText.slice(localeText.indexOf('end_anchor_tag') + 14, localeText.length);
+    let widgetLinkText = localeText.slice(localeText.indexOf('start_anchor_tag') + 16, localeText.indexOf('end_anchor_tag'));
 
-    let widgetLink = document.createElement("a")
-    widgetLink.textContent = widgetLinkText
+    let widgetLink = document.createElement("a");
+    widgetLink.textContent = widgetLinkText;
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
     widgetLink.id = ("widgetLink");
     widgetLink.href = elToReplace.src;
 
-    let firstNode = document.createElement("span")
-    firstNode.textContent = node1Text
+    let firstNode = document.createElement("span");
+    firstNode.textContent = node1Text;
 
-    let secondNode = document.createElement("span")
-    secondNode.textContent = node2Text
+    let secondNode = document.createElement("span");
+    secondNode.textContent = node2Text;
 
     let widgetLinkStyles = [
       "color: #ec9329",
@@ -477,8 +477,8 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     widgetLink.style = widgetLinkStyles.join(" !important;") + " !important";
 
     // package up one solid html chunk and append that to the replaced widget text node
-    wrapperDiv.appendChild(firstNode)
-    wrapperDiv.appendChild(widgetLink)
+    wrapperDiv.appendChild(firstNode);
+    wrapperDiv.appendChild(widgetLink);
     wrapperDiv.appendChild(secondNode);
 
     textDiv.appendChild(wrapperDiv);

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -446,25 +446,45 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
 
   // add link to replaced widget text if it has a src
   if (elToReplace.getAttribute("src") && elToReplace.tagName == 'IFRAME') {
+    // create wrapper divs for link and text nodes
+    let wrapperDiv = document.createElement("div");
+    let textNode1 = document.createElement("span");
+    let textNode2 = document.createElement("span");
+
     let widgetLink = document.createElement("a");
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
     widgetLink.href = elToReplace.src;
-    widgetLink.innerHTML = name + ' widget';
+    widgetLink.id = ("widgetLink");
+    widgetLink.innerText = 'this ' + name + ' widget';
 
     let widgetLinkStyles = [
       "color: #ec9329",
-      "margin-left: 3px",
       "text-decoration: none"
     ];
 
     widgetLink.style = widgetLinkStyles.join(" !important;") + " !important";
 
-    textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", '');
-    textDiv.appendChild(widgetLink);
+    // create html chunk
+    wrapperDiv.appendChild(textNode1).appendChild(widgetLink).appendChild(textNode2);
+
+    // replace placeholders in locale string
+    let textChunk = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", "");
+    textChunk = textChunk.replace("start_anchor_tag", "");
+    textChunk = textChunk.replace("end_anchor_tag", "");
+    textChunk = textChunk.replace("this", "");
+    textChunk = textChunk.replace("widget", "");
+
+    textDiv.appendChild(document.createTextNode(textChunk));
+
+    textDiv.appendChild(wrapperDiv);
   } else {
-    textDiv.appendChild(document.createTextNode(
-      TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)));
+    // there is no link to construct onto the widget replacement modal
+    // replace and remove the placeholders on the locales string
+    let textChunk = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name);
+    textChunk = textChunk.replace("start_anchor_tag", "");
+    textChunk = textChunk.replace("end_anchor_tag", "");
+    textDiv.appendChild(document.createTextNode(textChunk));
   }
 
   let infoIcon = document.createElement('a'),

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -453,7 +453,7 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
 
     // construct the widget link
     let text_before = summary.slice(0, summary.indexOf('start_anchor_tag'));
-    let text_after = summary.slice(summary.indexOf('end_anchor_tag') + 14, summary.length);
+    let text_after = summary.slice(summary.indexOf('end_anchor_tag') + 14);
     let link_text = summary.slice(summary.indexOf('start_anchor_tag') + 16, summary.indexOf('end_anchor_tag'));
 
     let widgetLink = document.createElement("a");

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -448,8 +448,14 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     link_start = "YYY",
     link_end = "ZZZ";
 
-  // add link to replaced widget text if it has a src
+  // get a direct link to widget content when available
+  let widget_url;
+  // use the frame URL for framed widgets
   if (elToReplace.nodeName.toLowerCase() == 'iframe' && elToReplace.src) {
+    widget_url = elToReplace.src;
+  }
+
+  if (widget_url) {
     // construct link to original widget frame
     let text_before = summary.slice(0, summary.indexOf(link_start)),
       text_after = summary.slice(summary.indexOf(link_end) + link_end.length),
@@ -464,9 +470,9 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     }
 
     let widgetLink = document.createElement("a");
+    widgetLink.href = widget_url;
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
-    widgetLink.href = elToReplace.src;
     widgetLink.appendChild(document.createTextNode(link_text));
     wrapperDiv.appendChild(widgetLink);
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -445,22 +445,22 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   textDiv.style = styleAttrs.join(" !important;") + " !important";
   // add link to replaced widget text if it has a src
   if (elToReplace.getAttribute("src")) {
-    let widget_link = document.createElement("a");
-    widget_link.rel = "noreferrer";
-    widget_link.target = "_blank";
-    widget_link.href = elToReplace.src;
-    widget_link.innerHTML = name + ' widget';
+    let widgetLink = document.createElement("a");
+    widgetLink.rel = "noreferrer";
+    widgetLink.target = "_blank";
+    widgetLink.href = elToReplace.src;
+    widgetLink.innerHTML = name + ' widget';
 
-    let widget_link_styles = [
+    let widgetLinkStyles = [
       "color: #ec9329",
       "margin-left: 3px",
       "text-decoration: none"
     ];
 
-    widget_link.style = widget_link_styles.join(" !important;") + " !important";
+    widgetLink.style = widgetLinkStyles.join(" !important;") + " !important";
 
     textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", '');
-    textDiv.appendChild(widget_link);
+    textDiv.appendChild(widgetLink);
   } else {
     textDiv.appendChild(document.createTextNode(
       TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)));

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -445,7 +445,7 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   textDiv.style = styleAttrs.join(" !important;") + " !important";
 
   // add link to replaced widget text if it has a src
-  if (elToReplace.getAttribute("src") && elToReplace.tagName == 'IFRAME') {
+  if (elToReplace.nodeName.toLowerCase() == 'iframe' && elToReplace.src) {
     // create wrapper divs for link and text nodes
     let wrapperDiv = document.createElement("div");
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -443,8 +443,9 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
 
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
+
   // add link to replaced widget text if it has a src
-  if (elToReplace.getAttribute("src")) {
+  if (elToReplace.getAttribute("src") && elToReplace.tagName == 'IFRAME') {
     let widgetLink = document.createElement("a");
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -448,15 +448,26 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   if (elToReplace.getAttribute("src") && elToReplace.tagName == 'IFRAME') {
     // create wrapper divs for link and text nodes
     let wrapperDiv = document.createElement("div");
-    let textNode1 = document.createElement("span");
-    let textNode2 = document.createElement("span");
 
-    let widgetLink = document.createElement("a");
+    // construct the widget link
+    let localeText = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name)
+
+    let node1Text = localeText.slice(0, localeText.indexOf('start_anchor_tag'))
+    let node2Text = localeText.slice(localeText.indexOf('end_anchor_tag') + 14, localeText.length)
+    let widgetLinkText = localeText.slice(localeText.indexOf('start_anchor_tag') + 16, localeText.indexOf('end_anchor_tag'))
+
+    let widgetLink = document.createElement("a")
+    widgetLink.textContent = widgetLinkText
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
-    widgetLink.href = elToReplace.src;
     widgetLink.id = ("widgetLink");
-    widgetLink.innerText = 'this ' + name + ' widget';
+    widgetLink.href = elToReplace.src;
+
+    let firstNode = document.createElement("span")
+    firstNode.textContent = node1Text
+
+    let secondNode = document.createElement("span")
+    secondNode.textContent = node2Text
 
     let widgetLinkStyles = [
       "color: #ec9329",
@@ -465,17 +476,10 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
 
     widgetLink.style = widgetLinkStyles.join(" !important;") + " !important";
 
-    // create html chunk
-    wrapperDiv.appendChild(textNode1).appendChild(widgetLink).appendChild(textNode2);
-
-    // replace placeholders in locale string
-    let textChunk = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", "");
-    textChunk = textChunk.replace("start_anchor_tag", "");
-    textChunk = textChunk.replace("end_anchor_tag", "");
-    textChunk = textChunk.replace("this", "");
-    textChunk = textChunk.replace("widget", "");
-
-    textDiv.appendChild(document.createTextNode(textChunk));
+    // package up one solid html chunk and append that to the replaced widget text node
+    wrapperDiv.appendChild(firstNode)
+    wrapperDiv.appendChild(widgetLink)
+    wrapperDiv.appendChild(secondNode);
 
     textDiv.appendChild(wrapperDiv);
   } else {

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -444,41 +444,41 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
 
-  let summary = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name);
+  let summary = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name),
+    link_start = "start_anchor_tag",
+    link_end = "end_anchor_tag";
 
   // add link to replaced widget text if it has a src
   if (elToReplace.nodeName.toLowerCase() == 'iframe' && elToReplace.src) {
-    // create wrapper divs for link and text nodes
+    // construct link to original widget frame
+    let text_before = summary.slice(0, summary.indexOf(link_start)),
+      text_after = summary.slice(summary.indexOf(link_end) + link_end.length),
+      link_text = summary.slice(
+        summary.indexOf(link_start) + link_start.length, summary.indexOf(link_end));
+
+    // nest in a wrapper to preserve whitespace (flexbox)
     let wrapperDiv = document.createElement("div");
 
-    // construct the widget link
-    let text_before = summary.slice(0, summary.indexOf('start_anchor_tag'));
-    let text_after = summary.slice(summary.indexOf('end_anchor_tag') + 14);
-    let link_text = summary.slice(summary.indexOf('start_anchor_tag') + 16, summary.indexOf('end_anchor_tag'));
+    if (text_before) {
+      wrapperDiv.appendChild(document.createTextNode(text_before));
+    }
 
     let widgetLink = document.createElement("a");
-    widgetLink.textContent = link_text;
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
     widgetLink.href = elToReplace.src;
-
-    let firstNode = document.createElement("span");
-    firstNode.textContent = text_before;
-
-    let secondNode = document.createElement("span");
-    secondNode.textContent = text_after;
-
-    // package up one solid html chunk and append that to the replaced widget text node
-    wrapperDiv.appendChild(firstNode);
+    widgetLink.appendChild(document.createTextNode(link_text));
     wrapperDiv.appendChild(widgetLink);
-    wrapperDiv.appendChild(secondNode);
+
+    if (text_after) {
+      wrapperDiv.appendChild(document.createTextNode(text_after));
+    }
 
     textDiv.appendChild(wrapperDiv);
+
   } else {
-    // there is no link to construct onto the widget replacement modal
-    // replace and remove the placeholders on the locales string
-    summary = summary.replace("start_anchor_tag", "");
-    summary = summary.replace("end_anchor_tag", "");
+    // no link to construct, remove the link markers
+    summary = summary.replace(link_start, "").replace(link_end, "");
     textDiv.appendChild(document.createTextNode(summary));
   }
 

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -444,30 +444,30 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   let textDiv = document.createElement('div');
   textDiv.style = styleAttrs.join(" !important;") + " !important";
 
+  let summary = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name);
+
   // add link to replaced widget text if it has a src
   if (elToReplace.nodeName.toLowerCase() == 'iframe' && elToReplace.src) {
     // create wrapper divs for link and text nodes
     let wrapperDiv = document.createElement("div");
 
     // construct the widget link
-    let localeText = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name);
-
-    let node1Text = localeText.slice(0, localeText.indexOf('start_anchor_tag'));
-    let node2Text = localeText.slice(localeText.indexOf('end_anchor_tag') + 14, localeText.length);
-    let widgetLinkText = localeText.slice(localeText.indexOf('start_anchor_tag') + 16, localeText.indexOf('end_anchor_tag'));
+    let text_before = summary.slice(0, summary.indexOf('start_anchor_tag'));
+    let text_after = summary.slice(summary.indexOf('end_anchor_tag') + 14, summary.length);
+    let link_text = summary.slice(summary.indexOf('start_anchor_tag') + 16, summary.indexOf('end_anchor_tag'));
 
     let widgetLink = document.createElement("a");
-    widgetLink.textContent = widgetLinkText;
+    widgetLink.textContent = link_text;
     widgetLink.rel = "noreferrer";
     widgetLink.target = "_blank";
     widgetLink.id = ("widgetLink");
     widgetLink.href = elToReplace.src;
 
     let firstNode = document.createElement("span");
-    firstNode.textContent = node1Text;
+    firstNode.textContent = text_before;
 
     let secondNode = document.createElement("span");
-    secondNode.textContent = node2Text;
+    secondNode.textContent = text_after;
 
     let widgetLinkStyles = [
       "color: #ec9329",
@@ -485,10 +485,9 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
   } else {
     // there is no link to construct onto the widget replacement modal
     // replace and remove the placeholders on the locales string
-    let textChunk = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX", name);
-    textChunk = textChunk.replace("start_anchor_tag", "");
-    textChunk = textChunk.replace("end_anchor_tag", "");
-    textDiv.appendChild(document.createTextNode(textChunk));
+    summary = summary.replace("start_anchor_tag", "");
+    summary = summary.replace("end_anchor_tag", "");
+    textDiv.appendChild(document.createTextNode(summary));
   }
 
   let infoIcon = document.createElement('a'),

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -451,7 +451,15 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     widget_link.href = elToReplace.src;
     widget_link.innerHTML = name + ' widget';
 
-    textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", ' ');
+    let widget_link_styles = [
+      "color: #ec9329",
+      "margin-left: 3px",
+      "text-decoration: none"
+    ];
+
+    widget_link.style = widget_link_styles.join(" !important;") + " !important";
+
+    textDiv.innerHTML = TRANSLATIONS.widget_placeholder_pb_has_replaced.replace("XXX widget", '');
     textDiv.appendChild(widget_link);
   } else {
     textDiv.appendChild(document.createTextNode(

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -631,7 +631,7 @@ let getWidgetList = (function () {
     },
     {
       key: "widget_placeholder_pb_has_replaced",
-      placeholders: ["XXX"]
+      placeholders: ["XXX", "start_anchor_tag", "end_anchor_tag"]
     },
     { key: "allow_once" },
     { key: "allow_on_site" },

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -631,7 +631,7 @@ let getWidgetList = (function () {
     },
     {
       key: "widget_placeholder_pb_has_replaced",
-      placeholders: ["XXX", "start_anchor_tag", "end_anchor_tag"]
+      placeholders: ["XXX", "YYY", "ZZZ"]
     },
     { key: "allow_once" },
     { key: "allow_on_site" },


### PR DESCRIPTION
Fixes #2384 

This adds a link to the text that overlays on the widget replacement notification that users get. It provides a click through (new tab, no referer) link so that users can get to the embedded media directly without having to interact with it on the given frame.

Here's how it looks:

![Screen Shot 2020-11-12 at 10 25 34 AM](https://user-images.githubusercontent.com/25778052/98980584-a29e9a00-24d1-11eb-932d-d93bfd6faef4.png)

