### PR TITLE
Switch to latest tracker data on extension updates when local learning is disabled

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -370,6 +370,8 @@ Badger.prototype = {
         return resolve();
       }
 
+      let userActions = [];
+
       if (self.isUpdate) {
         if (self.getSettings().getItem("learnLocally")) {
           log("No need to load seed data (local learning is enabled)");
@@ -377,12 +379,11 @@ Badger.prototype = {
 
         } else {
           let actions = Object.entries(
-              self.storage.getStore('action_map').getItemClones()),
-            userActions = [];
+            self.storage.getStore('action_map').getItemClones());
 
           log("Clearing tracker data ...");
 
-          // save user slider modifications
+          // first save user slider modifications
           for (const [domain, actionData] of actions) {
             if (actionData.userAction != "") {
               userActions.push({
@@ -394,17 +395,18 @@ Badger.prototype = {
 
           // clear existing data
           self.storage.clearTrackerData();
-
-          // reapply customized sliders
-          for (const item of userActions) {
-            self.storage.setupUserAction(item.domain, item.action);
-          }
         }
       }
 
       log("Loading seed data ...");
       self.loadSeedData(err => {
         log("Seed data loaded! (err=%o)", err);
+
+        // reapply customized sliders if any
+        for (const item of userActions) {
+          self.storage.setupUserAction(item.domain, item.action);
+        }
+
         return (err ? reject(err) : resolve());
       });
     });

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -328,9 +328,9 @@ HeuristicBlocker.prototype = {
     self.storage.setupHeuristicAction(tracker_fqdn, constants.ALLOW);
     self.storage.setupHeuristicAction(tracker_origin, constants.ALLOW);
 
-    // block the origin if it has been seen on multiple first party domains
+    // (cookie)block the tracker if it has been seen on multiple first party domains
     if (firstParties.length >= constants.TRACKING_THRESHOLD) {
-      log('blocklisting origin', tracker_fqdn);
+      log("blocklisting", tracker_fqdn);
       self.blocklistOrigin(tracker_origin, tracker_fqdn);
     }
   }


### PR DESCRIPTION
From the [blog post](https://www.eff.org/deeplinks/2020/10/privacy-badger-changing-protect-you-better):

>... [I]n future updates to Privacy Badger we plan to replace [tracker lists of users with default settings] with new data compiled by Badger Sett. That means users who do not opt in to local learning will share the same block list and will continue receiving information about new trackers we discover, keeping their Badgers up-to-date.

This replacement should preserve user-customized sliders.

Follows up on #2679.