### PR TITLE
Community learning discussion draft

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -173,6 +173,14 @@
         "message": "Learn in Private/Incognito windows",
         "description": "Checkbox label on the general settings page"
     },
+    "options_community_learning_setting": {
+        "message": "Enable community learning and share data about trackers",
+        "description": "Checkbox label on the general settings page"
+    },
+    "options_community_learning_warning": {
+        "message": "When you enable community learning, your browser will share some information it collects about trackers with EFF. Specifically, each time your instance of Privacy Badger observes a particular tracker on a website that it has not seen before, it will share the origin (top-level domain +1) of both the tracker and the website, as well as the type of tracking action that it observed. EFF will only use this information for generating community learning lists, and will never share personal information with third parties. For more details, see our privacy policy: https://link.to.come",
+        "description": "Checkbox label on the general settings page"
+    },
     "options_incognito_warning": {
         "message": "Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
         "description": "Tooltip on the general settings page"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1004,7 +1004,7 @@ Badger.prototype = {
   },
 
   /**
-   * Checks if local storage ( in dict) has any high-entropy keys
+   * Checks if local storage (in dict) has any high-entropy keys
    *
    * @param {Object} lsItems Local storage dict
    * @returns {boolean} true if it seems there are supercookies

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -715,6 +715,7 @@ Badger.prototype = {
     migrationLevel: 0,
     seenComic: false,
     sendDNTSignal: true,
+    shareLearning: false,
     showCounter: true,
     showIntroPage: true,
     showNonTrackingDomains: false,
@@ -930,10 +931,22 @@ Badger.prototype = {
    * and if tab_id is for an incognito window,
    * is learning in incognito windows enabled?
    */
-  isLearningEnabled(tab_id) {
+  isLocalLearningEnabled(tab_id) {
     return (
       this.getSettings().getItem("learnLocally") &&
       incognito.learningEnabled(tab_id)
+    );
+  },
+
+  /**
+   * Is any kind of learning (local or community) enabled on this tab?
+   *
+   * TODO: should community learning happen in incognito tabs?
+   */
+  isLearningEnabled(tab_id) {
+    return (
+      this.getSettings().getItem("shareLearning") ||
+      this.isLocalLearningEnabled(tab_id)
     );
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -939,14 +939,25 @@ Badger.prototype = {
   },
 
   /**
+   * Is community learning generally enabled,
+   * and is tab_id in a regular (not incognito) window?
+   */
+  isCommunityLearningEnabled(tab_id) {
+    return (
+      this.getSettings().getItem("shareLearning") &&
+      !incognito.isIncognito(tab_id)
+    );
+  },
+
+  /**
    * Is any kind of learning (local or community) enabled on this tab?
    *
    * TODO: should community learning happen in incognito tabs?
    */
   isLearningEnabled(tab_id) {
     return (
-      this.getSettings().getItem("shareLearning") ||
-      this.isLocalLearningEnabled(tab_id)
+      this.isLocalLearningEnabled(tab_id) ||
+      this.isCommunityLearningEnabled(tab_id)
     );
   },
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -50,5 +50,12 @@ exports.BLOCKED_ACTIONS = new Set([
   exports.USER_COOKIEBLOCK,
 ]);
 
+exports.TRACKER_TYPES = Object.freeze({
+  COOKIE: "cookie",
+  COOKIE_SHARE: "cookie_share",
+  SUPERCOOKIE: "supercookie",
+  FINGERPRINT: "fingerprint",
+})
+
 return exports;
 })();

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -40,6 +40,10 @@ var exports = {
   TRACKING_THRESHOLD: 3,
   MAX_COOKIE_ENTROPY: 12,
 
+  // The max amount of time (in milliseconds) that PB will wait before sharing a
+  // tracking action with EFF for community learning
+  MAX_CL_WAIT_TIME: 30 * 60 * 1000; // one half hour
+
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
 };
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -42,11 +42,14 @@ var exports = {
 
   // The max amount of time (in milliseconds) that PB will wait before sharing a
   // tracking action with EFF for community learning
-  MAX_CL_WAIT_TIME: 0, //30 * 60 * 1000, // one half hour
+  MAX_CL_WAIT_TIME: 5 * 60 * 1000, // five minutes
 
   // The probability that any given tracking action will be logged to the
   // community server, as a float from 0.0 to 1.0
   CL_PROBABILITY: 1.0,
+
+  // size of the in-memory community learning cache
+  CL_CACHE_SIZE: 5000,
 
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
 };

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -42,7 +42,11 @@ var exports = {
 
   // The max amount of time (in milliseconds) that PB will wait before sharing a
   // tracking action with EFF for community learning
-  MAX_CL_WAIT_TIME: 30 * 60 * 1000; // one half hour
+  MAX_CL_WAIT_TIME: 0, //30 * 60 * 1000, // one half hour
+
+  // The probability that any given tracking action will be logged to the
+  // community server, as a float from 0.0 to 1.0
+  CL_PROBABILITY: 1.0,
 
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
 };

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -328,7 +328,7 @@ HeuristicBlocker.prototype = {
     }
 
     // If community learning is enabled, queue up a request to the EFF server
-    if (badger.getSettings().getItem("shareLearning")) {
+    if (badger.isCommunityLearningEnabled(tab_id)) {
       let page_fqdn = (new URI(this.tabUrls[tab_id])).host;
       this.shareTrackerInfo(page_fqdn, tracker_fqdn, tracker_type);
     }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -326,7 +326,8 @@ HeuristicBlocker.prototype = {
 
     // If community learning is enabled, queue up a request to the EFF server
     if (badger.getSettings().getItem("shareLearning")) {
-      this.maybeShareTracker(page_origin, tracker_origin, tracker_type);
+      let page_fqdn = (new URI(this.tabUrls[tab_id])).host;
+      this.shareTrackerInfo(page_fqdn, tracker_fqdn, tracker_type);
     }
 
     // If local learning is enabled, record that we've seen this tracker on this
@@ -350,18 +351,18 @@ HeuristicBlocker.prototype = {
   },
 
   /**
-   * Flip a coin, then maybe share information about the tracker we just saw
+   * Share information about a tracker for community learning
    */
-  maybeShareTracker: function(page_origin, tracker_origin, tracker_type) {
-    // Some chance of sharing any given tracking action
+  shareTrackerInfo: function(page_host, tracker_host, tracker_type) {
+    // Share a random sample of trackers we observe
     if (Math.random() < constants.CL_PROBABILITY) {
       setTimeout(function() {
        fetch("http://localhost:8080", {
          method: "POST",
          body: JSON.stringify({
            tracker_data: {
-             page_origin: page_origin,
-             tracker_origin: tracker_origin,
+             page_host: page_host,
+             tracker_host: tracker_host,
              tracker_type: tracker_type,
            }
          })
@@ -370,7 +371,7 @@ HeuristicBlocker.prototype = {
            console.log("tracking action logging failed:", res);
          }
        });
-      // share info after a random delay
+      // share info after a random delay, to reduce network load on browser
       }, Math.floor(Math.random() * constants.MAX_CL_WAIT_TIME));
     }
   }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -340,11 +340,8 @@ HeuristicBlocker.prototype = {
     this.storage.setupHeuristicAction(tracker_fqdn, constants.ALLOW);
     this.storage.setupHeuristicAction(tracker_origin, constants.ALLOW);
 
-    // Blocking based on outbound cookies
-    var httpRequestPrevalence = firstParties.length;
-
     // block the origin if it has been seen on multiple first party domains
-    if (httpRequestPrevalence >= constants.TRACKING_THRESHOLD) {
+    if (firstParties.length >= constants.TRACKING_THRESHOLD) {
       log('blocklisting origin', tracker_fqdn);
       this.blocklistOrigin(tracker_origin, tracker_fqdn);
     }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -104,8 +104,10 @@ HeuristicBlocker.prototype = {
    * @param {Boolean} check_for_cookie_share whether to check for cookie sharing
    */
   heuristicBlockingAccounting: function (details, check_for_cookie_share) {
+    let tab_id = details.tabId;
+
     // ignore requests that are outside a tabbed window
-    if (details.tabId < 0 || !badger.isLearningEnabled(details.tabId)) {
+    if (tab_id < 0 || !badger.isLearningEnabled(tab_id)) {
       return {};
     }
 
@@ -115,12 +117,12 @@ HeuristicBlocker.prototype = {
 
     // if this is a main window request, update tab data and quit
     if (details.type == "main_frame") {
-      self.tabOrigins[details.tabId] = request_origin;
-      self.tabUrls[details.tabId] = details.url;
+      self.tabOrigins[tab_id] = request_origin;
+      self.tabUrls[tab_id] = details.url;
       return {};
     }
 
-    let tab_origin = self.tabOrigins[details.tabId];
+    let tab_origin = self.tabOrigins[tab_id];
 
     // ignore first-party requests
     if (!tab_origin || !utils.isThirdPartyDomain(request_origin, tab_origin)) {
@@ -147,10 +149,10 @@ HeuristicBlocker.prototype = {
     }
 
     // check for cookie sharing iff this is an image in the top-level frame, and the request URL has parameters
-    if (check_for_cookie_share && details.type == 'image' && details.frameId === 0 && details.url.indexOf('?') > -1) {
+    if (false && details.type == 'image' && details.frameId === 0 && details.url.indexOf('?') > -1) {
       // get all non-HttpOnly cookies for the top-level frame
       // and pass those to the cookie-share accounting function
-      let tab_url = self.tabUrls[details.tabId];
+      let tab_url = self.tabUrls[tab_id];
 
       let config = {
         url: tab_url

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -331,7 +331,7 @@ HeuristicBlocker.prototype = {
 
     // If community learning is enabled, queue up a request to the EFF server
     if (badger.getSettings().getItem("shareLearning")) {
-      this.maybeShareTracker(page_origin, tracker_fqdn, tracker_type);
+      this.maybeShareTracker(page_origin, tracker_origin, tracker_type);
     }
 
     // ALLOW indicates this is a tracker still below TRACKING_THRESHOLD
@@ -348,16 +348,29 @@ HeuristicBlocker.prototype = {
       log('blocklisting origin', tracker_fqdn);
       this.blocklistOrigin(tracker_origin, tracker_fqdn);
     }
-  }
+  },
 
   /**
    * Flip a coin, then maybe share information about the tracker we just saw
    */
-  maybeShareTracker(page_origin, tracker_fqdn, tracker_type) {
+  maybeShareTracker: function(page_origin, tracker_origin, tracker_type) {
     // 50% chance of sharing any given tracking action
-    if (Math.random() < 0.5) {
+    if (Math.random() < constants.CL_PROBABILITY) {
       setTimeout(function() {
-        // TODO
+       fetch("http://localhost:8080", {
+         method: "POST",
+         body: JSON.stringify({
+           tracker_data: {
+             page_origin: page_origin,
+             tracker_origin: tracker_origin,
+             tracker_type: tracker_type,
+           }
+         })
+       }).then(res => {
+         if (!res.ok) {
+           console.log("tracking action logging failed:", res);
+         }
+       });
       }, Math.floor(Math.random() * constants.MAX_CL_WAIT_TIME));
     }
   }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -141,7 +141,8 @@ HeuristicBlocker.prototype = {
 
     // check if there are tracking cookies
     if (hasCookieTracking(details, request_origin)) {
-      self._recordPrevalence(request_host, request_origin, tab_origin);
+      self._recordPrevalence(request_host, request_origin, tab_origin,
+                             constants.TRACKER_TYPES.COOKIE);
       return {};
     }
 
@@ -251,7 +252,8 @@ HeuristicBlocker.prototype = {
             log("Found high-entropy cookie share from", tab_origin, "to", request_host,
               ":", entropy, "bits\n  cookie:", cookie.name, '=', cookie.value,
               "\n  arg:", key, "=", value, "\n  substring:", s);
-            this._recordPrevalence(request_host, request_origin, tab_origin);
+            this._recordPrevalence(request_host, request_origin, tab_origin,
+                                   constants.TRACKER_TYPES.COOKIE_SHARE);
             return;
           }
         }
@@ -265,8 +267,9 @@ HeuristicBlocker.prototype = {
    * @param {String} tracker_fqdn The fully qualified domain name of the tracker
    * @param {String} tracker_origin Base domain of the third party tracker
    * @param {String} page_origin Base domain of page where tracking occurred
+   * @param {String} tracker_type the kind of tracking action that was observed
    */
-  updateTrackerPrevalence: function (tracker_fqdn, tracker_origin, page_origin) {
+  updateTrackerPrevalence: function (tracker_fqdn, tracker_origin, page_origin, tracker_type) {
     // abort if we already made a decision for this fqdn
     let action = this.storage.getAction(tracker_fqdn);
     if (action != constants.NO_TRACKING && action != constants.ALLOW) {
@@ -276,7 +279,8 @@ HeuristicBlocker.prototype = {
     this._recordPrevalence(
       tracker_fqdn,
       tracker_origin,
-      page_origin
+      page_origin,
+      tracker_type
     );
   },
 
@@ -292,8 +296,9 @@ HeuristicBlocker.prototype = {
    * @param {String} tracker_fqdn The FQDN of the third party tracker
    * @param {String} tracker_origin Base domain of the third party tracker
    * @param {String} page_origin Base domain of page where tracking occurred
+   * @param {String} tracker_type the kind of tracking action that was observed
    */
-  _recordPrevalence: function (tracker_fqdn, tracker_origin, page_origin) {
+  _recordPrevalence: function (tracker_fqdn, tracker_origin, page_origin, tracker_type) {
     var snitchMap = this.storage.getStore('snitch_map');
     var firstParties = [];
     if (snitchMap.hasItem(tracker_origin)) {

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -25,23 +25,30 @@ function startListeners() {
   chrome.tabs.onRemoved.addListener(onRemovedListener);
 }
 
+function isIncognito(tab_id) {
+  // if we don't have incognito data for whatever reason,
+  // default to "true"
+  if (!tabs.hasOwnProperty(tab_id)) {
+    return true;
+  }
+  // else, do not learn in incognito tabs
+  return tabs[tab_id];
+}
+
 function learningEnabled(tab_id) {
   if (badger.getSettings().getItem("learnInIncognito")) {
     // treat all pages as if they're not incognito
     return true;
   }
-  // if we don't have incognito data for whatever reason,
-  // default to disabled
-  if (!tabs.hasOwnProperty(tab_id)) {
-    return false;
-  }
-  // else, do not learn in incognito tabs
-  return !tabs[tab_id];
+
+  // otherwise, return true if this tab is _not_ incognito
+  return !isIncognito(tab_id);
 }
 
 /************************************** exports */
 let exports = {
   learningEnabled,
+  isIncognito,
   startListeners,
 };
 return exports;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -190,6 +190,18 @@ function loadOptions() {
       });
     });
 
+  $('#community-learning-checkbox')
+    .prop("checked", OPTIONS_DATA.settings.shareLearning)
+    .on("click", (event) => {
+      const enabled = $(event.currentTarget).prop("checked");
+      chrome.runtime.sendMessage({
+        type: "updateSettings",
+        data: {
+          shareLearning: enabled
+        }
+      }, function () {});
+    });
+
   $('#show-nontracking-domains-checkbox')
     .prop("disabled", OPTIONS_DATA.settings.learnLocally ? false : "disabled")
     .prop("checked", (

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -449,6 +449,7 @@ function recordSupercookie(tab_id, frame_url) {
     frame_host,
     window.getBaseDomain(frame_host),
     window.getBaseDomain(page_host),
+    tab_id,
     constants.TRACKER_TYPES.SUPERCOOKIE
   );
 }
@@ -517,7 +518,7 @@ function recordFingerprinting(tabId, msg) {
           // Mark this as a strike
           badger.heuristicBlocking.updateTrackerPrevalence(
             script_host, script_origin, window.getBaseDomain(document_host),
-            constants.TRACKER_TYPES.FINGERPRINT
+            tabId, constants.TRACKER_TYPES.FINGERPRINT
           );
         }
       }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -448,7 +448,8 @@ function recordSupercookie(tab_id, frame_url) {
   badger.heuristicBlocking.updateTrackerPrevalence(
     frame_host,
     window.getBaseDomain(frame_host),
-    window.getBaseDomain(page_host)
+    window.getBaseDomain(page_host),
+    constants.TRACKER_TYPES.SUPERCOOKIE
   );
 }
 
@@ -515,7 +516,9 @@ function recordFingerprinting(tabId, msg) {
 
           // Mark this as a strike
           badger.heuristicBlocking.updateTrackerPrevalence(
-            script_host, script_origin, window.getBaseDomain(document_host));
+            script_host, script_origin, window.getBaseDomain(document_host),
+            constants.TRACKER_TYPES.FINGERPRINT
+          );
         }
       }
       // This is a canvas write

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -235,6 +235,17 @@
           </label>
         </div>
       </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" id="community-learning-checkbox">
+          <span>
+            <span class="i18n_options_community_learning_setting"></span>
+            <span class="ui-icon ui-icon-alert tooltip"
+              title="i18n_options_community_learning_warning"></span>
+            <a href="https://www.eff.org/badger-evolution" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+          </span>
+        </label>
+      </div>
       <div class="checkbox" id="webRTCToggle" style="display:none">
         <label>
           <input type="checkbox" id="toggle_webrtc_mode">


### PR DESCRIPTION
#1299

This is the first stab at adding community learning to Privacy Badger -- giving users the option to share de-identified information about the trackers they collect with EFF. Users can now choose to opt-in to community learning. Then, whenever Privacy Badger observes a new tracker for the first time, it will share the following information:
```
{
  page_host: full domain of the page that the user is on, 
  tracker_host: full domain of the third-party tracker, 
  tracking_action: type of action that Privacy Badger observed, one of ("cookie", "supercookie", "fingerprint").
}
```

Other things:
- This is strictly opt-in, and no new data will be shared until a user checks the "community learning" box on the options page.
- Community learning is separate from local learning: both can be enabled or disabled independently.
- Community learning will not occur in incognito windows, even if local learning is enabled in incognito windows.
- A random sample of new tracking actions will be reported. The proportion of new trackers reported is controlled by `constants.CL_PROBABILITY`. Right now it's set to 1.0, meaning every action will be reported.
- To reduce network load, tracking actions will be reported after a random delay. The length of this delay is controlled by `constants.MAX_CL_WAIT_TIME`, currently set to 5 minutes.
- Only trackers which are not already blocked or cookieblocked will be reported. Furthermore, only tracker/page pairs that are not already in the snitch map will be reported. If evil.com has a snitch map entry logging it tracking on example.com in the past, but evil.com is not yet blocked, the evil.com/example.com tracking action will not be reported.
- To prevent duplicate reports, tracking actions that do get reported will be stored in an in-memory cache, `HeuristicBlocker.previouslySharedTrackers`. Tracking actions that are already present in the cache will not be reported again. Obviously, when the user restarts their browser, the cache will be cleared, but the goal is just to prevent crazy amounts of dupes. The size of the cache is capped by `constants.CL_CACHE_SIZE`.

This PR makes requests to "localhost:8080." If you want, you can set up a toy SQL server to test the logging.

On the server side, tracking actions will be stored in a SQL table that looks like this:

```
+----+---------------------+-----------------------------+-----------------------------+--------------+
| id | time                | page_host                   | tracker_host
| tracker_type |
+----+---------------------+-----------------------------+-----------------------------+--------------+
|  1 | 2020-10-28 10:38:48 | docs.python.org             | www.google.com
| cookie       |
|  2 | 2020-10-28 10:39:12 | docs.python.org             | adservice.google.com
| cookie       |
...
```

The server side is more up in the air, but for now, IP addresses and other identifying information will not be stored. Before this is deployed, we'll have some kind of privacy policy explaining exactly how logs etc. will be handled. We're still thinking through how best to prevent malicious reporting or other kinds of griefing.

We're thinking that the first version of community learning will be for informational purposes only -- the CL database will not automatically populate any block lists. This should reduce the incentive for bad actors to populate the database with bad data. We want to use the data to identify deficiencies in Badger Sett: what domains are we missing? on which domains do we need to crawl more widely? are there places where trackers don't appear unless a user logs in? 

Eventually, it might make sense to auto-generate a community learning list, but for now, we just want to see what kind of data people are generating.

Feedback, criticism, concern are welcome. What do you think?