### PR TITLE
Expose sites exemption list for widget tab in options UI

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -129,7 +129,7 @@
     },
     "options_allow_sites_widget_replacement": {
         "message": "Always allow widgets on these sites:",
-        "description": "Label for the widget site exceptions form"
+        "description": "Label for the site exceptions form on the widget replacement tab"
     },
     "options_show_nontracking_domains_checkbox": {
         "message": "Show domains that don't appear to be tracking you",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -119,6 +119,14 @@
         "message": "Import",
         "description": ""
     },
+    "options_widget_replacement_widget_exceptions": {
+        "message": "Widget Exceptions",
+        "description": "Header text above the section to add/remove widget exceptions"
+    },
+    "options_widget_replacement_site_exceptions": {
+        "message": "Site Exceptions",
+        "description": "Header text above the section to remove site exceptions"
+    },
     "options_hide_social_widgets": {
         "message": "Don't replace the following widgets:",
         "description": "Multiple selection box on the widget replacement tab"

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -91,6 +91,10 @@
         "message": "Prevent WebRTC from leaking local IP address",
         "description": "Checkbox label on the general settings page"
     },
+    "options_allow_sites_widget_replacement": {
+        "message": "Allows allow media widgets on these sites:",
+        "description": "Text above the options page area that lets users add or remove sites from the widget replacement always allow list."
+    },
     "intro_welcome": {
         "message": "Privacy Badger automatically learns to block invisible trackers. Take a minute to see how.",
         "description": "Intro page welcome paragraph."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -119,25 +119,33 @@
         "message": "Import",
         "description": ""
     },
