### PR TITLE
Organize sliders into expandable summary, add first party protections section

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -417,6 +417,14 @@
         "message": "user-controlled",
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
+    "popup_info_firstparty_description": {
+        "message": "Some websites, such as the one you're on right now, use hyperlinks to track where you're going. When you click on these links, instead of going straight to where you expect, it first directs you to one of this website's tracking servers, then to the final destination that you intended to navigate to. This happens in miliseconds without you even noticing! Privacy Badger removes all that creepy tracking stuff this website puts on these links, and once again provides you with faster, more private browsing.",
+        "description": "message show under the firstparty protections collapsible container on popup"
+    },
+    "popup_info_firstparty_protections": {
+        "message": "<a href='https://privacybadger.org/#What-about-tracking-by-the-sites-I-actively-visit%2c-like-NYTimes.com-or-Facebook.com'>Link tracking</a> protection is enforced on this site",
+        "description": "message shown on a site where first party outgoing link tracking protections are enabled"
+    },
     "popup_instructions": {
         "message": "$COUNT$ potential $LINK_START$trackers$LINK_END$ blocked",
         "description": "Popup message shown when at least one tracker was blocked.",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -644,6 +644,10 @@
         "message": "Share",
         "description": "Tooltip that comes up when you hover over the share button in the upper right corner of the popup."
     },
