### PR TITLE
Ignore Cisco OpenDNS/Umbrella proxy domains

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -847,6 +847,7 @@ Badger.prototype = {
       Migrations.forgetConsensu,
       Migrations.resetWebRTCIPHandlingPolicy2,
       Migrations.resetWebRtcIpHandlingPolicy3,
+      Migrations.forgetOpenDNS,
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -310,6 +310,11 @@ HeuristicBlocker.prototype = {
       return; // We already know about the presence of this tracker on the given domain
     }
 
+    // do not record Cisco OpenDNS/Umbrella proxy domains
+    if (tracker_fqdn.endsWith(".id.opendns.com")) {
+      return;
+    }
+
     // record that we've seen this tracker on this domain (in snitch map)
     firstParties.push(page_origin);
     snitchMap.setItem(tracker_origin, firstParties);

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -340,7 +340,12 @@ exports.Migrations= {
       // in case it needs to be migrated from Mode 4 to Mode 3
       badger.setPrivacyOverrides();
     });
-  }
+  },
+
+  forgetOpenDNS: (badger) => {
+    console.log("Forgetting Cisco OpenVPN domains ...");
+    badger.storage.forget("opendns.com");
+  },
 
 };
 


### PR DESCRIPTION
As the proxying makes all proxied domains seem third-party.

Two pieces:
- A check that skips updating `snitch_map` for domains that end in `.id.opendns.com`.
- A migration to remove any existing `opendns.com` domains from the database

We could instead strip the `.id.opendns.com` postfix before anything else is done with a request/response domain. Simply ignoring OpenDNS domains seems good enough for now though.