### PR TITLE
Hide sliders by default

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -451,6 +451,14 @@
         "message": "There are no third party resources on this page. Hooray for privacy!",
         "description": "Text shown in the popup when showing non-tracking domains is enabled, and there are no third-party domains on the page."
     },
+    "popup_show_more": {
+        "message": "Show more",
+        "description": "Instructions to click to expand the blocked resources container on the popup"
+    },
+    "popup_show_less": {
+        "message": "Show less",
+        "description": "Instructions to click to collapse the blocked resources container on the popup"
+    },
     "intro_by_eff": {
         "message": "A project of the Electronic Frontier Foundation",
         "description": ""

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -815,6 +815,7 @@ Badger.prototype = {
     seenComic: false,
     sendDNTSignal: true,
     showCounter: true,
+    showExpandedTrackingSection: false,
     showIntroPage: true,
     showNonTrackingDomains: false,
     showTrackingDomains: false,

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -192,6 +192,16 @@ function init() {
   $('#expand-blocked-resources-text').on('click', showBlockedResourcesHandler);
   $('#collapse-blocked-resources-text').on('click', hideBlockedResourcesHandler);
 
+  if (POPUP_DATA.showExpandedTrackingSection) {
+    $('#expand-blocked-resources-text').hide();
+    $('#collapse-blocked-resources-text').show();
+    $('#blockedResources').show();
+  } else if (!POPUP_DATA.showExpandedTrackingSection) {
+    $('#expand-blocked-resources-text').show();
+    $('#collapse-blocked-resources-text').hide();
+    $('#blockedResources').hide();
+  }
+
   $("#version").text(
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
   );
@@ -461,6 +471,7 @@ function revertDomainControl(event) {
 function showBlockedResourcesHandler() {
   $("#collapse-blocked-resources-text").show();
   $("#expand-blocked-resources-text").hide();
+  $("#blockedResources").show();
   chrome.runtime.sendMessage({
     type: "showTrackingDomainsSection"
   });
@@ -472,6 +483,7 @@ function showBlockedResourcesHandler() {
 function hideBlockedResourcesHandler() {
   $("#collapse-blocked-resources-text").hide();
   $("#expand-blocked-resources-text").show();
+  $("#blockedResources").hide();
   chrome.runtime.sendMessage({
     type: "hideTrackingDomainsSection"
   });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -622,7 +622,7 @@ function refreshPopup() {
     $("#instructions-no-trackers").css("margin", "10px 0");
   }
 
-  if (printable.length && POPUP_DATA.showExpandedTrackingSection) {
+  if (printable.length) {
     // get containing HTML for domain list along with toggle legend icons
     $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -543,9 +543,10 @@ function refreshPopup() {
   }
 
   if (!originsArr.length) {
-    // hide the number of trackers and slider instructions message
+    // hide the number of trackers, slider instructions messages
     // if no sliders will be displayed
     $("#instructions-many-trackers").hide();
+    $("#toggleBlockedResourcesContainer").hide();
 
     // show "no trackers" message
     $("#instructions-no-trackers").show();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -585,7 +585,7 @@ function refreshPopup() {
     $("#instructions-no-trackers").css("margin", "10px 0");
   }
 
-  if (printable.length) {
+  if (printable.length && POPUP_DATA.showExpandedTrackingSection) {
     // get containing HTML for domain list along with toggle legend icons
     $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -189,6 +189,9 @@ function init() {
   $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
   $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
 
+  $('#expand-blocked-resources-text').on('click', showBlockedResourcesHandler)
+  $('#collapse-blocked-resources-text').on('click', hideBlockedResourcesHandler)
+
   $("#version").text(
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
   );
@@ -450,6 +453,28 @@ function revertDomainControl(event) {
     chrome.tabs.reload(POPUP_DATA.tabId);
     window.close();
   });
+}
+
+/**
+ * Click handler for expanding the blocked resources section
+ */
+function showBlockedResourcesHandler() {
+  $("#collapse-blocked-resources-text").show();
+  $("#expand-blocked-resources-text").hide();
+  chrome.runtime.sendMessage({
+    type: "showTrackingDomainsSection"
+  })
+}
+
+/**
+ * Click handler for hiding the blocked resources section
+ */
+function hideBlockedResourcesHandler() {
+  $("#collapse-blocked-resources-text").hide();
+  $("#expand-blocked-resources-text").show();
+  chrome.runtime.sendMessage({
+    type: "hideTrackingDomainsSection"
+  })
 }
 
 /**

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -189,8 +189,8 @@ function init() {
   $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
   $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
 
-  $('#expand-blocked-resources-text').on('click', showBlockedResourcesHandler)
-  $('#collapse-blocked-resources-text').on('click', hideBlockedResourcesHandler)
+  $('#expand-blocked-resources-text').on('click', showBlockedResourcesHandler);
+  $('#collapse-blocked-resources-text').on('click', hideBlockedResourcesHandler);
 
   $("#version").text(
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
@@ -463,7 +463,7 @@ function showBlockedResourcesHandler() {
   $("#expand-blocked-resources-text").hide();
   chrome.runtime.sendMessage({
     type: "showTrackingDomainsSection"
-  })
+  });
 }
 
 /**
@@ -474,7 +474,7 @@ function hideBlockedResourcesHandler() {
   $("#expand-blocked-resources-text").show();
   chrome.runtime.sendMessage({
     type: "hideTrackingDomainsSection"
-  })
+  });
 }
 
 /**

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1127,6 +1127,18 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
+  case "showTrackingDomainsSection": {
+    badger.getSettings().setItem("showExpandedTrackingSection", true);
+    sendResponse();
+    break;
+  }
+
+  case "hideTrackingDomainsSection": {
+    badger.getSettings().setItem("showExpandedTrackingSection", false);
+    sendResponse();
+    break;
+  }
+
   case "downloadCloud": {
     chrome.storage.sync.get("disabledSites", function (store) {
       if (chrome.runtime.lastError) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1039,6 +1039,7 @@ function dispatcher(request, sender, sendResponse) {
       noTabData: false,
       origins,
       seenComic: badger.getSettings().getItem("seenComic"),
+      showExpandedTrackingSection: badger.getSettings().getItem("showExpandedTrackingSection"),
       showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
       showNonTrackingDomains: badger.getSettings().getItem("showNonTrackingDomains"),
       tabHost: tab_host,

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -173,6 +173,10 @@ font-size: 16px;
     min-height: 70px;
 }
 
+#toggleBlockedResourcesContainer {
+    text-align: center;
+}
+
 #intro-reminder-btn, #critical-error-link, #learning-prompt-btn {
     background-color: #ff641c;
     border: 2px solid #ff641c;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -129,12 +129,12 @@
       <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </span>
+    <div id="toggleBlockedResourcesContainer">
+      <span id="expand-blocked-resources-text" class="i18n_popup_show_more"><span class="ui-icon ui-icon-caret-d"></span></span>
+      <span id="collapse-blocked-resources-text" class="i18n_popup_show_less" style="display:none"><span class="ui-icon ui-icon-caret-u"></span></span>
+    </div>
   </p>
   <div class="spacer"></div>
-  <div id="toggleBlockedResourcesContainer">
-    <span class="i18n_popup_show_more"><span class="ui-icon ui-icon-carat-d"></span></span>
-    <span class="i18n_popup_show_less" style="display:none"><span class="ui-icon ui-icon-carat-u"></span></span>
-  </div>
   <div id="blockedResources"></div>
 </div>
 

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -131,6 +131,10 @@
     </span>
   </p>
   <div class="spacer"></div>
+  <div id="toggleBlockedResourcesContainer">
+    <span class="i18n_popup_show_more"><span class="ui-icon ui-icon-carat-d"></span></span>
+    <span class="i18n_popup_show_less" style="display:none"><span class="ui-icon ui-icon-carat-u"></span></span>
+  </div>
   <div id="blockedResources"></div>
 </div>
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -230,6 +230,9 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.open_popup(origins={DOMAIN:"cookieblock"})
 
+        # make sure the 'see more' blocked resources container is expanded
+        self.driver.find_element_by_id("expand-blocked-resources-text").click()
+
         # set the domain to user control
         # click input with JavaScript to avoid "Element ... is not clickable" /
         # "Other element would receive the click" Selenium limitation


### PR DESCRIPTION
This changes the ui of the popup to hide the blocked resources section by default. The user can "show more" or less to set their preference for the popup ui. This makes room for other notifications in the popup ui, and hopefully furthers our agenda to resist the temptation to futz with those controls and mess things up.

<img width="425" alt="Screen Shot 2021-02-25 at 11 18 35 AM" src="https://user-images.githubusercontent.com/25778052/109205372-55ca9080-775b-11eb-95f5-53eea7bb42a8.png">


<img width="433" alt="Screen Shot 2021-02-25 at 11 18 23 AM" src="https://user-images.githubusercontent.com/25778052/109205385-5bc07180-775b-11eb-8338-e5606dd85d1c.png">

