### PR TITLE
Fix dark control arrows

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -548,4 +548,7 @@ div.overlay.active {
         background-color: #333;
         border: solid 2px #ddd;
     }
+    .userset .honeybadgerPowered {
+        filter: invert(100%);
+    }
 }


### PR DESCRIPTION
- Fixes the behavior in the dark mode where revert control arrows aren't visible.
- Invert the arrows when in dark mode with `filter: invert(100%)`
- Resolves #2738