### PR TITLE
Tweaks to navigator.globalPrivacyControl

### DIFF
--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -30,7 +30,7 @@ function getPageScript() {
 
     OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "globalPrivacyControl", {
       get: function globalPrivacyControl() {
-        return "1";
+        return true;
       }
     });
 

--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -31,11 +31,13 @@ function getPageScript() {
     }
 
     if (!NAVIGATOR.globalPrivacyControl) {
-      OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "globalPrivacyControl", {
-        get: function globalPrivacyControl() {
-          return true;
-        }
-      });
+      try {
+        OBJECT.defineProperty(NAVIGATOR, "globalPrivacyControl", {
+          value: true
+        });
+      } catch (e) {
+        console.error("Privacy Badger failed to set navigator.globalPrivacyControl, probably because another extension set it in an incompatible way first.");
+      }
     }
 
   // save locally to keep from getting overwritten by site code

--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -22,17 +22,21 @@ function getPageScript() {
   // return a string
   return "(" + function (NAVIGATOR, OBJECT) {
 
-    OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "doNotTrack", {
-      get: function doNotTrack() {
-        return "1";
-      }
-    });
+    if (!NAVIGATOR.doNotTrack) {
+      OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "doNotTrack", {
+        get: function doNotTrack() {
+          return "1";
+        }
+      });
+    }
 
-    OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "globalPrivacyControl", {
-      get: function globalPrivacyControl() {
-        return true;
-      }
-    });
+    if (!NAVIGATOR.globalPrivacyControl) {
+      OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "globalPrivacyControl", {
+        get: function globalPrivacyControl() {
+          return true;
+        }
+      });
+    }
 
   // save locally to keep from getting overwritten by site code
   } + "(window.navigator, Object));";

--- a/src/js/contentscripts/dnt.js
+++ b/src/js/contentscripts/dnt.js
@@ -22,7 +22,7 @@ function getPageScript() {
   // return a string
   return "(" + function (NAVIGATOR, OBJECT) {
 
-    if (!NAVIGATOR.doNotTrack) {
+    if (NAVIGATOR.doNotTrack != "1") {
       OBJECT.defineProperty(OBJECT.getPrototypeOf(NAVIGATOR), "doNotTrack", {
         get: function doNotTrack() {
           return "1";

--- a/tests/selenium/dnt_test.py
+++ b/tests/selenium/dnt_test.py
@@ -279,8 +279,8 @@ class DntTest(pbtest.PBSeleniumTest):
         )
         self.assertEqual(
             self.js("return navigator.globalPrivacyControl"),
-            "1",
-            "navigator.globalPrivacyControl should have been set to \"1\""
+            True,
+            "navigator.globalPrivacyControl should have been set to true"
         )
 
     def test_navigator_unmodified_when_disabled_on_site(self):


### PR DESCRIPTION
- [x] Set GPC to `true` instead of `"1"`
- [x] Don't set GPC when already set to something truthy
- [x] Don't set DNT when already set to `"1"` (truthiness check doesn't work as Firefox defaults to `"unspecified"`; Chrome defaults to `null`)
- [x] Set GPC on the Navigator object (instead of on Navigator's prototype) to improve chances of overwriting another extension that previously set GPC (to something falsy).
- [x] Set GPC via value/data descriptor (instead of via getter/accessor descriptor) for the same reason
- [x] Log an error to the console when setting GPC fails to make the problem a bit more visible. You will see this error now if you install Privacy Badger from this branch, and then install the current production version of [DDG](https://duckduckgo.com/app).

Related discussion: https://github.com/globalprivacycontrol/gpc-spec/issues/11