### PR TITLE
Add privacy override to disable network prediction

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -3,7 +3,13 @@
 This document explains the need for each [extension permission](https://developer.chrome.com/extensions/declare_permissions) declared in Privacy Badger's [extension manifest](/src/manifest.json).
 
 ## Privacy
-The Privacy API lets extensions modify browser-wide privacy settings. Privacy Badger uses the Privacy API to disable [hyperlink auditing](https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/). Privacy Badger also disables suggestions for similar pages when a page can't be found in Chrome, as this Chrome feature sends visited web addresses to Google. In addition, Privacy Badger allows users to set a stricter WebRTC IP handling policy in order to prevent leaking local network address information.
+The Privacy API lets extensions modify browser-wide privacy settings. Privacy Badger uses the Privacy API to disable the following settings:
+
+- [hyperlink auditing](https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/)
+- [prefetching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) (network predictions), as it presents a poor tradeoff between privacy and perceived browsing performance
+- suggestions for similar pages when a page can't be found in Chrome, as this Chrome feature sends visited web addresses to Google
+
+In addition, Privacy Badger allows users to set a stricter WebRTC IP handling policy in order to prevent leaking local network address information.
 
 ## Cookies
 Privacy Badger needs access to the cookies API in order to detect and correct a common error where Cloudflare domains are identified as trackers and blocked.

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -3,11 +3,11 @@
 This document explains the need for each [extension permission](https://developer.chrome.com/extensions/declare_permissions) declared in Privacy Badger's [extension manifest](/src/manifest.json).
 
 ## Privacy
-The Privacy API lets extensions modify browser-wide privacy settings. Privacy Badger uses the Privacy API to disable the following settings:
+The Privacy API lets extensions modify browser-wide privacy settings. Privacy Badger uses the Privacy API to disable:
 
-- [hyperlink auditing](https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/)
+- [hyperlink auditing](https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/), an [HTML feature](https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing) meant to optimize and normalize click tracking on the Web
 - [prefetching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) (network predictions), as it presents a poor tradeoff between privacy and perceived browsing performance
-- suggestions for similar pages when a page can't be found in Chrome, as this Chrome feature sends visited web addresses to Google
+- suggestions for similar pages when a page can't be found, as this Chrome feature sends visited web addresses to Google
 
 In addition, Privacy Badger allows users to set a stricter WebRTC IP handling policy in order to prevent leaking local network address information.
 

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -389,6 +389,10 @@
         "message": "Disable hyperlink auditing",
         "description": "Checkbox label found on the general settings page"
     },
+    "options_disable_network_prediction": {
+        "message": "Disable prefetching",
+        "description": "Checkbox label found on the general settings page"
+    },
     "options_domain_filter_user": {
         "message": "user-controlled",
         "description": "Dropdown control setting on the Tracking Domains options page tab."

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -299,6 +299,14 @@ Badger.prototype = {
       });
     }
 
+    if (chrome.privacy.network) {
+      _set_override(
+        "networkPredictionEnabled",
+        chrome.privacy.network.networkPredictionEnabled,
+        (self.getSettings().getItem("disableNetworkPrediction") ? false : null)
+      );
+    }
+
     if (chrome.privacy.services) {
       _set_override(
         "alternateErrorPagesEnabled",
@@ -798,6 +806,7 @@ Badger.prototype = {
     disabledSites: [],
     disableGoogleNavErrorService: true,
     disableHyperlinkAuditing: true,
+    disableNetworkPrediction: true,
     hideBlockedElements: true,
     learnInIncognito: false,
     learnLocally: false,

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -116,6 +116,20 @@ function loadOptions() {
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
   $("#check_dnt_policy_checkbox").prop("checked", OPTIONS_DATA.settings.checkForDNTPolicy).prop("disabled", !OPTIONS_DATA.settings.sendDNTSignal);
 
+  // only show the networkPredictionEnabled override when the browser supports it
+  if (chrome.privacy && chrome.privacy.network && chrome.privacy.network.networkPredictionEnabled) {
+    $("#privacy-settings-header").show();
+    $("#disable-network-prediction").show();
+    $('#disable-network-prediction-checkbox')
+      .prop("checked", OPTIONS_DATA.settings.disableNetworkPrediction)
+      .on("click", function () {
+        updatePrivacyOverride(
+          "disableNetworkPrediction",
+          $("#disable-network-prediction-checkbox").prop("checked")
+        );
+      });
+  }
+
   // only show the alternateErrorPagesEnabled override if browser supports it
   if (chrome.privacy && chrome.privacy.services && chrome.privacy.services.alternateErrorPagesEnabled) {
     $("#privacy-settings-header").show();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -128,6 +128,14 @@ function loadOptions() {
           $("#disable-network-prediction-checkbox").prop("checked")
         );
       });
+    // use a different help link in Firefox
+    if (chrome.runtime.getBrowserInfo) {
+      chrome.runtime.getBrowserInfo((info) => {
+        if (info.name == "Firefox" || info.name == "Waterfox") {
+          $('#disable-network-prediction-help-link')[0].href = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ";
+        }
+      });
+    }
   }
 
   // only show the alternateErrorPagesEnabled override if browser supports it

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -201,7 +201,7 @@
           <input type="checkbox" id="disable-network-prediction-checkbox">
           <span>
             <span class="i18n_options_disable_network_prediction"></span>
-            <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+            <a id="disable-network-prediction-help-link" href="https://www.google.com/intl/en/chrome/privacy/whitepaper.html#netpredict" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
           </span>
         </label>
       </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -196,6 +196,15 @@
           </span>
         </label>
       </div>
+      <div class="checkbox" id="disable-network-prediction" style="display:none">
+        <label>
+          <input type="checkbox" id="disable-network-prediction-checkbox">
+          <span>
+            <span class="i18n_options_disable_network_prediction"></span>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+          </span>
+        </label>
+      </div>
       <div class="checkbox" id="disable-google-nav-error-service" style="display:none">
         <label>
           <input type="checkbox" id="disable-google-nav-error-service-checkbox">


### PR DESCRIPTION
Fixes #1897.

As per https://developer.chrome.com/docs/extensions/reference/privacy/, disables "pre-resolving DNS entries and preemptively opening TCP and SSL connections to servers". In Chrome, "only affects actions taken by Chrome's internal prediction service" and [unfortunately](https://bugs.chromium.org/p/chromium/issues/detail?id=785125) "does not affect webpage-initiated prefectches [sic] or preconnects."

See also: https://www.google.com/intl/en/chrome/privacy/whitepaper.html#netpredict

----

As far as remaining `chrome.privacy` settings, we may want to disable search suggestions (using `chrome.privacy.services.searchSuggestEnabled`) in the future. This would "prevent Chrome from using a prediction service to help complete web addresses or search terms, when users type in the address bar". Not available in Firefox.