### PR TITLE
Fix inconsistent button font display

### DIFF
--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -512,8 +512,9 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     "transition: background-color 0.25s ease-out, border-color 0.25s ease-out, color 0.25s ease-out",
     "border-radius: 3px",
     "cursor: pointer",
-    "font-family: 'Lucida Grande', 'Segoe UI', Tahoma, 'DejaVu Sans', Arial, sans-serif",
-    "font-size: 12px",
+    // systemfontstack.com
+    "font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif",
+    "font-size: 14px",
     "font-weight: bold",
     "line-height: 16px",
     "padding: 10px",

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -516,6 +516,9 @@ function createReplacementWidget(widget, elToReplace, activationFn) {
     "font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif",
     "font-size: 14px",
     "font-weight: bold",
+    // fix overly bold text on macOS
+    "-webkit-font-smoothing: antialiased",
+    "-moz-osx-font-smoothing: grayscale",
     "line-height: 16px",
     "padding: 10px",
     "margin: 4px",

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -332,6 +332,9 @@ button {
     font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif;
     font-size: 14px;
     font-weight: bold;
+    /* fix overly bold text on macOS */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     line-height: 16px;
     margin-top: 8px;
     padding: 10px;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -328,8 +328,9 @@ button {
     border: 2px solid;
     border-radius: 3px;
     cursor: pointer;
-    font-family: 'Lucida Grande', 'Segoe UI', Tahoma, 'DejaVu Sans', Arial, sans-serif;
-    font-size: 12px;
+    /* systemfontstack.com */
+    font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif;
+    font-size: 14px;
     font-weight: bold;
     line-height: 16px;
     margin-top: 8px;


### PR DESCRIPTION
By using a ["system font stack"](https://systemfontstack.com/).

The font stack we use now is inconsistent across OS's. Take a look below: on one platform (in the default locale) a single word ("site") occupies a line all by itself, while the same button appears more balanced on other platforms.

## How popup buttons look in production now:

:x: Chrome on macOS:
<img width="419" alt="Screen Shot 2021-01-06 at 4 00 08 PM" src="https://user-images.githubusercontent.com/794578/103820221-f349f380-5039-11eb-9fa6-665e3758717c.png">

:x: Firefox on Windows (?):
![103813979-f1c6fe00-502e-11eb-8cd9-406e53a3ccec](https://user-images.githubusercontent.com/794578/103827018-06fb5700-5046-11eb-9229-c67af0b6a776.png)

:heavy_check_mark: Chrome on Ubuntu Linux:
![Screenshot from 2021-01-06 14-56-28](https://user-images.githubusercontent.com/794578/103814296-6ef27300-502f-11eb-8933-a5f1267c70b5.png)

## How popup buttons look with this patch:

:heavy_check_mark: Chrome on macOS:
<img width="426" alt="Screen Shot 2021-01-06 at 4 03 06 PM" src="https://user-images.githubusercontent.com/794578/103820333-27bdaf80-503a-11eb-90ed-91b81de23d94.png">

:heavy_check_mark: Chrome on Ubuntu Linux:
![Screenshot from 2021-01-06 14-57-46](https://user-images.githubusercontent.com/794578/103814524-d14b7380-502f-11eb-9fd3-08d86f3fbe9f.png)