+    "show_more_information": {
+        "message": "Click to show more information",
+        "description": "Tooltip that shows when you hover on the click-to-expand popup information sections."
+    },
     "share_tracker_header": {
         "message": "Privacy Badger blocked $COUNT$ potential trackers on $DOMAIN$:",
         "description": "Header above the list of tracking domains in the share message.",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -422,7 +422,7 @@
         "description": "Clickable status header text in the popup. Shown when Privacy Badger's link tracking protection is active (for example, on facebook.com)."
     },
     "popup_info_firstparty_description": {
-        "message": "Some websites, such as the one you're on right now, $LINK_START$use link tracking to follow you$LINK_END$ whenever you click a link to leave the website. Privacy Badger removes this link tracking.",
+        "message": "Some websites, such as the one you're on right now, $LINK_START$use link tracking to follow you$LINK_END$ whenever you click a link to leave the website. Privacy Badger is removing link tracking on this website.",
         "description": "Text revealed by clicking on the link tracking protection header in the popup",
         "placeholders": {
             "link_start": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -644,10 +644,6 @@
         "message": "Share",
         "description": "Tooltip that comes up when you hover over the share button in the upper right corner of the popup."
     },
-    "show_more_information": {
-        "message": "Click to show more information",
-        "description": "Tooltip that shows when you hover on the click-to-expand popup information sections."
-    },
     "share_tracker_header": {
         "message": "Privacy Badger blocked $COUNT$ potential trackers on $DOMAIN$:",
         "description": "Header above the list of tracking domains in the share message.",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -418,8 +418,16 @@
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "popup_info_firstparty_description": {
-        "message": "Some websites, such as the one you're on right now, <a href='https://privacybadger.org/#What-about-tracking-by-the-sites-I-actively-visit%2c-like-NYTimes.com-or-Facebook.com' target='_blank'>use hyperlinks to secretly track you.</a> Privacy Badger works behind the scenes to prevent them from doing that.",
-        "description": "message show under the firstparty protections collapsible container on popup"
+        "message": "Some websites, such as the one you're on right now, $LINK_START$use hyperlinks to secretly track you.$LINK_END$ Privacy Badger works behind the scenes to prevent them from doing that.",
+        "description": "message show under the firstparty protections collapsible container on popup",
+        "placeholders": {
+            "link_start": {
+                "content": "<a href='https://privacybadger.org/#What-about-tracking-by-the-sites-I-actively-visit%2c-like-NYTimes.com-or-Facebook.com' target='_blank'>"
+            },
+            "link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "popup_info_firstparty_protections": {
         "message": "Link tracking protection is enforced on this site",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -417,6 +417,10 @@
         "message": "user-controlled",
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
+    "popup_info_firstparty_protections": {
+        "message": "Link tracking protection is enforced on this site",
+        "description": "message shown on a site where first party outgoing link tracking protections are enabled"
+    },
     "popup_info_firstparty_description": {
         "message": "Some websites, such as the one you're on right now, $LINK_START$use hyperlinks to secretly track you.$LINK_END$ Privacy Badger works behind the scenes to prevent them from doing that.",
         "description": "message show under the firstparty protections collapsible container on popup",
@@ -428,10 +432,6 @@
                 "content": "</a>"
             }
         }
-    },
-    "popup_info_firstparty_protections": {
-        "message": "Link tracking protection is enforced on this site",
-        "description": "message shown on a site where first party outgoing link tracking protections are enabled"
     },
     "popup_instructions": {
         "message": "$COUNT$ potential $LINK_START$trackers$LINK_END$ blocked",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -418,11 +418,11 @@
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "popup_info_firstparty_description": {
-        "message": "Some websites, such as the one you're on right now, use hyperlinks to track where you're going. When you click on these links, instead of going straight to where you expect, it first directs you to one of this website's tracking servers, then to the final destination that you intended to navigate to. This happens in miliseconds without you even noticing! Privacy Badger removes all that creepy tracking stuff this website puts on these links, and once again provides you with faster, more private browsing.",
+        "message": "Some websites, such as the one you're on right now, <a href='https://privacybadger.org/#What-about-tracking-by-the-sites-I-actively-visit%2c-like-NYTimes.com-or-Facebook.com' target='_blank'>use hyperlinks to secretly track you.</a> Privacy Badger works behind the scenes to prevent them from doing that.",
         "description": "message show under the firstparty protections collapsible container on popup"
     },
     "popup_info_firstparty_protections": {
-        "message": "<a href='https://privacybadger.org/#What-about-tracking-by-the-sites-I-actively-visit%2c-like-NYTimes.com-or-Facebook.com'>Link tracking</a> protection is enforced on this site",
+        "message": "Link tracking protection is enforced on this site",
         "description": "message shown on a site where first party outgoing link tracking protections are enabled"
     },
     "popup_instructions": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -422,7 +422,7 @@
         "description": "Clickable status header text in the popup. Shown when Privacy Badger's link tracking protection is active (for example, on facebook.com)."
     },
     "popup_info_firstparty_description": {
-        "message": "Some websites, such as the one you're on right now, $LINK_START$use link tracking to follow you$LINK_END$ whenever you click a link to leave the website. Privacy Badger is removing link tracking on this website.",
+        "message": "Some websites $LINK_START$use link tracking to follow you$LINK_END$ whenever you click a link to leave the website. Privacy Badger removes tracking from such links on this website.",
         "description": "Text revealed by clicking on the link tracking protection header in the popup",
         "placeholders": {
             "link_start": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -418,12 +418,12 @@
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "popup_info_firstparty_protections": {
-        "message": "Link tracking protection is enforced on this site",
-        "description": "message shown on a site where first party outgoing link tracking protections are enabled"
+        "message": "Link tracking protection active",
+        "description": "Clickable status header text in the popup. Shown when Privacy Badger's link tracking protection is active (for example, on facebook.com)."
     },
     "popup_info_firstparty_description": {
-        "message": "Some websites, such as the one you're on right now, $LINK_START$use hyperlinks to secretly track you.$LINK_END$ Privacy Badger works behind the scenes to prevent them from doing that.",
-        "description": "message show under the firstparty protections collapsible container on popup",
+        "message": "Some websites, such as the one you're on right now, $LINK_START$use link tracking to follow you$LINK_END$ whenever you click a link to leave the website. Privacy Badger removes this link tracking.",
+        "description": "Text revealed by clicking on the link tracking protection header in the popup",
         "placeholders": {
             "link_start": {
                 "content": "<a href='https://privacybadger.org/#What-about-tracking-by-the-sites-I-actively-visit%2c-like-NYTimes.com-or-Facebook.com' target='_blank'>"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -93,13 +93,13 @@ function Badger() {
     await dntHashesPromise;
     await tabDataPromise;
 
-    // gather list of url schemes that firstparty content scripts run on
-    let manifestBlob = await chrome.runtime.getManifest();
+    // gather list of url match patterns that firstparty content scripts run on
+    let manifestJson = chrome.runtime.getManifest();
     let firstParties = [];
 
-    for (let contentScriptObj of manifestBlob.content_scripts) {
+    for (let contentScriptObj of manifestJson.content_scripts) {
       // only include parts from content scripts that have firstparties entries
-      if (contentScriptObj.js[0].includes("firstparties")) {
+      if (contentScriptObj.js[0].includes("/firstparties/")) {
         firstParties.push(contentScriptObj.matches);
       }
     }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -93,6 +93,19 @@ function Badger() {
     await dntHashesPromise;
     await tabDataPromise;
 
+    // gather list of url schemes that firstparty content scripts run on
+    let manifestBlob = await chrome.runtime.getManifest();
+    let firstParties = [];
+
+    for (let contentScriptObj of manifestBlob.content_scripts) {
+      // only include parts from content scripts that have firstparties entries
+      if (contentScriptObj.js[0].includes("firstparties")) {
+        firstParties.push(contentScriptObj.matches);
+      }
+    }
+    // set list of firstparty url schemes onto badger object
+    self.firstPartiesList = [].concat.apply([], firstParties);
+
     if (badger.isFirstRun || badger.isUpdate) {
       // block all widget domains
       // only need to do this when the widget list could have gotten updated

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -815,6 +815,7 @@ Badger.prototype = {
     seenComic: false,
     sendDNTSignal: true,
     showCounter: true,
+    showExpandedTrackingSection: false,
     showIntroPage: true,
     showNonTrackingDomains: false,
     showTrackingDomains: false,

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -93,23 +93,6 @@ function Badger() {
     await dntHashesPromise;
     await tabDataPromise;
 
-    // gather list of url match patterns that firstparty content scripts run on
-    let manifestJson = chrome.runtime.getManifest();
-    let firstParties = [];
-
-    for (let contentScriptObj of manifestJson.content_scripts) {
-      // only include parts from content scripts that have firstparties entries
-      if (contentScriptObj.js[0].includes("/firstparties/")) {
-        let extractedUrls = [];
-        for (let match of contentScriptObj.matches) {
-          extractedUrls.push(window.extractHostFromURL(match));
-        }
-        firstParties.push(extractedUrls);
-      }
-    }
-    // set list of firstparty url schemes onto badger object
-    self.firstPartiesList = [].concat.apply([], firstParties);
-
     if (badger.isFirstRun || badger.isUpdate) {
       // block all widget domains
       // only need to do this when the widget list could have gotten updated

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -100,7 +100,11 @@ function Badger() {
     for (let contentScriptObj of manifestJson.content_scripts) {
       // only include parts from content scripts that have firstparties entries
       if (contentScriptObj.js[0].includes("/firstparties/")) {
-        firstParties.push(contentScriptObj.matches);
+        let extractedUrls = [];
+        for (let match of contentScriptObj.matches) {
+          extractedUrls.push(window.extractHostFromURL(match));
+        }
+        firstParties.push(extractedUrls);
       }
     }
     // set list of firstparty url schemes onto badger object

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -127,7 +127,7 @@ function showNagMaybe() {
   if (POPUP_DATA.showLearningPrompt) {
     _showLearningPrompt();
 
-  } else if (!POPUP_DATA.seenComic) {
+  } else if (!POPUP_DATA.settings.seenComic) {
     chrome.tabs.query({active: true, currentWindow: true}, function (focusedTab) {
       // Show the popup instruction if the active tab is not firstRun.html page
       if (!focusedTab[0].url.startsWith(intro_page_url)) {
@@ -202,7 +202,7 @@ function init() {
 
   // show sliders when sliders were shown last
   // or when there is at least one breakage warning
-  if (POPUP_DATA.showExpandedTrackingSection || (
+  if (POPUP_DATA.settings.showExpandedTrackingSection || (
     POPUP_DATA.cookieblocked && Object.keys(POPUP_DATA.cookieblocked).some(
       d => POPUP_DATA.origins[d] == constants.USER_BLOCK)
   )) {
@@ -589,7 +589,7 @@ function refreshPopup() {
     // show "no trackers" message
     $("#instructions-no-trackers").show();
 
-    if (POPUP_DATA.learnLocally && POPUP_DATA.showNonTrackingDomains) {
+    if (POPUP_DATA.settings.learnLocally && POPUP_DATA.settings.showNonTrackingDomains) {
       // show the "no third party resources on this site" message
       $("#no-third-parties").show();
     }
@@ -632,7 +632,7 @@ function refreshPopup() {
   // show breakage warning sliders at the top of the list
   printable = printableWarningSliders.concat(printable);
 
-  if (POPUP_DATA.learnLocally && unblockedTrackers.length) {
+  if (POPUP_DATA.settings.learnLocally && unblockedTrackers.length) {
     printable.push(
       '<div class="clicker tooltip" id="not-yet-blocked-header" title="' +
       chrome.i18n.getMessage("intro_not_an_adblocker_paragraph") +
@@ -647,7 +647,7 @@ function refreshPopup() {
     });
   }
 
-  if (POPUP_DATA.learnLocally && POPUP_DATA.showNonTrackingDomains && nonTracking.length) {
+  if (POPUP_DATA.settings.learnLocally && POPUP_DATA.settings.showNonTrackingDomains && nonTracking.length) {
     printable.push(
       '<div class="clicker tooltip" id="non-trackers-header" title="' +
       chrome.i18n.getMessage("non_tracker_tip") +

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -586,10 +586,6 @@ function refreshPopup() {
   }
 
   if (!originsArr.length) {
-    // hide the number of trackers and slider instructions message
-    // if no sliders will be displayed
-    $("#instructions-many-trackers").hide();
-
     // show "no trackers" message
     $("#instructions-no-trackers").show();
 
@@ -675,9 +671,6 @@ function refreshPopup() {
   $('.tooltip').tooltipster();
 
   if (POPUP_DATA.trackerCount === 0) {
-    // hide multiple trackers message
-    $("#instructions-many-trackers").hide();
-
     // show "no trackers" message
     $("#instructions-no-trackers").show();
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -467,13 +467,15 @@ function toggleBlockedResourcesHandler() {
     $("#collapse-blocked-resources, #blockedResources").show();
     $("#expand-blocked-resources").hide();
     chrome.runtime.sendMessage({
-      type: "showTrackingDomainsSection"
+      type: "updateSettings",
+      data: { showExpandedTrackingSection: true }
     });
   } else {
     $("#collapse-blocked-resources, #blockedResources").hide();
     $("#expand-blocked-resources").show();
     chrome.runtime.sendMessage({
-      type: "hideTrackingDomainsSection"
+      type: "updateSettings",
+      data: { showExpandedTrackingSection: false }
     });
   }
 }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -194,8 +194,21 @@ function init() {
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
   );
 
+  $('#expand-blocked-resources').on('click', showBlockedResourcesHandler);
+  $('#collapse-blocked-resources').on('click', hideBlockedResourcesHandler);
+
   $('#expand-firstparty-popup').on('click', showFirstPartyInfoHandler);
   $('#collapse-firstparty-popup').on('click', hideFirstPartyInfoHandler);
+
+  if (POPUP_DATA.showExpandedTrackingSection) {
+    $('#expand-blocked-resources').hide();
+    $('#collapse-blocked-resources').show();
+    $('#blockedResources').show();
+  } else if (!POPUP_DATA.showExpandedTrackingSection) {
+    $('#expand-blocked-resources').show();
+    $('#collapse-blocked-resources').hide();
+    $('#blockedResources').hide();
+  }
 
   $('#instructions-firstparty-description').hide();
   $('#collapse-firstparty-popup').hide();
@@ -462,7 +475,26 @@ function share() {
   }
   $("#share_output").val(share_msg);
 }
+/**
+ * Click handlers for showing/hiding the blocked resources section
+ */
+function showBlockedResourcesHandler() {
+  $("#collapse-blocked-resources").show();
+  $("#expand-blocked-resources").hide();
+  $("#blockedResources").show();
+  chrome.runtime.sendMessage({
+    type: "showTrackingDomainsSection"
+  });
+}
 
+function hideBlockedResourcesHandler() {
+  $("#collapse-blocked-resources").hide();
+  $("#expand-blocked-resources").show();
+  $("#blockedResources").hide();
+  chrome.runtime.sendMessage({
+    type: "hideTrackingDomainsSection"
+  });
+}
 /**
  * Click handlers for showing/hiding the firstparty popup info text
  */
@@ -552,6 +584,7 @@ function refreshPopup() {
     // hide the number of trackers and slider instructions message
     // if no sliders will be displayed
     $("#instructions-many-trackers").hide();
+    $("#toggleBlockedResourcesContainer").hide();
 
     // show "no trackers" message
     $("#instructions-no-trackers").show();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -470,7 +470,11 @@ function share() {
 /**
  * Click handlers for showing/hiding the blocked resources section
  */
-function toggleBlockedResourcesHandler() {
+function toggleBlockedResourcesHandler(e) {
+  if (e.target.nodeName.toLowerCase() == 'a') {
+    // don't toggle contents when clicking links in the header
+    return;
+  }
   if ($("#expand-blocked-resources").is(":visible")) {
     $("#collapse-blocked-resources").show();
     $("#expand-blocked-resources").hide();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -194,10 +194,10 @@ function init() {
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
   );
 
+  // add event listeners for click-to-expand blocked resources popup section
   $('#expand-blocked-resources, #collapse-blocked-resources, #instructions-many-trackers').on('click', toggleBlockedResourcesHandler);
-  // $('#collapse-blocked-resources, #instructions-many-trackers').on('click', hideBlockedResourcesHandler);
 
-  // set up visibility click handler for firstparty protections header section
+  // add event listeners for click-to-expand first party protections popup section
   $('#expand-firstparty-popup, #collapse-firstparty-popup, #instructions-firstparty-protections').on('click', toggleFirstPartyInfoHandler);
 
   if (POPUP_DATA.showExpandedTrackingSection) {
@@ -213,26 +213,10 @@ function init() {
   $('#instructions-firstparty-description').hide();
   $('#collapse-firstparty-popup').hide();
 
-  // check if any firstparty scripts are run on current tab & show message in popup
-  async function fetchFirstPartiesManifest() {
-    // fetch the manifest
-    const response = await fetch('../manifest.json');
-    const blob = await response.json();
-
-    // remove the 'www.' from current tab for string matching against first parties manifest url schemes
-    let current_tab = POPUP_DATA.tabHost.slice(4);
-
-    // if current tab is in first parties list, show the popup message
-    for (let firstPartyObj of blob.content_scripts) {
-      firstPartyObj.matches.forEach((urlScheme) => {
-        if (urlScheme.includes(current_tab)) {
-          $("#firstparty-protections-container").show();
-        }
-      });
-    }
+  // show firstparty protections message if current tab is in our content scripts
+  if (POPUP_DATA.enabled && POPUP_DATA.isOnFirstParty) {
+    $("#firstparty-protections-container").show();
   }
-
-  if (POPUP_DATA.enabled) { fetchFirstPartiesManifest(); }
 
   // improve on Firefox's built-in options opening logic
   if (typeof browser == "object" && typeof browser.runtime.getBrowserInfo == "function") {
@@ -581,7 +565,7 @@ function refreshPopup() {
     // hide the number of trackers and slider instructions message
     // if no sliders will be displayed
     $("#instructions-many-trackers").hide();
-    $("#toggleBlockedResourcesContainer").hide();
+    $("#toggle-blocked-resources-container").hide();
 
     // show "no trackers" message
     $("#instructions-no-trackers").show();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -226,7 +226,9 @@ function init() {
     for (let firstPartyObj of blob.content_scripts) {
       firstPartyObj.matches.forEach((urlScheme) => {
         if (urlScheme.includes(current_tab)) {
-          $("#firstpartyProtectionsContainer").show();
+          $("#firstparty-protections-container").show();
+          // in the edge case that no-trackers are detected, align text to left to match
+          $("#instructions-no-trackers").css("text-align","left");
         }
       });
     }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -194,6 +194,33 @@ function init() {
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
   );
 
+  $('#expand-firstparty-popup').on('click', showFirstPartyInfoHandler);
+  $('#collapse-firstparty-popup').on('click', hideFirstPartyInfoHandler);
+
+  $('#instructions-firstparty-description').hide();
+  $('#collapse-firstparty-popup').hide();
+
+  // check if any firstparty scripts are run on current tab & show message in popup
+  async function fetchFirstPartiesManifest() {
+    // fetch the manifest
+    const response = await fetch('../manifest.json');
+    const blob = await response.json();
+
+    // remove the 'www.' from current tab for string matching against first parties manifest url schemes
+    let current_tab = POPUP_DATA.tabHost.slice(4);
+
+    // if current tab is in first parties list, show the popup message
+    for (let firstPartyObj of blob.content_scripts) {
+      firstPartyObj.matches.forEach((urlScheme) => {
+        if (urlScheme.includes(current_tab)) {
+          $("#firstpartyProtectionsContainer").show();
+        }
+      });
+    }
+  }
+
+  fetchFirstPartiesManifest();
+
   // improve on Firefox's built-in options opening logic
   if (typeof browser == "object" && typeof browser.runtime.getBrowserInfo == "function") {
     browser.runtime.getBrowserInfo().then(function (info) {
@@ -434,6 +461,21 @@ function share() {
     share_msg += tracking.join("\n");
   }
   $("#share_output").val(share_msg);
+}
+
+/**
+ * Click handlers for showing/hiding the firstparty popup info text
+ */
+function showFirstPartyInfoHandler() {
+  $("#collapse-firstparty-popup").show();
+  $("#expand-firstparty-popup").hide();
+  $("#instructions-firstparty-description").show();
+}
+
+function hideFirstPartyInfoHandler() {
+  $("#collapse-firstparty-popup").hide();
+  $("#expand-firstparty-popup").show();
+  $("#instructions-firstparty-description").hide();
 }
 
 /**

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -603,7 +603,8 @@ function refreshPopup() {
     return;
   }
 
-  let printable = [];
+  let printable = [],
+    printableWarningSliders = [];
   let unblockedTrackers = [];
   let nonTracking = [];
   originsArr = htmlUtils.sortDomains(originsArr);
@@ -620,11 +621,17 @@ function refreshPopup() {
         action == constants.USER_BLOCK &&
         POPUP_DATA.cookieblocked.hasOwnProperty(origin)
       );
-      printable.push(
-        htmlUtils.getOriginHtml(origin, action, show_breakage_warning)
-      );
+      let slider_html = htmlUtils.getOriginHtml(origin, action, show_breakage_warning);
+      if (show_breakage_warning) {
+        printableWarningSliders.push(slider_html);
+      } else {
+        printable.push(slider_html);
+      }
     }
   }
+
+  // show breakage warning sliders at the top of the list
+  printable = printableWarningSliders.concat(printable);
 
   if (POPUP_DATA.learnLocally && unblockedTrackers.length) {
     printable.push(

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -197,8 +197,8 @@ function init() {
   $('#expand-blocked-resources').on('click', showBlockedResourcesHandler);
   $('#collapse-blocked-resources').on('click', hideBlockedResourcesHandler);
 
-  $('#expand-firstparty-popup').on('click', showFirstPartyInfoHandler);
-  $('#collapse-firstparty-popup').on('click', hideFirstPartyInfoHandler);
+  // set up visibility click handler for firstparty protections header section
+  $('#expand-firstparty-popup, #collapse-firstparty-popup, #instructions-firstparty-protections').on('click', toggleFirstPartyInfoHandler);
 
   if (POPUP_DATA.showExpandedTrackingSection) {
     $('#expand-blocked-resources').hide();
@@ -225,10 +225,8 @@ function init() {
     // if current tab is in first parties list, show the popup message
     for (let firstPartyObj of blob.content_scripts) {
       firstPartyObj.matches.forEach((urlScheme) => {
-        if (urlScheme.includes(current_tab)) {
+        if (urlScheme.includes(current_tab) && POPUP_DATA.enabled) {
           $("#firstparty-protections-container").show();
-          // in the edge case that no-trackers are detected, align text to left to match
-          $("#instructions-no-trackers").css("text-align","left");
         }
       });
     }
@@ -498,18 +496,16 @@ function hideBlockedResourcesHandler() {
   });
 }
 /**
- * Click handlers for showing/hiding the firstparty popup info text
+ * Click handler for showing/hiding the firstparty popup info text
  */
-function showFirstPartyInfoHandler() {
-  $("#collapse-firstparty-popup").show();
-  $("#expand-firstparty-popup").hide();
-  $("#instructions-firstparty-description").show();
-}
-
-function hideFirstPartyInfoHandler() {
-  $("#collapse-firstparty-popup").hide();
-  $("#expand-firstparty-popup").show();
-  $("#instructions-firstparty-description").hide();
+function toggleFirstPartyInfoHandler() {
+  if($('#collapse-firstparty-popup').is(":visible")) {
+    $("#collapse-firstparty-popup, #instructions-firstparty-description").hide();
+    $("#expand-firstparty-popup").show();
+  } else {
+    $("#collapse-firstparty-popup, #instructions-firstparty-description").show();
+    $("#expand-firstparty-popup").hide();
+  }
 }
 
 /**

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -200,10 +200,13 @@ function init() {
   // add event listeners for click-to-expand first party protections popup section
   $('#firstparty-protections-header').on('click', toggleFirstPartyInfoHandler);
 
-  if (POPUP_DATA.showExpandedTrackingSection) {
+  // show sliders when sliders were shown last
+  // or when there is at least one breakage warning
+  if (POPUP_DATA.showExpandedTrackingSection || Object.keys(POPUP_DATA.cookieblocked).some(d => POPUP_DATA.origins[d] == constants.USER_BLOCK)) {
     $('#expand-blocked-resources').hide();
     $('#collapse-blocked-resources').show();
     $('#blockedResources').show();
+
   } else {
     $('#expand-blocked-resources').show();
     $('#collapse-blocked-resources').hide();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -194,8 +194,8 @@ function init() {
     chrome.i18n.getMessage("version", chrome.runtime.getManifest().version)
   );
 
-  $('#expand-blocked-resources').on('click', showBlockedResourcesHandler);
-  $('#collapse-blocked-resources').on('click', hideBlockedResourcesHandler);
+  $('#expand-blocked-resources, #collapse-blocked-resources, #instructions-many-trackers').on('click', toggleBlockedResourcesHandler);
+  // $('#collapse-blocked-resources, #instructions-many-trackers').on('click', hideBlockedResourcesHandler);
 
   // set up visibility click handler for firstparty protections header section
   $('#expand-firstparty-popup, #collapse-firstparty-popup, #instructions-firstparty-protections').on('click', toggleFirstPartyInfoHandler);
@@ -225,14 +225,14 @@ function init() {
     // if current tab is in first parties list, show the popup message
     for (let firstPartyObj of blob.content_scripts) {
       firstPartyObj.matches.forEach((urlScheme) => {
-        if (urlScheme.includes(current_tab) && POPUP_DATA.enabled) {
+        if (urlScheme.includes(current_tab)) {
           $("#firstparty-protections-container").show();
         }
       });
     }
   }
 
-  fetchFirstPartiesManifest();
+  if (POPUP_DATA.enabled) { fetchFirstPartiesManifest(); }
 
   // improve on Firefox's built-in options opening logic
   if (typeof browser == "object" && typeof browser.runtime.getBrowserInfo == "function") {
@@ -478,28 +478,27 @@ function share() {
 /**
  * Click handlers for showing/hiding the blocked resources section
  */
-function showBlockedResourcesHandler() {
-  $("#collapse-blocked-resources").show();
-  $("#expand-blocked-resources").hide();
-  $("#blockedResources").show();
-  chrome.runtime.sendMessage({
-    type: "showTrackingDomainsSection"
-  });
+function toggleBlockedResourcesHandler() {
+  if ($("#expand-blocked-resources").is(":visible")) {
+    $("#collapse-blocked-resources, #blockedResources").show();
+    $("#expand-blocked-resources").hide();
+    chrome.runtime.sendMessage({
+      type: "showTrackingDomainsSection"
+    });
+  } else {
+    $("#collapse-blocked-resources, #blockedResources").hide();
+    $("#expand-blocked-resources").show();
+    chrome.runtime.sendMessage({
+      type: "hideTrackingDomainsSection"
+    });
+  }
 }
 
-function hideBlockedResourcesHandler() {
-  $("#collapse-blocked-resources").hide();
-  $("#expand-blocked-resources").show();
-  $("#blockedResources").hide();
-  chrome.runtime.sendMessage({
-    type: "hideTrackingDomainsSection"
-  });
-}
 /**
  * Click handler for showing/hiding the firstparty popup info text
  */
 function toggleFirstPartyInfoHandler() {
-  if($('#collapse-firstparty-popup').is(":visible")) {
+  if ($('#collapse-firstparty-popup').is(":visible")) {
     $("#collapse-firstparty-popup, #instructions-firstparty-description").hide();
     $("#expand-firstparty-popup").show();
   } else {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -202,7 +202,10 @@ function init() {
 
   // show sliders when sliders were shown last
   // or when there is at least one breakage warning
-  if (POPUP_DATA.showExpandedTrackingSection || Object.keys(POPUP_DATA.cookieblocked).some(d => POPUP_DATA.origins[d] == constants.USER_BLOCK)) {
+  if (POPUP_DATA.showExpandedTrackingSection || (
+    POPUP_DATA.cookieblocked && Object.keys(POPUP_DATA.cookieblocked).some(
+      d => POPUP_DATA.origins[d] == constants.USER_BLOCK)
+  )) {
     $('#expand-blocked-resources').hide();
     $('#collapse-blocked-resources').show();
     $('#blockedResources').show();

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -479,7 +479,7 @@ let firstPartyProtectionsEnabled = (function () {
 
     for (let url_pattern of firstPartiesList) {
       if (url_pattern.startsWith("*")) {
-        if ((url_pattern.slice(2) == tab_host.slice(4)) || url_pattern.slice(2) == tab_host.slice(2)) {
+        if (tab_host.endsWith(url_pattern.slice(1))) {
           return true;
         }
       } else if (url_pattern == tab_host) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -486,7 +486,6 @@ function firstPartyProtectionsEnabled(domain, badger) {
   return false;
 }
 
-
 /**
  * Checks whether a given URL is a special browser page.
  * TODO account for browser-specific pages:

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -445,6 +445,23 @@ function isThirdPartyDomain(domain1, domain2) {
   return false;
 }
 
+// checks to see if a given tab host is in url schemes of our first parties content scripts list
+function firstPartyProtectionsEnabled(tab_host) {
+  // trim www from tab_host if need be
+  if (tab_host.startsWith('www.')) {
+    tab_host = tab_host.slice(4);
+  }
+  // trim trailing wildcard
+
+  for (let url_pattern of badger.firstPartiesList) {
+    // if given tab_host is matched in our firstparties list, return true
+    if (url_pattern.includes(tab_host)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 
 /**
  * Checks whether a given URL is a special browser page.
@@ -469,6 +486,7 @@ let exports = {
   estimateMaxEntropy,
   explodeSubdomains,
   findCommonSubstrings,
+  firstPartyProtectionsEnabled,
   getHostFromDomainInput,
   isRestrictedUrl,
   isThirdPartyDomain,

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -455,8 +455,11 @@ function isThirdPartyDomain(domain1, domain2) {
 function firstPartyProtectionsEnabled(domain, firstPartiesList) {
   for (let url_pattern of firstPartiesList) {
     // account for wildcards in entries on firstPartiesList & avoid false positives
-    if (url_pattern.startsWith("*") && url_pattern.endsWith(domain)) {
-      return true;
+    if (url_pattern.startsWith("*")) {
+      // compare against pattern without '*.' and the domain without 'www.'
+      if (url_pattern.slice(2) == domain.slice(4)) {
+        return true;
+      }
     } else if (url_pattern == domain) {
       return true;
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -446,11 +446,11 @@ function isThirdPartyDomain(domain1, domain2) {
 }
 
 /**
- * checks to see if a given url has firstparty protections scripts run on it
- * @param {String} domain
- * @param {Object} firstPartiesList a second fqdn
+ * Checks whether a given site hostname matches
+ * any first party protections content scripts.
  *
- * @return {Boolean} true if the domains are third party
+ * @param {String} tab_host
+ * @return {Boolean}
  */
 let firstPartyProtectionsEnabled = (function () {
   let firstPartiesList;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -453,15 +453,11 @@ function isThirdPartyDomain(domain1, domain2) {
  * @return {Boolean} true if the domains are third party
  */
 function firstPartyProtectionsEnabled(domain, firstPartiesList) {
-  // trim www from tab_host if need be
-  if (domain.startsWith('www.')) {
-    domain = domain.slice(4);
-  }
-  // trim trailing wildcard
-
   for (let url_pattern of firstPartiesList) {
-    // if given domain is matched in our firstparties list, return true
-    if (url_pattern.includes(domain)) {
+    // account for wildcards in entries on firstPartiesList & avoid false positives
+    if (url_pattern.startsWith("*") && url_pattern.endsWith(domain)) {
+      return true;
+    } else if (url_pattern == domain) {
       return true;
     }
   }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -445,17 +445,23 @@ function isThirdPartyDomain(domain1, domain2) {
   return false;
 }
 
-// checks to see if a given tab host is in url schemes of our first parties content scripts list
-function firstPartyProtectionsEnabled(tab_host) {
+/**
+ * checks to see if a given url has firstparty protections scripts run on it
+ * @param {String} domain
+ * @param {Object} firstPartiesList a second fqdn
+ *
+ * @return {Boolean} true if the domains are third party
+ */
+function firstPartyProtectionsEnabled(domain, firstPartiesList) {
   // trim www from tab_host if need be
-  if (tab_host.startsWith('www.')) {
-    tab_host = tab_host.slice(4);
+  if (domain.startsWith('www.')) {
+    domain = domain.slice(4);
   }
   // trim trailing wildcard
 
-  for (let url_pattern of badger.firstPartiesList) {
-    // if given tab_host is matched in our firstparties list, return true
-    if (url_pattern.includes(tab_host)) {
+  for (let url_pattern of firstPartiesList) {
+    // if given domain is matched in our firstparties list, return true
+    if (url_pattern.includes(domain)) {
       return true;
     }
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1038,6 +1038,7 @@ function dispatcher(request, sender, sendResponse) {
       noTabData: false,
       origins,
       seenComic: badger.getSettings().getItem("seenComic"),
+      showExpandedTrackingSection: badger.getSettings().getItem("showExpandedTrackingSection"),
       showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
       showNonTrackingDomains: badger.getSettings().getItem("showNonTrackingDomains"),
       tabHost: tab_host,
@@ -1122,6 +1123,18 @@ function dispatcher(request, sender, sendResponse) {
     sendResponse({
       origins: badger.storage.getTrackingDomains()
     });
+    break;
+  }
+
+  case "showTrackingDomainsSection": {
+    badger.getSettings().setItem("showExpandedTrackingSection", true);
+    sendResponse();
+    break;
+  }
+
+  case "hideTrackingDomainsSection": {
+    badger.getSettings().setItem("showExpandedTrackingSection", false);
+    sendResponse();
     break;
   }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1021,7 +1021,7 @@ function dispatcher(request, sender, sendResponse) {
     let tab_host = window.extractHostFromURL(request.tabUrl),
       origins = badger.tabData[tab_id].origins,
       cookieblocked = {},
-      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host);
+      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host, badger.firstPartiesList);
 
     for (let origin in origins) {
       // see if origin would be cookieblocked if not for user override

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1013,15 +1013,14 @@ function dispatcher(request, sender, sendResponse) {
       sendResponse({
         criticalError: badger.criticalError,
         noTabData: true,
-        seenComic: true,
+        settings: { seenComic: true },
       });
       break;
     }
 
     let tab_host = window.extractHostFromURL(request.tabUrl),
       origins = badger.tabData[tab_id].origins,
-      cookieblocked = {},
-      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host);
+      cookieblocked = {};
 
     for (let origin in origins) {
       // see if origin would be cookieblocked if not for user override
@@ -1035,14 +1034,11 @@ function dispatcher(request, sender, sendResponse) {
       criticalError: badger.criticalError,
       enabled: badger.isPrivacyBadgerEnabled(tab_host),
       errorText: badger.tabData[tab_id].errorText,
-      isOnFirstParty: isOnFirstParty,
-      learnLocally: badger.getSettings().getItem("learnLocally"),
+      isOnFirstParty: utils.firstPartyProtectionsEnabled(tab_host),
       noTabData: false,
       origins,
-      seenComic: badger.getSettings().getItem("seenComic"),
-      showExpandedTrackingSection: badger.getSettings().getItem("showExpandedTrackingSection"),
       showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
-      showNonTrackingDomains: badger.getSettings().getItem("showNonTrackingDomains"),
+      settings: badger.getSettings().getItemClones(),
       tabHost: tab_host,
       tabId: tab_id,
       tabUrl: request.tabUrl,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1021,7 +1021,7 @@ function dispatcher(request, sender, sendResponse) {
     let tab_host = window.extractHostFromURL(request.tabUrl),
       origins = badger.tabData[tab_id].origins,
       cookieblocked = {},
-      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host, badger.firstPartiesList);
+      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host, badger);
 
     for (let origin in origins) {
       // see if origin would be cookieblocked if not for user override

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -819,23 +819,6 @@ function initializeAllowedWidgets(tab_id, tab_host) {
   }
 }
 
-// checks to see if a given tab host is in url schemes of our first parties content scripts list
-function checkHostIsFirstParty(tab_host) {
-  // trim www from tab_host if need be
-  if (tab_host.startsWith('www.')) {
-    tab_host = tab_host.slice(4);
-  }
-  // trim trailing wildcard
-
-  for (let url_scheme of badger.firstPartiesList) {
-    // if given tab_host is matched in our firstparties list, return true
-    if (url_scheme.includes(tab_host)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 // NOTE: sender.tab is available for content script (not popup) messages only
 function dispatcher(request, sender, sendResponse) {
 
@@ -1038,7 +1021,7 @@ function dispatcher(request, sender, sendResponse) {
     let tab_host = window.extractHostFromURL(request.tabUrl),
       origins = badger.tabData[tab_id].origins,
       cookieblocked = {},
-      isOnFirstParty = checkHostIsFirstParty(tab_host);
+      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host);
 
     for (let origin in origins) {
       // see if origin would be cookieblocked if not for user override

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1128,18 +1128,6 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
-  case "showTrackingDomainsSection": {
-    badger.getSettings().setItem("showExpandedTrackingSection", true);
-    sendResponse();
-    break;
-  }
-
-  case "hideTrackingDomainsSection": {
-    badger.getSettings().setItem("showExpandedTrackingSection", false);
-    sendResponse();
-    break;
-  }
-
   case "downloadCloud": {
     chrome.storage.sync.get("disabledSites", function (store) {
       if (chrome.runtime.lastError) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1021,7 +1021,7 @@ function dispatcher(request, sender, sendResponse) {
     let tab_host = window.extractHostFromURL(request.tabUrl),
       origins = badger.tabData[tab_id].origins,
       cookieblocked = {},
-      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host, badger);
+      isOnFirstParty = utils.firstPartyProtectionsEnabled(tab_host);
 
     for (let origin in origins) {
       // see if origin would be cookieblocked if not for user override

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -819,6 +819,23 @@ function initializeAllowedWidgets(tab_id, tab_host) {
   }
 }
 
+// checks to see if a given tab host is in url schemes of our first parties content scripts list
+function checkHostIsFirstParty(tab_host) {
+  // trim www from tab_host if need be
+  if (tab_host.startsWith('www.')) {
+    tab_host = tab_host.slice(4);
+  }
+  // trim trailing wildcard
+
+  for (let url_scheme of badger.firstPartiesList) {
+    // if given tab_host is matched in our firstparties list, return true
+    if (url_scheme.includes(tab_host)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // NOTE: sender.tab is available for content script (not popup) messages only
 function dispatcher(request, sender, sendResponse) {
 
@@ -1020,7 +1037,8 @@ function dispatcher(request, sender, sendResponse) {
 
     let tab_host = window.extractHostFromURL(request.tabUrl),
       origins = badger.tabData[tab_id].origins,
-      cookieblocked = {};
+      cookieblocked = {},
+      isOnFirstParty = checkHostIsFirstParty(tab_host);
 
     for (let origin in origins) {
       // see if origin would be cookieblocked if not for user override
@@ -1034,6 +1052,7 @@ function dispatcher(request, sender, sendResponse) {
       criticalError: badger.criticalError,
       enabled: badger.isPrivacyBadgerEnabled(tab_host),
       errorText: badger.tabData[tab_id].errorText,
+      isOnFirstParty: isOnFirstParty,
       learnLocally: badger.getSettings().getItem("learnLocally"),
       noTabData: false,
       origins,

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -30,13 +30,19 @@ body {
 
   min-width: 430px; /* Chrome */
   max-width: 100%;  /* FF android */
-  min-height: 270px;
+  min-height: 300px;
 }
 @media screen and (min--moz-device-pixel-ratio:0) {
     body {
         min-width: 200px; /* FF android */
         width: 430px;     /* FF desktop */
     }
+}
+
+/* popup only (not options page) */
+body#main {
+    display: flex;
+    flex-direction: column;
 }
 
 @font-face {
@@ -139,9 +145,10 @@ a:hover { color: #ec9329 }
     display: inline-block;
 }
 
-#privacyBadgerHeader{
-color: #505050;
-font-size: 16px;
+#privacyBadgerHeader {
+    color: #505050;
+    font-size: 16px;
+    margin-bottom: 5px;
 }
 
 #title {
@@ -169,9 +176,12 @@ font-size: 16px;
     float: left;
 }
 
-#blockedResourcesContainer {
-    min-height: 70px;
-    margin-top: 10px;
+/* body#main to avoid applying this to options page */
+body#main #blockedResourcesContainer {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
 #intro-reminder-btn, #critical-error-link, #learning-prompt-btn {
@@ -196,7 +206,7 @@ font-size: 16px;
 .clickerContainer {
     max-height: 290px;
     overflow-y: auto;
-    background-color: #E8E9EA;
+    background-color: #e8e9ea;
     position: relative;
     margin-top: 25px;
 }
@@ -284,49 +294,33 @@ font-size: 16px;
 #options {
     margin-inline-end: 3px;
 }
-.pbInstructions, #special-browser-page, #disabled-site-message, #instructions-firstparty-protections {
+.pbInstructions, .toggle-header-title, #special-browser-page, #disabled-site-message {
     color: #505050;
     font-size: 16px;
     margin: 0;
-    padding-top: 10px;
 }
-#instructions-firstparty-protections, #toggle-blocked-resources-container, #instructions-many-trackers, #toggle-firstparty-info-section {
-    cursor: pointer;
-}
-.pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a {
+/* body#main to avoid applying this to options page */
+body#main .pbInstructions a, #firstparty-protections-container a {
     text-decoration: underline;
     color: black;
     font-weight: bold;
 }
-.pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a:hover {
-    color: #ec9329
-}
-#firstparty-protections-container a {
-    text-decoration: underline;
-    color: black;
-    font-weight: bold;
-}
-#firstparty-protections-container a:hover {
+body#main .pbInstructions a:hover, #firstparty-protections-container a:hover {
     color: #ec9329
 }
 #instructions-firstparty-description {
     font-size: 14px;
-    margin-top: -30px;
-    background-color: #E8E9EA;
-    color: #555555;
+    background-color: #e8e9ea;
+    color: #555;
     padding: 8px;
-    text-align: left;
     font-size: 12px;
 }
-#instructions-no-trackers, #special-browser-page, #disabled-site-message, #instructions-many-trackers, #firstparty-protections-container {
+#special-browser-page, #disabled-site-message {
     text-align: center;
-    margin: 45px 0;
+    margin: 40px 0;
     padding: 0;
 }
-#instructions-many-trackers {
-    margin: 10px 0;
-}
-#instructions-many-trackers, #instructions-no-trackers, #no-third-parties, #instructions-firstparty-description {
+#instructions-many-trackers, #no-third-parties {
     display: block;
 }
 #no-third-parties {
@@ -337,11 +331,7 @@ font-size: 16px;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    margin-top: 5px;
     text-align: center;
-}
-button {
-    color: #333;
 }
 .pbButton {
     background-color: #fefefe;
@@ -480,32 +470,49 @@ div.overlay.active {
     border: none;
 }
 #firstparty-protections-container {
-    display: none;
-    border-top: 1px solid #d3d3d3;
-    margin: auto;
+    border-bottom: 1px solid #d3d3d3;
+    margin: 10px 0;
+    padding-bottom: 5px;
+}
+.basic-header {
+    text-align: center;
+    margin: 15px 0;
+}
+.toggle-header {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    transition: border 0.25s ease-out;
+    background-color: #fff;
+    border: 2px solid #fff;
+    border-radius: 3px;
     padding: 0;
+    width: 100%;
 }
-#instructions-firstparty-protections {
-    margin: 45px 0;
-    padding: 0;
+.toggle-header:hover {
+    border: 2px solid #f06a0a;
 }
-#toggle-firstparty-info-section {
-    float: right;
-    margin-top: -65px;
+.toggle-header:hover .toggle-header-title {
+    color: #000;
 }
-#toggle-blocked-resources-container {
-    float: right;
-    margin-top: -30px;
+.toggle-header-title {
+    flex: 1;
+    transition: color 0.25s ease-out;
+    margin: 10px 0;
+}
+.toggle-header::before {
+    content: '';
+    font-size: 18px;
+    padding: 0 4px;
+    width: 1.2em;
+    visibility: hidden;
+}
+.toggle-header-icon {
+    margin-inline-end: auto;
+    padding: 0 4px;
 }
 .ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
     font-size: 18px;
-    transition: 250ms;
-}
-.ui-icon.ui-icon-caret-d:hover {
-    transform: translateY(5px);
-}
-.ui-icon.ui-icon-caret-u:hover {
-    transform: translateY(-5px);
 }
 @media screen and (max-width: 400px){
     .origin {
@@ -552,11 +559,26 @@ div.overlay.active {
     }
 
     button,
-    .pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a,
+    /* body#main to avoid applying this to options page */
+    body#main .pbInstructions a,
+    #firstparty-protections-container a,
     .pbInstructions,
+    .toggle-header-title,
     #special-browser-page,
     #disabled-site-message {
         color: #ddd;
+    }
+
+    .toggle-header {
+        background-color: #333;
+        border: 2px solid #333;
+    }
+    .toggle-header:hover .toggle-header-title {
+        color: #fff;
+    }
+
+    #firstparty-protections-container {
+        border-bottom: 1px solid #555;
     }
 
     /* TODO:
@@ -590,6 +612,11 @@ div.overlay.active {
     .clickerContainer {
         background-color: #3a3a3a;
      }
+
+    #instructions-firstparty-description {
+        background-color: #3a3a3a;
+        color: #ddd;
+    }
 
     .pbButton {
         background-color: #333;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -312,6 +312,11 @@ font-size: 16px;
 #instructions-firstparty-description {
     font-size: 14px;
     margin-top: -30px;
+    background-color: #E8E9EA;
+    color: #555555;
+    padding: 8px;
+    text-align: left;
+    font-size: 12px;
 }
 #instructions-no-trackers, #special-browser-page, #disabled-site-message, #instructions-many-trackers, #firstparty-protections-container {
     text-align: center;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -283,7 +283,7 @@ font-size: 16px;
 #options {
     margin-inline-end: 3px;
 }
-#pbInstructions, #special-browser-page, #disabled-site-message {
+#pbInstructions, #special-browser-page, #disabled-site-message, #firstparty-protections-container {
     color: #505050;
     font-size: 16px;
     margin: 0;
@@ -297,7 +297,18 @@ font-size: 16px;
 #pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a:hover {
     color: #ec9329
 }
-#instructions-no-trackers, #special-browser-page, #disabled-site-message {
+#firstparty-protections-container a {
+    text-decoration: underline;
+    color: black;
+    font-weight: bold;
+}
+#firstparty-protections-container a:hover {
+    color: #ec9329
+}
+#instructions-firstparty-description {
+    font-size: 14px;
+}
+#instructions-no-trackers, #special-browser-page, #disabled-site-message, #instructions-firstparty-protections {
     text-align: center;
     margin: 45px 0;
     padding: 0;
@@ -306,7 +317,7 @@ font-size: 16px;
     text-align: center;
     margin: 10px 0;
 }
-#instructions-many-trackers, #instructions-no-trackers, #no-third-parties {
+#instructions-many-trackers, #instructions-no-trackers, #no-third-parties, #instructions-firstparty-description {
     display: block;
 }
 #no-third-parties {
@@ -459,6 +470,9 @@ div.overlay.active {
 .tooltipster-sidetip .tooltipster-arrow-border {
     border: none;
 }
+/* #firstparty-protections-container {
+    display: none;
+} */
 
 @media screen and (max-width: 400px){
     .origin {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -291,6 +291,9 @@ font-size: 16px;
     padding-top: 10px;
     cursor: pointer;
 }
+#toggle-blocked-resources-container {
+    cursor: pointer;
+}
 .pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a {
     text-decoration: underline;
     color: black;
@@ -474,9 +477,9 @@ div.overlay.active {
 }
 #firstparty-protections-container {
     display: none;
-    border-top: 1px solid #707070;
+    border-top: 1px solid #d3d3d3;
+    margin: auto;
     padding: 0;
-    margin: 0;
 }
 #instructions-firstparty-protections {
     margin: 45px 0;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -294,18 +294,18 @@ body#main #blockedResourcesContainer {
 #options {
     margin-inline-end: 3px;
 }
-.pbInstructions, .toggle-header-title, #special-browser-page, #disabled-site-message {
+#pbInstructions, #special-browser-page, #disabled-site-message, .toggle-header-title {
     color: #505050;
     font-size: 16px;
     margin: 0;
 }
 /* body#main to avoid applying this to options page */
-body#main .pbInstructions a, #firstparty-protections-container a {
+body#main #pbInstructions a, #firstparty-protections-container a {
     text-decoration: underline;
     color: black;
     font-weight: bold;
 }
-body#main .pbInstructions a:hover, #firstparty-protections-container a:hover {
+body#main #pbInstructions a:hover, #firstparty-protections-container a:hover {
     color: #ec9329
 }
 #instructions-firstparty-description {
@@ -560,9 +560,9 @@ div.overlay.active {
 
     button,
     /* body#main to avoid applying this to options page */
-    body#main .pbInstructions a,
+    body#main #pbInstructions a,
     #firstparty-protections-container a,
-    .pbInstructions,
+    #pbInstructions,
     .toggle-header-title,
     #special-browser-page,
     #disabled-site-message {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -284,14 +284,13 @@ font-size: 16px;
 #options {
     margin-inline-end: 3px;
 }
-.pbInstructions, #special-browser-page, #disabled-site-message, #firstparty-protections-container {
+.pbInstructions, #special-browser-page, #disabled-site-message, #instructions-firstparty-protections {
     color: #505050;
     font-size: 16px;
     margin: 0;
     padding-top: 10px;
-    cursor: pointer;
 }
-#toggle-blocked-resources-container {
+#instructions-firstparty-protections, #toggle-blocked-resources-container, #instructions-many-trackers, #toggle-firstparty-info-section {
     cursor: pointer;
 }
 .pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -320,10 +320,8 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover {
     margin: 40px 0;
     padding: 0;
 }
-#instructions-many-trackers, #no-third-parties {
-    display: block;
-}
 #no-third-parties {
+    display: block;
     font-size: 12px;
 }
 
@@ -469,6 +467,7 @@ div.overlay.active {
 .tooltipster-sidetip .tooltipster-arrow-border {
     border: none;
 }
+
 #firstparty-protections-container {
     border-bottom: 1px solid #d3d3d3;
     margin: 10px 0;
@@ -514,6 +513,7 @@ div.overlay.active {
 .ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
     font-size: 18px;
 }
+
 @media screen and (max-width: 400px){
     .origin {
         max-width: 150px;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -284,18 +284,19 @@ font-size: 16px;
 #options {
     margin-inline-end: 3px;
 }
-#pbInstructions, #special-browser-page, #disabled-site-message, #firstparty-protections-container {
+.pbInstructions, #special-browser-page, #disabled-site-message, #firstparty-protections-container {
     color: #505050;
     font-size: 16px;
     margin: 0;
     padding-top: 10px;
+    cursor: pointer;
 }
-#pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a {
+.pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a {
     text-decoration: underline;
     color: black;
     font-weight: bold;
 }
-#pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a:hover {
+.pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a:hover {
     color: #ec9329
 }
 #firstparty-protections-container a {
@@ -310,7 +311,7 @@ font-size: 16px;
     font-size: 14px;
     margin-top: -30px;
 }
-#instructions-no-trackers, #special-browser-page, #disabled-site-message {
+#instructions-no-trackers, #special-browser-page, #disabled-site-message, #instructions-many-trackers, #firstparty-protections-container {
     text-align: center;
     margin: 45px 0;
     padding: 0;
@@ -476,7 +477,6 @@ div.overlay.active {
     border-top: 1px solid #707070;
     padding: 0;
     margin: 0;
-    text-align: left;
 }
 #instructions-firstparty-protections {
     margin: 45px 0;
@@ -541,8 +541,8 @@ div.overlay.active {
     }
 
     button,
-    #pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a,
-    #pbInstructions,
+    .pbInstructions :not(#options_domain_list_trackers):not(#options_domain_list_no_trackers) a,
+    .pbInstructions,
     #special-browser-page,
     #disabled-site-message {
         color: #ddd;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -171,6 +171,7 @@ font-size: 16px;
 
 #blockedResourcesContainer {
     min-height: 70px;
+    margin-top: 10px;
 }
 
 #intro-reminder-btn, #critical-error-link, #learning-prompt-btn {
@@ -307,14 +308,14 @@ font-size: 16px;
 }
 #instructions-firstparty-description {
     font-size: 14px;
+    margin-top: -30px;
 }
-#instructions-no-trackers, #special-browser-page, #disabled-site-message, #instructions-firstparty-protections {
+#instructions-no-trackers, #special-browser-page, #disabled-site-message {
     text-align: center;
     margin: 45px 0;
     padding: 0;
 }
 #instructions-many-trackers {
-    text-align: center;
     margin: 10px 0;
 }
 #instructions-many-trackers, #instructions-no-trackers, #no-third-parties, #instructions-firstparty-description {
@@ -470,10 +471,31 @@ div.overlay.active {
 .tooltipster-sidetip .tooltipster-arrow-border {
     border: none;
 }
-/* #firstparty-protections-container {
+#firstparty-protections-container {
     display: none;
-} */
-
+    border-top: 1px solid #707070;
+    padding: 0;
+    margin: 0;
+    text-align: left;
+}
+#instructions-firstparty-protections {
+    margin: 45px 0;
+    padding: 0;
+}
+#toggle-firstparty-info-section {
+    float: right;
+    margin-top: -65px;
+}
+#toggle-blocked-resources-container {
+    float: right;
+    margin-top: -30px;
+}
+.ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
+    font-size: 18px;
+}
+.ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
+    font-size: 18px;
+}
 @media screen and (max-width: 400px){
     .origin {
         max-width: 150px;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -495,9 +495,13 @@ div.overlay.active {
 }
 .ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
     font-size: 18px;
+    transition: 250ms;
 }
-.ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
-    font-size: 18px;
+.ui-icon.ui-icon-caret-d:hover {
+    transform: translateY(5px);
+}
+.ui-icon.ui-icon-caret-u:hover {
+    transform: translateY(-5px);
 }
 @media screen and (max-width: 400px){
     .origin {

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -133,6 +133,13 @@
   <div id="blockedResources"></div>
 </div>
 
+<div id="firstpartyProtectionsContainer">
+  <div id="instructions-firstparty-protections" class="i18n_popup_info_firstparty_protections popup_info"></div>
+  <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
+  <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>
+  <div id="instructions-firstparty-description" class="i18n_popup_info_firstparty_description"></div>
+</div>
+
 <div id="special-browser-page" style="display:none">
     <p><b><span class="i18n_popup_special_page_header"></span></b></p>
     <p><span class="i18n_popup_special_page_paragraph"></span></p>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -122,15 +122,15 @@
 </div>
 
 <div id="blockedResourcesContainer">
-  <p id="pbInstructions">
+  <p class="pbInstructions">
     <span id="instructions-many-trackers"></span>
     <span id="instructions-no-trackers" style="display:none">
       <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </span>
     <div id="toggle-blocked-resources-container">
-      <span id="expand-blocked-resources" class="ui-icon ui-icon-caret-d"></span>
-      <span id="collapse-blocked-resources" class="ui-icon ui-icon-caret-u"></span>
+      <span id="expand-blocked-resources" title="i18n_show_more_information" class="ui-icon ui-icon-caret-d tooltip"></span>
+      <span id="collapse-blocked-resources" title="i18n_show_more_information" class="ui-icon ui-icon-caret-u tooltip"></span>
     </div>
   </p>
   <div class="spacer"></div>
@@ -139,9 +139,9 @@
 
 <div id="firstparty-protections-container">
   <div id="instructions-firstparty-protections" class="i18n_popup_info_firstparty_protections popup_info"></div>
-    <div id="toggle-firstparty-info-section">
-      <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
-      <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>
+    <div id="toggle-firstparty-info-section" tabIndex="0">
+      <span id="expand-firstparty-popup" title="i18n_show_more_information" class="ui-icon ui-icon-caret-d tooltip"></span>
+      <span id="collapse-firstparty-popup" title="i18n_show_more_information" class="ui-icon ui-icon-caret-u tooltip"></span>
     </div>
   <div id="instructions-firstparty-description" class="i18n_popup_info_firstparty_description"></div>
 </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -128,6 +128,10 @@
       <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </span>
+    <div id="toggle-blocked-resources-container">
+      <span id="expand-blocked-resources" class="ui-icon ui-icon-caret-d"></span>
+      <span id="collapse-blocked-resources" class="ui-icon ui-icon-caret-u"></span>
+    </div>
   </p>
   <div class="spacer"></div>
   <div id="blockedResources"></div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -129,8 +129,8 @@
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </span>
     <div id="toggle-blocked-resources-container" tabIndex="0">
-      <span id="expand-blocked-resources" title="i18n_show_more_information" class="ui-icon ui-icon-caret-d tooltip"></span>
-      <span id="collapse-blocked-resources" title="i18n_show_more_information" class="ui-icon ui-icon-caret-u tooltip"></span>
+      <span id="expand-blocked-resources" class="ui-icon ui-icon-caret-d"></span>
+      <span id="collapse-blocked-resources" class="ui-icon ui-icon-caret-u"></span>
     </div>
   </p>
   <div class="spacer"></div>
@@ -140,8 +140,8 @@
 <div id="firstparty-protections-container">
   <div id="instructions-firstparty-protections" class="i18n_popup_info_firstparty_protections popup_info"></div>
     <div id="toggle-firstparty-info-section" tabIndex="0">
-      <span id="expand-firstparty-popup" title="i18n_show_more_information" class="ui-icon ui-icon-caret-d tooltip"></span>
-      <span id="collapse-firstparty-popup" title="i18n_show_more_information" class="ui-icon ui-icon-caret-u tooltip"></span>
+      <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
+      <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>
     </div>
   <div id="instructions-firstparty-description" class="i18n_popup_info_firstparty_description"></div>
 </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -135,7 +135,7 @@
 </div>
 
 <div id="blockedResourcesContainer">
-  <div class="pbInstructions">
+  <div id="pbInstructions">
     <button class="toggle-header" id="tracker-list-header" style="display:none">
       <span class="toggle-header-title" id="instructions-many-trackers"></span>
       <span class="toggle-header-icon">

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -128,7 +128,7 @@
       <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </span>
-    <div id="toggle-blocked-resources-container">
+    <div id="toggle-blocked-resources-container" tabIndex="0">
       <span id="expand-blocked-resources" title="i18n_show_more_information" class="ui-icon ui-icon-caret-d tooltip"></span>
       <span id="collapse-blocked-resources" title="i18n_show_more_information" class="ui-icon ui-icon-caret-u tooltip"></span>
     </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -121,29 +121,34 @@
   <div class='clear'></div>
 </div>
 
-<div id="blockedResourcesContainer">
-  <p class="pbInstructions">
-    <span id="instructions-many-trackers"></span>
-    <span id="instructions-no-trackers" style="display:none">
-      <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
-      <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
-    </span>
-    <div id="toggle-blocked-resources-container" tabIndex="0">
-      <span id="expand-blocked-resources" class="ui-icon ui-icon-caret-d"></span>
-      <span id="collapse-blocked-resources" class="ui-icon ui-icon-caret-u"></span>
+<div id="firstparty-protections-container" style="display:none">
+  <button class="toggle-header" id="firstparty-protections-header">
+    <div class="toggle-header-title" id="instructions-firstparty-protections">
+      <span class="i18n_popup_info_firstparty_protections popup_info"></span>
     </div>
-  </p>
-  <div class="spacer"></div>
-  <div id="blockedResources"></div>
+    <span class="toggle-header-icon">
+      <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d" style="display:none"></span>
+      <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u" style="display:none"></span>
+    </span>
+  </button>
+  <div id="instructions-firstparty-description" class="i18n_popup_info_firstparty_description" style="display:none"></div>
 </div>
 
-<div id="firstparty-protections-container">
-  <div id="instructions-firstparty-protections" class="i18n_popup_info_firstparty_protections popup_info"></div>
-    <div id="toggle-firstparty-info-section" tabIndex="0">
-      <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
-      <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>
+<div id="blockedResourcesContainer">
+  <div class="pbInstructions">
+    <button class="toggle-header" id="tracker-list-header" style="display:none">
+      <span class="toggle-header-title" id="instructions-many-trackers"></span>
+      <span class="toggle-header-icon">
+        <span id="expand-blocked-resources" class="ui-icon ui-icon-caret-d" style="display:none"></span>
+        <span id="collapse-blocked-resources" class="ui-icon ui-icon-caret-u" style="display:none"></span>
+      </span>
+    </button>
+    <div class="basic-header" id="instructions-no-trackers" style="display:none">
+      <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
+      <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </div>
-  <div id="instructions-firstparty-description" class="i18n_popup_info_firstparty_description"></div>
+  </div>
+  <div id="blockedResources"></div>
 </div>
 
 <div id="special-browser-page" style="display:none">

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -123,7 +123,7 @@
 
 <div id="firstparty-protections-container" style="display:none">
   <button class="toggle-header" id="firstparty-protections-header">
-    <div class="toggle-header-title" id="instructions-firstparty-protections">
+    <div class="toggle-header-title">
       <span class="i18n_popup_info_firstparty_protections popup_info"></span>
     </div>
     <span class="toggle-header-icon">

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -139,8 +139,10 @@
 
 <div id="firstparty-protections-container">
   <div id="instructions-firstparty-protections" class="i18n_popup_info_firstparty_protections popup_info"></div>
-  <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
-  <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>
+    <div id="toggle-firstparty-info-section">
+      <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
+      <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>
+    </div>
   <div id="instructions-firstparty-description" class="i18n_popup_info_firstparty_description"></div>
 </div>
 

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -133,7 +133,7 @@
   <div id="blockedResources"></div>
 </div>
 
-<div id="firstpartyProtectionsContainer">
+<div id="firstparty-protections-container">
   <div id="instructions-firstparty-protections" class="i18n_popup_info_firstparty_protections popup_info"></div>
   <span id="expand-firstparty-popup" class="ui-icon ui-icon-caret-d"></span>
   <span id="collapse-firstparty-popup" class="ui-icon ui-icon-caret-u"></span>

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -573,7 +573,7 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 QUnit.test("firstPartyProtectionsEnabled", assert => {
   assert.equal(
-    utils.firstPartyProtectionsEnabled("google.com", badger.firstPartiesList),
+    utils.firstPartyProtectionsEnabled("www.google.com", badger.firstPartiesList),
     true,
     "properly identifies a url pattern from our firstparties list"
   );

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -571,4 +571,19 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 });
 
+QUnit.test("firstPartyProtectionsEnabled", assert => {
+  assert.equal(
+    utils.firstPartyProtectionsEnabled("google.com"),
+    true,
+    "properly identifies a url pattern from our firstparties list"
+  );
+
+  assert.equal(
+    utils.firstPartyProtectionsEnabled("foobar.com"),
+    false,
+    "determines that a url not in the firstparties list is not protected by a firstparty script"
+  );
+
+});
+
 })();

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -573,13 +573,13 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 QUnit.test("firstPartyProtectionsEnabled", assert => {
   assert.equal(
-    utils.firstPartyProtectionsEnabled("google.com"),
+    utils.firstPartyProtectionsEnabled("google.com", badger.firstPartiesList),
     true,
     "properly identifies a url pattern from our firstparties list"
   );
 
   assert.equal(
-    utils.firstPartyProtectionsEnabled("foobar.com"),
+    utils.firstPartyProtectionsEnabled("foobar.com", badger.firstPartiesList),
     false,
     "determines that a url not in the firstparties list is not protected by a firstparty script"
   );

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -573,19 +573,19 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 QUnit.test("firstPartyProtectionsEnabled", assert => {
   assert.equal(
-    utils.firstPartyProtectionsEnabled("www.google.com", badger.firstPartiesList),
+    utils.firstPartyProtectionsEnabled("www.google.com", badger),
     true,
     "properly identifies a url pattern from our firstparties list"
   );
 
   assert.equal(
-    utils.firstPartyProtectionsEnabled("foobar.com", badger.firstPartiesList),
+    utils.firstPartyProtectionsEnabled("foobar.com", badger),
     false,
     "determines that a url not in the firstparties list is not protected by a firstparty script"
   );
 
   assert.equal(
-    utils.firstPartyProtectionsEnabled("www.messenger.com", badger.firstPartiesList),
+    utils.firstPartyProtectionsEnabled("www.messenger.com", badger),
     true,
     "accurately IDs a site with firstparty protections covered by a wildcard url match"
   );

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -573,19 +573,19 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 QUnit.test("firstPartyProtectionsEnabled", assert => {
   assert.equal(
-    utils.firstPartyProtectionsEnabled("www.google.com", badger),
+    utils.firstPartyProtectionsEnabled("www.google.com"),
     true,
     "properly identifies a url pattern from our firstparties list"
   );
 
   assert.equal(
-    utils.firstPartyProtectionsEnabled("foobar.com", badger),
+    utils.firstPartyProtectionsEnabled("foobar.com"),
     false,
     "determines that a url not in the firstparties list is not protected by a firstparty script"
   );
 
   assert.equal(
-    utils.firstPartyProtectionsEnabled("www.messenger.com", badger),
+    utils.firstPartyProtectionsEnabled("www.messenger.com"),
     true,
     "accurately IDs a site with firstparty protections covered by a wildcard url match"
   );

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -584,6 +584,12 @@ QUnit.test("firstPartyProtectionsEnabled", assert => {
     "determines that a url not in the firstparties list is not protected by a firstparty script"
   );
 
+  assert.equal(
+    utils.firstPartyProtectionsEnabled("www.messenger.com", badger.firstPartiesList),
+    true,
+    "accurately IDs a site with firstparty protections covered by a wildcard url match"
+  );
+
 });
 
 })();

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -572,24 +572,40 @@ QUnit.test("estimateMaxEntropy", assert => {
 });
 
 QUnit.test("firstPartyProtectionsEnabled", assert => {
-  assert.equal(
+  assert.ok(
     utils.firstPartyProtectionsEnabled("www.google.com"),
-    true,
     "properly identifies a url pattern from our firstparties list"
   );
 
-  assert.equal(
+  assert.ok(
+    utils.firstPartyProtectionsEnabled("www.google.co.uk"),
+    "properly identifies a url pattern from our firstparties list"
+  );
+
+  assert.notOk(
     utils.firstPartyProtectionsEnabled("foobar.com"),
-    false,
     "determines that a url not in the firstparties list is not protected by a firstparty script"
   );
 
-  assert.equal(
+  assert.ok(
     utils.firstPartyProtectionsEnabled("www.messenger.com"),
-    true,
     "accurately IDs a site with firstparty protections covered by a wildcard url match"
   );
 
+  assert.ok(
+    utils.firstPartyProtectionsEnabled("www.facebook.com"),
+    "wildcard pattern matching"
+  );
+
+  assert.ok(
+    utils.firstPartyProtectionsEnabled("m.facebook.com"),
+    "wildcard pattern matching"
+  );
+
+  assert.notOk(
+    utils.firstPartyProtectionsEnabled("acebook.com"),
+    "wildcard pattern matching"
+  );
 });
 
 })();

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -230,6 +230,9 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.open_popup(origins={DOMAIN:"cookieblock"})
 
+        # expand the blocked resources container so that sliders are visible
+        self.driver.find_element_by_id("expand-blocked-resources").click()
+
         # set the domain to user control
         # click input with JavaScript to avoid "Element ... is not clickable" /
         # "Other element would receive the click" Selenium limitation

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -138,7 +138,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.open_popup()
 
         # Get all possible tracker links (none, one, multiple)
-        trackers_links = self.driver.find_elements_by_css_selector("#pbInstructions a")
+        trackers_links = self.driver.find_elements_by_css_selector(".pbInstructions a")
         if not trackers_links:
             self.fail("Unable to find trackers link on popup")
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -230,9 +230,6 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.open_popup(origins={DOMAIN:"cookieblock"})
 
-        # expand the blocked resources container so that sliders are visible
-        self.driver.find_element_by_id("expand-blocked-resources").click()
-
         # set the domain to user control
         # click input with JavaScript to avoid "Element ... is not clickable" /
         # "Other element would receive the click" Selenium limitation

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -137,8 +137,8 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         self.open_popup()
 
-        # Get all possible tracker links (none, one, multiple)
-        trackers_links = self.driver.find_elements_by_css_selector(".pbInstructions a")
+        # Get all possible tracker links ("no" and "multiple" messages)
+        trackers_links = self.driver.find_elements_by_css_selector("#pbInstructions a")
         if not trackers_links:
             self.fail("Unable to find trackers link on popup")
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -62,7 +62,7 @@ class PopupTest(pbtest.PBSeleniumTest):
             "    type: 'getPopupData',"
             "    tabId: tabs[0].id"
             "  }, (response) => {"
-            "    response.seenComic = !show_nag;"
+            "    response.settings.seenComic = !show_nag;"
             "    response.origins = origins;"
             "    setPopupData(response);"
             "    refreshPopup();"


### PR DESCRIPTION
Fixes #2482.

Should help with #2021, and with the problem of users not noticing the "Disable for this site" button.

adds the following sections to the popup:
* firstparty notifications for when the current site has any unique firstparty protections protections scripts happening on it
* blocked resources container hidden by default behind the current ’n potential trackers blocked’ message

each of the sections have the option to drop down expand into a more detailed informational or control panel for each: 
* The firstparty section just drops down into a message that describes the type of protection that is taking place, and links to reading more about link tracking and how privacy badger protects against it. 
* The blocked resources hidden under the ’n potential trackers blocked’ message is the same blocked resources container the the current popup shows, with the sliders for each.


_EDIT:_ Widget section forthcoming in #2758