### PR TITLE
add a dark theme

### DIFF
--- a/src/skin/css/firstRun.css
+++ b/src/skin/css/firstRun.css
@@ -796,3 +796,33 @@ body {
     margin-bottom:5rem;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  body,
+  #pb-privacy-policy {
+    background-color: #222;
+    color: #ddd;
+  }
+
+  a:hover, a:focus {
+  	color: #f06a0a;
+  }
+
+  a:hover.button {
+    color: #f9f9f9;
+  }
+
+  #pb-settings {
+  	background-image: linear-gradient(#EC9329, #EC9329 30%, #222 30%);
+  }
+  #pb-donate {
+  	background-image: linear-gradient(#333, #333 45%, #222 45%);
+  	padding: 7rem 0;
+  }
+
+  .share-links > a span {
+  	background-color: #555;
+  	border-left: 0.4275rem solid #bbb;
+    color: #f9f9f9;
+  }
+}

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -262,3 +262,130 @@ header {
         padding: 0.5em 0;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    h1 {
+        color: #f9f9f9;
+    }
+
+    h4::after,
+    #tabs .ui-widget-header {
+	      border-bottom: solid 1px #555;
+    }
+
+    input[type="text"] {
+        padding: 8px;
+    }
+
+    input[type="text"],
+    #allowlist-select,
+    .select2-container--default .select2-selection--multiple,
+    .select2-dropdown {
+        background-color: #222;
+        border: solid 1px #555;
+        border-radius: 3px;
+        color: #ddd;
+    }
+
+    input[type="text"]:focus,
+    #allowlist-select:focus {
+        border: solid 1px #f06a0a;
+        outline: none;
+    }
+
+    #tab-general-settings a,
+    .tooltip.tooltipstered,
+    .ui-tabs-panel {
+        color: #ddd;
+    }
+
+    #tab-general-settings a:hover {
+        color: #f06a0a;
+    }
+
+    #tabs .ui-tabs-nav .ui-state-default a {
+        color: #bbb;
+    }
+
+    #tabs .ui-tabs-nav .ui-state-hover a,
+    #tabs .ui-tabs-nav .ui-state-active a {
+	      color: #f9f9f9;
+    }
+
+    #tracking-domains-filters {
+        color: #ddd;
+        border: 1px solid #555;
+    }
+
+    #resetData,
+    #removeAllData {
+	      background-color: #86151d;
+        background-image: none;
+        border: solid 1px #e02431;
+    }
+
+    #resetData:hover,
+    #removeAllData:hover {
+	      background-color: #9c1922;
+        background-image: none;
+        border: solid 1px #e64f5a;
+    }
+
+
+    .ui-widget-content a {
+        color: #ddd;
+    }
+
+    .ui-widget-content a:hover {
+        color: #f06a0a;
+    }
+
+    .ui-button.ui-corner-all.ui-widget {
+	      background-color: #555;
+        background-image: none;
+        border: solid 1px #777;
+        color: #f9f9f9;
+    }
+
+    .ui-button.ui-corner-all.ui-widget:hover {
+	      background-color: #666;
+        border: solid 1px #bbb;
+    }
+
+    .ui-button.ui-corner-all.ui-widget:focus {
+        border: solid 1px #f06a0a;
+        outline: none;
+    }
+
+    .select2-container--default.select2-container--focus .select2-selection--multiple {
+	      border: solid #555 1px;
+        color: #ddd;
+    }
+
+    .select2-container--default .select2-results__option--highlighted[aria-selected] {
+	      background-color: #f06a0a;
+    }
+
+    .select2-container--default .select2-selection--multiple .select2-selection__choice {
+        background-color: #333;
+    	  border: 1px solid #555;
+    }
+
+    .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+    	  color: #ddd;
+    }
+
+    .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+    	  color: #f96a0a;
+    }
+
+    .select2-container--default.select2-container--disabled .select2-selection--multiple     {
+	      background-color: #222;
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .select2-container--default .select2-search--inline .select2-search__field {
+      color: #ddd;
+    }
+}

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -153,7 +153,7 @@
         </div>
         <div style="clear: both; overflow: hidden">
           <div style="float: left; max-width: 420px; width: 100%; margin-inline-end: 10px; padding-top: 5px">
-            <select id="allowlist-select" size="10" multiple style="width: 100%; background: white;"></select>
+            <select id="allowlist-select" size="10" multiple style="width: 100%;"></select>
           </div>
           <div style="float: left; padding-top: 5px">
             <button id="remove-disabled-site"><span class="i18n_remove_button"></span></button>

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -486,3 +486,64 @@ div.overlay.active {
         margin-right: 0px;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    body,
+    #instruction,
+    .key {
+        background-color: #333;
+        color: #ddd;
+    }
+
+    button,
+    #pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a,
+    #pbInstructions,
+    #special-browser-page,
+    #disabled-site-message {
+        color: #ddd;
+    }
+
+    /* TODO:
+     *  - Add f06a0a color on hover
+     */
+    #fittslaw,
+    #help,
+    #options,
+    #share {
+        filter: invert(0.85);
+    }
+
+    #privacyBadgerHeader h2 {
+    	  color: #f9f9f9;
+    }
+
+    textarea,
+    #share_output {
+        background-color: #333;
+        border: solid 1px #555;
+        border-radius: 3px;
+        color: #ddd;
+    }
+
+    #version {
+        color: #bbb;
+    }
+
+    .clicker,
+    .origin {
+        color: #ddd;
+    }
+    .clicker {
+        border-top: solid 1px #555;
+    }
+
+    .clickerContainer {
+        background-color: #3a3a3a;
+     }
+
+    .pbButton {
+        background-color: #333;
+        border: solid 2px #ddd;
+    }
+
+}


### PR DESCRIPTION
This adds a dark theme for the popup, settings page and
first run page.

Fixes: #2630, closes #2648

A few elements, like on the light theme, aren't themed (e.g checkboxes) because they need `appearance: none` and to redo the widget. So I think we could if needed do this in a different patch. Any thought?