-    "options_widget_replacement_widget_exceptions": {
-        "message": "Widget Exceptions",
-        "description": "Header text above the section to add/remove widget exceptions"
+    "options_widget_replacement_tab": {
+        "message": "Widget Replacement",
+        "description": "Options page tab heading"
     },
-    "options_widget_replacement_site_exceptions": {
-        "message": "Site Exceptions",
-        "description": "Header text above the section to remove site exceptions"
-    },
-    "options_hide_social_widgets": {
-        "message": "Don't replace the following widgets:",
-        "description": "Multiple selection box on the widget replacement tab"
+    "options_widget_replacement_desc": {
+        "message": "When blocking social buttons and other potentially useful (video, audio, comments) widgets, Privacy Badger can replace them with click-to-activate placeholders.",
+        "description": "Introduction to the Widget Replacement tab on the options page"
     },
     "options_social_widgets_checkbox": {
         "message": "Enable widget replacement",
-        "description": "Checkbox label on the widget replacement tab"
+        "description": "Checkbox label on the Widget Replacement tab"
     },
-    "options_allow_sites_widget_replacement": {
+    "options_widget_exceptions_header": {
+        "message": "Widget Exceptions",
+        "description": "Header text on the Widget Replacement tab"
+    },
+    "options_hide_social_widgets": {
+        "message": "Don't replace the following widgets:",
+        "description": "Label for a form on the Widget Replacement tab"
+    },
+    "options_widget_site_exceptions_header": {
+        "message": "Site Exceptions",
+        "description": "Header text on the Widget Replacement tab"
+    },
+    "options_widget_site_exceptions_label": {
         "message": "Always allow widgets on these sites:",
-        "description": "Label for the site exceptions form on the widget replacement tab"
+        "description": "Label for a form on the Widget Replacement tab"
     },
     "options_show_nontracking_domains_checkbox": {
         "message": "Show domains that don't appear to be tracking you",
@@ -653,14 +661,6 @@
     "popup_disabled_site_header": {
         "message": "Privacy Badger is disabled on this site",
         "description": "Shown in the popup on disabled sites."
-    },
-    "options_widget_replacement_tab": {
-        "message": "Widget Replacement",
-        "description": "Options page tab heading"
-    },
-    "options_widget_replacement_desc": {
-        "message": "When blocking social buttons and other potentially useful (video, audio, comments) widgets, Privacy Badger can replace them with click-to-activate placeholders.",
-        "description": "Introduction to the Widget Replacement tab on the options page."
     },
     "disabled_sites": {
         "message": "Disabled Sites",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -92,8 +92,8 @@
         "description": "Checkbox label on the general settings page"
     },
     "options_allow_sites_widget_replacement": {
-        "message": "Allows allow media widgets on these sites:",
-        "description": "Text above the options page area that lets users add or remove sites from the widget replacement always allow list."
+        "message": "Always allow media widgets on these sites:",
+        "description": "Text above the options page area that lets users add or remove domains from the widget site allow list."
     },
     "intro_welcome": {
         "message": "Privacy Badger automatically learns to block invisible trackers. Take a minute to see how.",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -91,10 +91,6 @@
         "message": "Prevent WebRTC from leaking local IP address",
         "description": "Checkbox label on the general settings page"
     },
-    "options_allow_sites_widget_replacement": {
-        "message": "Always allow widgets on these sites:",
-        "description": "Text above the options page area that lets users add or remove domains from the widget site allow list."
-    },
     "intro_welcome": {
         "message": "Privacy Badger automatically learns to block invisible trackers. Take a minute to see how.",
         "description": "Intro page welcome paragraph."
@@ -130,6 +126,10 @@
     "options_social_widgets_checkbox": {
         "message": "Enable widget replacement",
         "description": "Checkbox label on the widget replacement tab"
+    },
+    "options_allow_sites_widget_replacement": {
+        "message": "Always allow widgets on these sites:",
+        "description": "Label for the widget site exceptions form"
     },
     "options_show_nontracking_domains_checkbox": {
         "message": "Show domains that don't appear to be tracking you",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -92,7 +92,7 @@
         "description": "Checkbox label on the general settings page"
     },
     "options_allow_sites_widget_replacement": {
-        "message": "Always allow media widgets on these sites:",
+        "message": "Always allow widgets on these sites:",
         "description": "Text above the options page area that lets users add or remove domains from the widget site allow list."
     },
     "intro_welcome": {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1043,6 +1043,35 @@ Badger.prototype = {
     }
   },
 
+  addDomainWidgetReplacementExceptions: function(domain) {
+    let settings = this.getSettings();
+    let exceptionsList = settings.getItem("widgetSiteAllowlist");
+
+    // grab all the widget types that badger currently covers
+    let widgetTypes = [];
+    for (let widget of this.widgetList) {
+      widgetTypes.push(widget.name);
+    }
+
+    // permit all widget types on the given domain
+    exceptionsList[domain] = widgetTypes;
+
+    // reset the new modified widget site allow list
+    settings.setItem("widgetSiteAllowlist", exceptionsList);
+  },
+
+  // run from a loop of domains given in ./webrequest.js
+  removeDomainWidgetReplacementExceptions: function(domain) {
+    let settings = this.getSettings();
+    let exceptionsList = settings.getItem("widgetSiteAllowlist");
+
+    // remove the domain entirely from the exceptions list
+    delete exceptionsList[domain];
+
+    // apply these changes to the widget site allowlist settings map
+    settings.setItem("widgetSiteAllowlist", exceptionsList);
+  },
+
   /**
    * Checks if local storage ( in dict) has any high-entropy keys
    *

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1043,18 +1043,6 @@ Badger.prototype = {
     }
   },
 
-  // run from a loop of domains given in ./webrequest.js
-  removeDomainWidgetReplacementExceptions: function(domain) {
-    let settings = this.getSettings();
-    let exceptionsList = settings.getItem("widgetSiteAllowlist");
-
-    // remove the domain entirely from the exceptions list
-    delete exceptionsList[domain];
-
-    // apply these changes to the widget site allowlist settings map
-    settings.setItem("widgetSiteAllowlist", exceptionsList);
-  },
-
   /**
    * Checks if local storage ( in dict) has any high-entropy keys
    *

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -990,13 +990,6 @@ Badger.prototype = {
     );
   },
 
-  /**
-   * Check if widget replacement functionality is enabled.
-   */
-  isWidgetReplacementEnabled: function () {
-    return this.getSettings().getItem("socialWidgetReplacementEnabled");
-  },
-
   isDNTSignalEnabled: function() {
     return this.getSettings().getItem("sendDNTSignal");
   },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1043,23 +1043,6 @@ Badger.prototype = {
     }
   },
 
-  addDomainWidgetReplacementExceptions: function(domain) {
-    let settings = this.getSettings();
-    let exceptionsList = settings.getItem("widgetSiteAllowlist");
-
-    // grab all the widget types that badger currently covers
-    let widgetTypes = [];
-    for (let widget of this.widgetList) {
-      widgetTypes.push(widget.name);
-    }
-
-    // permit all widget types on the given domain
-    exceptionsList[domain] = widgetTypes;
-
-    // reset the new modified widget site allow list
-    settings.setItem("widgetSiteAllowlist", exceptionsList);
-  },
-
   // run from a loop of domains given in ./webrequest.js
   removeDomainWidgetReplacementExceptions: function(domain) {
     let settings = this.getSettings();

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -220,14 +220,17 @@ function loadOptions() {
     });
 
   const widgetSelector = $("#hide-widgets-select");
+  const widgetSitesSelectBox = $("#widget-allowlist-select");
   widgetSelector.prop("disabled",
     OPTIONS_DATA.isWidgetReplacementEnabled ? false : "disabled");
 
   $("#replace-widgets-checkbox").on("change", function () {
     if ($(this).is(":checked")) {
       widgetSelector.prop("disabled", false);
+      widgetSitesSelectBox.prop("disabled", false);
     } else {
       widgetSelector.prop("disabled", "disabled");
+      widgetSitesSelectBox.prop("disabled", "disabled");
     }
   });
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -317,13 +317,15 @@ function parseUserDataFile(storageMapsList) {
     type: "mergeUserData",
     data: lists
   }, (response) => {
-    OPTIONS_DATA.settings.disabledSites = response.disabledSites;
     OPTIONS_DATA.origins = response.origins;
+    OPTIONS_DATA.settings = response.settings;
 
+    // TODO general settings are not updated
     reloadDisabledSites();
     reloadTrackingDomainsTab();
+    // TODO widget replacement toggle not updated
+    // TODO widget replacement exceptions not updated
     reloadWidgetSiteExceptions();
-    // TODO general settings are not updated
 
     alert(i18n.getMessage("import_successful"));
   });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -111,7 +111,7 @@ function loadOptions() {
   $("#show_counter_checkbox").prop("checked", OPTIONS_DATA.settings.showCounter);
   $("#replace-widgets-checkbox")
     .on("click", updateWidgetReplacement)
-    .prop("checked", OPTIONS_DATA.isWidgetReplacementEnabled);
+    .prop("checked", OPTIONS_DATA.settings.socialWidgetReplacementEnabled);
   $("#enable_dnt_checkbox").on("click", updateDNTCheckboxClicked);
   $("#enable_dnt_checkbox").prop("checked", OPTIONS_DATA.settings.sendDNTSignal);
   $("#check_dnt_policy_checkbox").on("click", updateCheckingDNTPolicy);
@@ -233,7 +233,7 @@ function loadOptions() {
       $('#widget-site-exceptions-remove-button').button("option", "disabled", true);
     }
   }
-  _disable_widget_forms(OPTIONS_DATA.isWidgetReplacementEnabled);
+  _disable_widget_forms(OPTIONS_DATA.settings.socialWidgetReplacementEnabled);
   $("#replace-widgets-checkbox").on("change", function () {
     _disable_widget_forms($(this).is(":checked"));
   });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -568,8 +568,8 @@ function reloadWidgetSitesAllowlist() {
   sites = htmlUtils.sortDomains(sites);
 
   $select.empty();
-  for (let i of sites) {
-    $('<option>').text(i).appendTo($select);
+  for (let domain of sites) {
+    $('<option>').text(domain).appendTo($select);
   }
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -49,7 +49,7 @@ function loadOptions() {
   $('#exportTrackers').on("click", exportUserData);
   $('#resetData').on("click", resetData);
   $('#removeAllData').on("click", removeAllData);
-  $('#widget-site-exceptions-remove-button').on("click", removeWidgetSiteAllowlist);
+  $('#widget-site-exceptions-remove-button').on("click", removeWidgetSiteExceptions);
 
   if (OPTIONS_DATA.settings.showTrackingDomains) {
     $('#tracking-domains-overlay').hide();
@@ -252,7 +252,7 @@ function loadOptions() {
 
   reloadDisabledSites();
   reloadTrackingDomainsTab();
-  reloadWidgetSitesAllowlist();
+  reloadWidgetSiteExceptions();
 
   $('html').css({
     overflow: 'visible',
@@ -322,7 +322,7 @@ function parseUserDataFile(storageMapsList) {
 
     reloadDisabledSites();
     reloadTrackingDomainsTab();
-    reloadWidgetSitesAllowlist();
+    reloadWidgetSiteExceptions();
     // TODO general settings are not updated
 
     alert(i18n.getMessage("import_successful"));
@@ -565,9 +565,10 @@ function removeDisabledSite(event) {
   });
 }
 
-// update the select box on the widget site allow list options page when domains are added/removed
-function reloadWidgetSitesAllowlist() {
-
+/**
+ * Updates the Site Exceptions form on the Widget Replacement tab.
+ */
+function reloadWidgetSiteExceptions() {
   let sites = Object.keys(OPTIONS_DATA.settings.widgetSiteAllowlist),
     $select = $('#widget-site-exceptions-select');
 
@@ -576,32 +577,24 @@ function reloadWidgetSitesAllowlist() {
 
   $select.empty();
   for (let domain of sites) {
-    // list allowed widget types alongside the domain they belong to in exempted list select box
-    let textBlob = domain + " (" + OPTIONS_DATA.settings.widgetSiteAllowlist[domain].join(', ') + ")";
-    $('<option>').text(textBlob).appendTo($select);
+    // list allowed widget types alongside the domain they belong to
+    let display_text = domain + " (" + OPTIONS_DATA.settings.widgetSiteAllowlist[domain].join(', ') + ")";
+    $('<option>').text(display_text).val(domain).appendTo($select);
   }
 }
 
-// takes domain(s) from select list on widgets tab of options page and passes along to be removed from settings map
-function removeWidgetSiteAllowlist(event) {
+function removeWidgetSiteExceptions(event) {
   event.preventDefault();
 
-  let domains = [];
-  let $selected = $("#widget-site-exceptions-select option:selected");
-  for (let i of $selected) {
-    // isolate site name from longer string of site + allowed widget types
-    let site = i.text.substring(0, i.text.indexOf(' '));
-    domains.push(site);
-  }
-
   chrome.runtime.sendMessage({
-    type: "removeDomainWidgetReplacementExceptions",
-    domains
+    type: "removeWidgetSiteExceptions",
+    domains: $("#widget-site-exceptions-select").val()
   }, (response) => {
     OPTIONS_DATA.settings.widgetSiteAllowlist = response.widgetSiteAllowlist;
-    reloadWidgetSitesAllowlist();
+    reloadWidgetSiteExceptions();
   });
 }
+
 // Tracking Domains slider functions
 
 /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -572,7 +572,9 @@ function reloadWidgetSitesAllowlist() {
 
   $select.empty();
   for (let domain of sites) {
-    $('<option>').text(domain).appendTo($select);
+    // list allowed widget types alongside the domain they belong to in exempted list select box
+    let textBlob = domain + " (" + OPTIONS_DATA.settings.widgetSiteAllowlist[domain].join(', ') + ")";
+    $('<option>').text(textBlob).appendTo($select);
   }
 }
 
@@ -583,7 +585,9 @@ function removeWidgetSiteAllowlist(event) {
   let domains = [];
   let $selected = $("#widget-allowlist-select option:selected");
   for (let i of $selected) {
-    domains.push(i.text);
+    // isolate site name from longer string of site + allowed widget types
+    let site = i.text.substring(0, i.text.indexOf(' '));
+    domains.push(site);
   }
 
   chrome.runtime.sendMessage({

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -49,7 +49,7 @@ function loadOptions() {
   $('#exportTrackers').on("click", exportUserData);
   $('#resetData').on("click", resetData);
   $('#removeAllData').on("click", removeAllData);
-  $('#remove-widget-allowlist-site-button').on("click", removeWidgetSiteAllowlist);
+  $('#widget-site-exceptions-remove-button').on("click", removeWidgetSiteAllowlist);
 
   if (OPTIONS_DATA.settings.showTrackingDomains) {
     $('#tracking-domains-overlay').hide();
@@ -220,18 +220,22 @@ function loadOptions() {
     });
 
   const widgetSelector = $("#hide-widgets-select");
-  const widgetSitesSelectBox = $("#widget-allowlist-select");
-  widgetSelector.prop("disabled",
-    OPTIONS_DATA.isWidgetReplacementEnabled ? false : "disabled");
 
-  $("#replace-widgets-checkbox").on("change", function () {
-    if ($(this).is(":checked")) {
+  // disable Widget Replacement form elements when widget replacement is off
+  function _disable_widget_forms(enable) {
+    if (enable) {
       widgetSelector.prop("disabled", false);
-      widgetSitesSelectBox.prop("disabled", false);
+      $("#widget-site-exceptions-select").prop("disabled", false);
+      $('#widget-site-exceptions-remove-button').button("option", "disabled", false);
     } else {
       widgetSelector.prop("disabled", "disabled");
-      widgetSitesSelectBox.prop("disabled", "disabled");
+      $("#widget-site-exceptions-select").prop("disabled", "disabled");
+      $('#widget-site-exceptions-remove-button').button("option", "disabled", true);
     }
+  }
+  _disable_widget_forms(OPTIONS_DATA.isWidgetReplacementEnabled);
+  $("#replace-widgets-checkbox").on("change", function () {
+    _disable_widget_forms($(this).is(":checked"));
   });
 
   // Initialize Select2 and populate options
@@ -565,7 +569,7 @@ function removeDisabledSite(event) {
 function reloadWidgetSitesAllowlist() {
 
   let sites = Object.keys(OPTIONS_DATA.settings.widgetSiteAllowlist),
-    $select = $('#widget-allowlist-select');
+    $select = $('#widget-site-exceptions-select');
 
   // sort widget exemptions sites the same way other options page domains lists are
   sites = htmlUtils.sortDomains(sites);
@@ -583,7 +587,7 @@ function removeWidgetSiteAllowlist(event) {
   event.preventDefault();
 
   let domains = [];
-  let $selected = $("#widget-allowlist-select option:selected");
+  let $selected = $("#widget-site-exceptions-select option:selected");
   for (let i of $selected) {
     // isolate site name from longer string of site + allowed widget types
     let site = i.text.substring(0, i.text.indexOf(' '));

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -49,7 +49,6 @@ function loadOptions() {
   $('#exportTrackers').on("click", exportUserData);
   $('#resetData').on("click", resetData);
   $('#removeAllData').on("click", removeAllData);
-  $('#widget-site-allowlist-form').on("submit", addWidgetSiteAllowlist);
   $('#remove-widget-allowlist-site-button').on("click", removeWidgetSiteAllowlist);
 
   if (OPTIONS_DATA.settings.showTrackingDomains) {
@@ -572,28 +571,6 @@ function reloadWidgetSitesAllowlist() {
   for (let i of sites) {
     $('<option>').text(i).appendTo($select);
   }
-}
-
-// takes domain from allowlist input box on widgets tab of options page and passes along to be added to settings map
-function addWidgetSiteAllowlist(event) {
-  event.preventDefault();
-
-  let domain = utils.getHostFromDomainInput(
-    document.getElementById("widget-site-allow-list-input").value.replace(/\s/g, "")
-  );
-
-  if (!domain) {
-    return alert(i18n.getMessage("invalid_domain"));
-  }
-
-  chrome.runtime.sendMessage({
-    type: "addDomainWidgetReplacementExceptions",
-    domain
-  }, (response) => {
-    OPTIONS_DATA.settings.widgetSiteAllowlist = response.widgetSiteAllowlist;
-    reloadWidgetSitesAllowlist();
-    document.getElementById("widget-site-allow-list-input").value = "";
-  });
 }
 
 // takes domain(s) from select list on widgets tab of options page and passes along to be removed from settings map

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -363,7 +363,7 @@ function hideBlockedFrame(tab_id, parent_frame_id, frame_url, frame_host) {
   }
 
   // don't hide widget frames
-  if (badger.isWidgetReplacementEnabled()) {
+  if (badger.getSettings().getItem("socialWidgetReplacementEnabled")) {
     let exceptions = badger.getSettings().getItem('widgetReplacementExceptions');
     for (let widget of badger.widgetList) {
       if (exceptions.includes(widget.name)) {
@@ -998,7 +998,7 @@ function dispatcher(request, sender, sendResponse) {
       tab_host = window.extractHostFromURL(sender.tab.url);
 
     if (badger.isPrivacyBadgerEnabled(tab_host) &&
-        badger.isWidgetReplacementEnabled()) {
+        badger.getSettings().getItem("socialWidgetReplacementEnabled")) {
       response = getWidgetList(sender.tab.id);
     }
 
@@ -1063,7 +1063,6 @@ function dispatcher(request, sender, sendResponse) {
 
     sendResponse({
       cookieblocked,
-      isWidgetReplacementEnabled: badger.isWidgetReplacementEnabled(),
       origins,
       settings: badger.getSettings().getItemClones(),
       webRTCAvailable: badger.webRTCAvailable,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1244,15 +1244,6 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
-  // adds a domain to the widgetSiteAllowlist, managed in the UI of the options page
-  case "addDomainWidgetReplacementExceptions": {
-    badger.addDomainWidgetReplacementExceptions(request.domain);
-    sendResponse({
-      widgetSiteAllowlist: badger.getSettings().getItem("widgetSiteAllowlist")
-    });
-    break;
-  }
-
   // removes domain(s) selected in options page UI to be removed from widgetSiteAllowlist
   case "removeDomainWidgetReplacementExceptions": {
     request.domains.forEach((domain) => {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1244,6 +1244,26 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
+  // adds a domain to the widgetSiteAllowlist, managed in the UI of the options page
+  case "addDomainWidgetReplacementExceptions": {
+    badger.addDomainWidgetReplacementExceptions(request.domain);
+    sendResponse({
+      widgetSiteAllowlist: badger.getSettings().getItem("widgetSiteAllowlist")
+    });
+    break;
+  }
+
+  // removes domain(s) selected in options page UI to be removed from widgetSiteAllowlist
+  case "removeDomainWidgetReplacementExceptions": {
+    request.domains.forEach((domain) => {
+      badger.removeDomainWidgetReplacementExceptions(domain);
+    });
+    sendResponse({
+      widgetSiteAllowlist: badger.getSettings().getItem("widgetSiteAllowlist")
+    });
+    break;
+  }
+
   case "removeOrigin": {
     badger.storage.getStore("snitch_map").deleteItem(request.origin);
     badger.storage.getStore("action_map").deleteItem(request.origin);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1247,7 +1247,14 @@ function dispatcher(request, sender, sendResponse) {
   // removes domain(s) selected in options page UI to be removed from widgetSiteAllowlist
   case "removeDomainWidgetReplacementExceptions": {
     request.domains.forEach((domain) => {
-      badger.removeDomainWidgetReplacementExceptions(domain);
+      let settings = badger.getSettings();
+      let exceptionsList = settings.getItem("widgetSiteAllowlist");
+
+      // remove the domain entirely from the exceptions list
+      delete exceptionsList[domain];
+
+      // apply these changes to the widget site allowlist settings map
+      settings.setItem("widgetSiteAllowlist", exceptionsList);
     });
     sendResponse({
       widgetSiteAllowlist: badger.getSettings().getItem("widgetSiteAllowlist")

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1246,18 +1246,19 @@ function dispatcher(request, sender, sendResponse) {
 
   // removes domain(s) selected in options page UI to be removed from widgetSiteAllowlist
   case "removeDomainWidgetReplacementExceptions": {
-    request.domains.forEach((domain) => {
-      let settings = badger.getSettings();
-      let exceptionsList = settings.getItem("widgetSiteAllowlist");
+    let settings = badger.getSettings();
+    let exceptionsList = settings.getItem("widgetSiteAllowlist");
 
+    request.domains.forEach((domain) => {
       // remove the domain entirely from the exceptions list
       delete exceptionsList[domain];
-
-      // apply these changes to the widget site allowlist settings map
-      settings.setItem("widgetSiteAllowlist", exceptionsList);
     });
+
+    // apply these changes to the widget site allowlist settings map
+    settings.setItem("widgetSiteAllowlist", exceptionsList);
+
     sendResponse({
-      widgetSiteAllowlist: badger.getSettings().getItem("widgetSiteAllowlist")
+      widgetSiteAllowlist: settings.getItem("widgetSiteAllowlist")
     });
     break;
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1193,8 +1193,8 @@ function dispatcher(request, sender, sendResponse) {
     badger.blockWidgetDomains();
     badger.setPrivacyOverrides();
     sendResponse({
-      disabledSites: badger.getDisabledSites(),
       origins: badger.storage.getTrackingDomains(),
+      settings: badger.getSettings().getItemClones(),
     });
     break;
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1244,22 +1244,20 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
-  // removes domain(s) selected in options page UI to be removed from widgetSiteAllowlist
-  case "removeDomainWidgetReplacementExceptions": {
-    let settings = badger.getSettings();
-    let exceptionsList = settings.getItem("widgetSiteAllowlist");
+  case "removeWidgetSiteExceptions": {
+    let settings = badger.getSettings(),
+      allowedWidgets = settings.getItem("widgetSiteAllowlist");
 
-    request.domains.forEach((domain) => {
-      // remove the domain entirely from the exceptions list
-      delete exceptionsList[domain];
-    });
+    for (let domain of request.domains) {
+      delete allowedWidgets[domain];
+    }
 
-    // apply these changes to the widget site allowlist settings map
-    settings.setItem("widgetSiteAllowlist", exceptionsList);
+    settings.setItem("widgetSiteAllowlist", allowedWidgets);
 
     sendResponse({
-      widgetSiteAllowlist: settings.getItem("widgetSiteAllowlist")
+      widgetSiteAllowlist: allowedWidgets
     });
+
     break;
   }
 

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -75,7 +75,7 @@ function setTextDirection() {
     document.body.appendChild(css);
 
     // fix floats
-    ['.btn-silo', '.btn-silo div', '#allowlist-form > div > div > div'].forEach((selector) => {
+    ['.btn-silo', '.btn-silo div', '#allowlist-form > div > div > div', '#widget-allowed-sites-list-section', '#remove-widget-allowlist-site-button'].forEach((selector) => {
       toggle_css_value(selector, "float", "left", "right");
     });
   }

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -75,7 +75,7 @@ function setTextDirection() {
     document.body.appendChild(css);
 
     // fix floats
-    ['.btn-silo', '.btn-silo div', '#allowlist-form > div > div > div', '#widget-allowed-sites-list-section', '#remove-widget-allowlist-site-button'].forEach((selector) => {
+    ['.btn-silo', '.btn-silo div', '#allowlist-form > div > div > div', '#widget-site-exceptions-select-div', '#widget-site-exceptions-remove-button'].forEach((selector) => {
       toggle_css_value(selector, "float", "left", "right");
     });
   }

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -206,14 +206,15 @@ p, #settingsForm {
 #hide-widgets-row {
     width: 100%;
     margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 #hide-widgets-select {
-  width: 300px;
+  width: 420px;
 }
 
 #always-allow-sites-widget-section {
-    margin-top: 30px;
+    margin-top: 20px;
 }
 
 #widget-allowed-sites-list-section {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -90,7 +90,7 @@ p, #settingsForm {
     margin: 10px 0;
 }
 
-#allowlist-form {
+#allowlist-form  {
     margin: 20px 0 0;
 }
 
@@ -203,36 +203,27 @@ p, #settingsForm {
     max-height: 400px; /* override popup.css */
 }
 
-#hide-widgets-row {
-    width: 100%;
-    margin-top: 5px;
-    margin-bottom: 5px;
+label[for=hide-widgets-select] {
+    display: block;
 }
-
 #hide-widgets-select {
-  width: 420px;
+    width: 420px;
 }
 
-#always-allow-sites-widget-section {
-    margin-top: 20px;
-}
-
-#widget-allowed-sites-list-section {
+#widget-site-exceptions-select-div {
     float: left;
     max-width: 420px;
     width: 100%;
     margin-inline-end: 10px;
-    padding-top: 5px;
 }
 
-#remove-widget-allowlist-site-button {
+#widget-site-exceptions-remove-button {
     float: left;
     margin-top: 5px;
 }
 
-#widget-allowlist-select {
+#widget-site-exceptions-select {
     width: 100%;
-    background: white;
 }
 
 #tabs, header {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -215,11 +215,12 @@ label[for=hide-widgets-select] {
     max-width: 420px;
     width: 100%;
     margin-inline-end: 10px;
+    margin-bottom: 5px;
 }
 
 #widget-site-exceptions-remove-button {
     float: left;
-    margin-top: 5px;
+    margin-bottom: 10px;
 }
 
 #widget-site-exceptions-select {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -212,6 +212,40 @@ p, #settingsForm {
   width: 300px;
 }
 
+#always-allow-sites-widget-section {
+    margin-top: 30px;
+}
+
+#widget-site-allow-input-section {
+    float: left;
+    max-width: 400px;
+    width: 100%;
+    margin-inline-end: 30px;
+    padding-top: 5px
+}
+
+#widget-site-allow-list-input {
+    width: 100%;
+}
+
+#widget-allowed-sites-list-section {
+    float: left;
+    max-width: 420px;
+    width: 100%;
+    margin-inline-end: 10px;
+    padding-top: 5px;
+}
+
+#remove-widget-allowlist-site-button {
+    float: left;
+    margin-top: 5px;
+}
+
+#widget-allowlist-select {
+    width: 100%;
+    background: white;
+}
+
 #tabs, header {
     background: transparent;
     border: none;

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -216,18 +216,6 @@ p, #settingsForm {
     margin-top: 30px;
 }
 
-#widget-site-allow-input-section {
-    float: left;
-    max-width: 400px;
-    width: 100%;
-    margin-inline-end: 30px;
-    padding-top: 5px
-}
-
-#widget-site-allow-list-input {
-    width: 100%;
-}
-
 #widget-allowed-sites-list-section {
     float: left;
     max-width: 420px;

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -256,12 +256,19 @@
       <span class="i18n_options_social_widgets_checkbox"></span>
     </label>
     </p>
-    <div id="hide-widgets-row" class="indent1">
+
+    <h4 class="i18n_options_widget_replacement_widget_exceptions"></h4>
+
+    <div id="hide-widgets-row">
       <label for="hide-widgets-select">
         <span class="i18n_options_hide_social_widgets"></span>
       </label>
-      <select name="states[]" multiple="multiple" id="hide-widgets-select"></select>
+      <div>
+        <select name="states[]" multiple="multiple" id="hide-widgets-select"></select>
+      </div>
     </div>
+
+    <h4 class="i18n_options_widget_replacement_site_exceptions"></h4>
 
     <div id="always-allow-sites-widget-section">
       <span class="i18n_options_allow_sites_widget_replacement"></span>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -262,6 +262,20 @@
       </label>
       <select name="states[]" multiple="multiple" id="hide-widgets-select"></select>
     </div>
+
+    <div id="always-allow-sites-widget-section">
+      <span class="i18n_options_allow_sites_widget_replacement"></span>
+      <form id="widget-site-allowlist-form" action="#">
+          <div id="widget-site-allow-input-section">
+            <input type="text" id="widget-site-allow-list-input" placeholder="i18n_allowlist_domain_input_placeholder">
+          </div>
+          <button id="add-widget-allowlist-site-button" type="submit"><span class="i18n_add_domain_button"></span></button>
+        <div id="widget-allowed-sites-list-section">
+          <select id="widget-allowlist-select" size="10" multiple></select>
+        </div>
+        <button id="remove-widget-allowlist-site-button" class="i18n_remove_button"></button>
+      </form>
+    </div>
   </div>
 
   <div id="tab-manage-data">

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -266,10 +266,6 @@
     <div id="always-allow-sites-widget-section">
       <span class="i18n_options_allow_sites_widget_replacement"></span>
       <form id="widget-site-allowlist-form" action="#">
-          <div id="widget-site-allow-input-section">
-            <input type="text" id="widget-site-allow-list-input" placeholder="i18n_allowlist_domain_input_placeholder">
-          </div>
-          <button id="add-widget-allowlist-site-button" type="submit"><span class="i18n_add_domain_button"></span></button>
         <div id="widget-allowed-sites-list-section">
           <select id="widget-allowlist-select" size="10" multiple></select>
         </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -259,24 +259,22 @@
 
     <h4 class="i18n_options_widget_exceptions_header"></h4>
 
-    <div id="hide-widgets-row">
+    <div>
       <label for="hide-widgets-select">
         <span class="i18n_options_hide_social_widgets"></span>
       </label>
-      <div>
-        <select name="states[]" multiple="multiple" id="hide-widgets-select"></select>
-      </div>
+      <select name="states[]" multiple="multiple" id="hide-widgets-select"></select>
     </div>
 
     <h4 class="i18n_options_widget_site_exceptions_header"></h4>
 
-    <div id="always-allow-sites-widget-section">
+    <div>
       <span class="i18n_options_widget_site_exceptions_label"></span>
-      <form id="widget-site-allowlist-form" action="#">
-        <div id="widget-allowed-sites-list-section">
-          <select id="widget-allowlist-select" size="10" multiple></select>
+      <form action="#">
+        <div id="widget-site-exceptions-select-div">
+          <select id="widget-site-exceptions-select" size="10" multiple></select>
         </div>
-        <button id="remove-widget-allowlist-site-button" class="i18n_remove_button"></button>
+        <button id="widget-site-exceptions-remove-button" class="i18n_remove_button"></button>
       </form>
     </div>
   </div>

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -257,7 +257,7 @@
     </label>
     </p>
 
-    <h4 class="i18n_options_widget_replacement_widget_exceptions"></h4>
+    <h4 class="i18n_options_widget_exceptions_header"></h4>
 
     <div id="hide-widgets-row">
       <label for="hide-widgets-select">
@@ -268,10 +268,10 @@
       </div>
     </div>
 
-    <h4 class="i18n_options_widget_replacement_site_exceptions"></h4>
+    <h4 class="i18n_options_widget_site_exceptions_header"></h4>
 
     <div id="always-allow-sites-widget-section">
-      <span class="i18n_options_allow_sites_widget_replacement"></span>
+      <span class="i18n_options_widget_site_exceptions_label"></span>
       <form id="widget-site-allowlist-form" action="#">
         <div id="widget-allowed-sites-list-section">
           <select id="widget-allowlist-select" size="10" multiple></select>

--- a/tests/selenium/widgets_test.py
+++ b/tests/selenium/widgets_test.py
@@ -13,11 +13,13 @@ from selenium.common.exceptions import (
     TimeoutException
 )
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import Select
 
 
 class WidgetsTest(pbtest.PBSeleniumTest):
 
     FIXTURES_URL = "https://efforg.github.io/privacybadger-test-fixtures/html/"
+    FIXTURES_HOST = "efforg.github.io"
     BASIC_FIXTURE_URL = FIXTURES_URL + "widget_basic.html"
     DYNAMIC_FIXTURE_URL = FIXTURES_URL + "widget_dynamic.html"
     THIRD_PARTY_DOMAIN = "privacybadger-tests.eff.org"
@@ -252,6 +254,19 @@ class WidgetsTest(pbtest.PBSeleniumTest):
         # verify basic widget is neither replaced nor blocked
         self.assert_no_replacement()
         self.assert_widget()
+
+        # remove the site exception
+        self.load_url(self.options_url)
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('a[href="#tab-manage-widgets"]').click()
+        select = Select(self.driver.find_element_by_id('widget-site-exceptions-select'))
+        select.select_by_value(self.FIXTURES_HOST)
+        self.driver.find_element_by_id('widget-site-exceptions-remove-button').click()
+
+        # verify basic widget is replaced again
+        self.open_window()
+        self.load_url(self.BASIC_FIXTURE_URL)
+        self.assert_replacement()
 
     def test_disabling_site(self):
         self.block_domain(self.THIRD_PARTY_DOMAIN)


### PR DESCRIPTION
Fixes #2705. Follows up on #2653.

This adds a section in the widgets tab of the options page where a user can manage which sites are always exempted from having widgets replaced on them. Aside from testing in the options page itself, I've been using this [soundcloud widget demo site](https://demo.mekshq.com/voice/?p=303) to add to the exempts list from an outside source.

Mostly this undoes the gripe that a few users have come forward with that they can't undo the "always allow" button on the widget replacement modal after it's been clicked on a page. From there, I figured I might as well add the capability to add sites to this list directly from the same section in the options page.

When a user exempts a site from the replacement modal, it adds the widget type as well as the domain to the settings map, in an example like this: `{"demo.mekshq.com": [ "SoundCloud" ]}`. I think it would overcomplicate the UI in the options page to also give the user another menu option to choose which widgets to exempt the domain they input, I decided to just attach all 18 widgets that we cover as of now. I think this decisions solves more problems than it creates, but I'm definitely open to hearing any other ideas about how this weird edge case could be handled.