### PR TITLE
Protect from Link Tracking on Tumblr

### DIFF
--- a/src/js/firstparties/tumblr.js
+++ b/src/js/firstparties/tumblr.js
@@ -1,5 +1,5 @@
 // only observed links with this format out in the wild
-let tumblr_links = "a[href^='https://t.umblr.com/redirect?']"
+let tumblr_links = "a[href^='https://t.umblr.com/redirect?']";
 
 // reassigns the href and scrubs link of all unnecessary attributes
 function unwrapLink(a) {
@@ -10,7 +10,7 @@ function unwrapLink(a) {
 
   for (let attr of a.attributes) {
     if (!['target', 'class', 'style'].includes(attr.name)) {
-      a.removeAttribute(attr.name)
+      a.removeAttribute(attr.name);
     }
   }
 

--- a/src/js/firstparties/tumblr.js
+++ b/src/js/firstparties/tumblr.js
@@ -1,0 +1,36 @@
+// only observed links with this format out in the wild
+let tumblr_links = "a[href^='https://t.umblr.com/redirect?']"
+
+// reassigns the href and scrubs link of all unnecessary attributes
+function unwrapLink(a) {
+  let href = new URL(a.href).searchParams.get('z');
+  if (!window.isURL(href)) {
+    return;
+  }
+
+  for (let attr of a.attributes) {
+    if (!['target', 'class', 'style'].includes(attr.name)) {
+      a.removeAttribute(attr.name)
+    }
+  }
+
+  a.rel = "noreferrer";
+  a.href = href;
+}
+
+// main handler to target each link on page and launder them through the unwrapLink func
+function unwrapAll() {
+  document.querySelectorAll(tumblr_links).forEach((a) => {
+    unwrapLink(a);
+  });
+}
+
+chrome.runtime.sendMessage({
+  type: "checkEnabled"
+}, function (enabled) {
+  if (!enabled) {
+    return;
+  }
+  unwrapAll();
+  setInterval(unwrapAll, 2000);
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -463,6 +463,20 @@
     },
     {
       "js": [
+        "js/firstparties/lib/utils.js",
+        "js/firstparties/tumblr.js"
+      ],
+      "matches": [
+        "https://tumblr.com/*",
+        "http://tumblr.com/*",
+        "https://*.tumblr.com/*",
+        "http://*.tumblr.com/*"
+      ],
+      "all_frames": true,
+      "run_at": "document_idle"
+    },
+    {
+      "js": [
         "js/contentscripts/utils.js",
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",


### PR DESCRIPTION
Turns out tumblr has familiar redirects on every outgoing link. Whether or not it's for tracking or just analytics, this proposed change scrubs the links of all unwanted things and reassigns the href to what the user expects.

Before:
 
![Screen Shot 2021-01-13 at 2 31 35 PM](https://user-images.githubusercontent.com/25778052/104518513-a1125080-55ac-11eb-8770-bbd0793a985c.png)

After:

![Screen Shot 2021-01-13 at 2 31 06 PM](https://user-images.githubusercontent.com/25778052/104518534-a8d1f500-55ac-11eb-9b64-8bf620fee78c.png)

