### PR TITLE
Add option to disable FLoC

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -151,6 +151,10 @@
         "message": "Show domains that don't appear to be tracking you",
         "description": "Checkbox label on the general settings page. Should match wording used in the 'non_tracker' message."
     },
+    "options_disable_floc": {
+        "message": "Disable Google's FLoC and stop sharing your FLoC ID on sites where Privacy Badger is enabled.",
+        "description": "Checkbox label on the general settings page."
+    },
     "report_button": {
         "message": "Submit Error",
         "description": ""

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -152,7 +152,7 @@
         "description": "Checkbox label on the general settings page. Should match wording used in the 'non_tracker' message."
     },
     "options_disable_floc": {
-        "message": "Disable Google's FLoC and stop sharing your FLoC ID on sites where Privacy Badger is enabled.",
+        "message": "Disable Google's Federated Learnnig of Cohorts (FLoC)",
         "description": "Checkbox label on the general settings page."
     },
     "report_button": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -151,10 +151,6 @@
         "message": "Show domains that don't appear to be tracking you",
         "description": "Checkbox label on the general settings page. Should match wording used in the 'non_tracker' message."
     },
-    "options_disable_floc": {
-        "message": "Disable Google's Federated Learnnig of Cohorts (FLoC)",
-        "description": "Checkbox label on the general settings page."
-    },
     "report_button": {
         "message": "Submit Error",
         "description": ""
@@ -416,6 +412,10 @@
     "options_disable_network_prediction": {
         "message": "Disable prefetching",
         "description": "Checkbox label found on the general settings page"
+    },
+    "options_disable_floc": {
+        "message": "Disable Google's Federated Learning of Cohorts (FLoC)",
+        "description": "(Chrome only) Checkbox label on the general settings page."
     },
     "options_domain_filter_user": {
         "message": "user-controlled",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1046,7 +1046,7 @@ Badger.prototype = {
   isCheckingDNTPolicyEnabled: function() {
     return this.getSettings().getItem("checkForDNTPolicy");
   },
-  
+
   isFlocOverwriteEnabled: function() {
     // only try to disable floc if it's enabled
     return (document.interestCohort && this.getSettings().getItem("disableFLoC"));

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -804,7 +804,7 @@ Badger.prototype = {
   defaultSettings: {
     checkForDNTPolicy: true,
     disabledSites: [],
-	disableFLoC: true,
+    disableFLoC: true,
     disableGoogleNavErrorService: true,
     disableHyperlinkAuditing: true,
     disableNetworkPrediction: true,

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1048,8 +1048,7 @@ Badger.prototype = {
   },
 
   isFlocOverwriteEnabled: function() {
-    // only try to disable floc if it's enabled
-    return (document.interestCohort && this.getSettings().getItem("disableFLoC"));
+    return this.getSettings().getItem("disableFLoC");
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -804,6 +804,7 @@ Badger.prototype = {
   defaultSettings: {
     checkForDNTPolicy: true,
     disabledSites: [],
+	disableFLoC: true,
     disableGoogleNavErrorService: true,
     disableHyperlinkAuditing: true,
     disableNetworkPrediction: true,
@@ -1044,6 +1045,10 @@ Badger.prototype = {
 
   isCheckingDNTPolicyEnabled: function() {
     return this.getSettings().getItem("checkForDNTPolicy");
+  },
+  
+  isFlocOverwriteEnabled: function() {
+    return this.getSettings().getItem("disableFLoC");
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1048,7 +1048,8 @@ Badger.prototype = {
   },
   
   isFlocOverwriteEnabled: function() {
-    return this.getSettings().getItem("disableFLoC");
+    // only try to disable floc if it's enabled
+    return (document.interestCohort && this.getSettings().getItem("disableFLoC"));
   },
 
   /**

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -804,7 +804,7 @@ Badger.prototype = {
   defaultSettings: {
     checkForDNTPolicy: true,
     disabledSites: [],
-    disableFLoC: true,
+    disableFloc: true,
     disableGoogleNavErrorService: true,
     disableHyperlinkAuditing: true,
     disableNetworkPrediction: true,
@@ -1048,7 +1048,10 @@ Badger.prototype = {
   },
 
   isFlocOverwriteEnabled: function() {
-    return this.getSettings().getItem("disableFLoC");
+    if (document.interestCohort) {
+      return this.getSettings().getItem("disableFloc");
+    }
+    return false;
   },
 
   /**

--- a/src/js/contentscripts/floc.js
+++ b/src/js/contentscripts/floc.js
@@ -15,18 +15,6 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function getFlocPageScript() {
-  // code below is not a content script: no chrome.* APIs /////////////////////
-
-  // return a string
-  return "(" + function (DOCUMENT) {
-    delete DOCUMENT.prototype.interestCohort;
-  // save locally to keep from getting overwritten by site code
-  } + "(Document));";
-
-  // code above is not a content script: no chrome.* APIs /////////////////////
-}
-
 // END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
 
 (function () {
@@ -42,10 +30,13 @@ if (document instanceof HTMLDocument === false && (
 
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
-  type: "checkFLoC"
+  type: "checkFloc"
 }, function (enabled) {
   if (enabled) {
-    window.injectScript(getFlocPageScript());
+    window.injectScript("(" +
+      function () { delete Document.prototype.interestCohort; }
+      + "());"
+    );
   }
 });
 

--- a/src/js/contentscripts/floc.js
+++ b/src/js/contentscripts/floc.js
@@ -20,7 +20,7 @@ function getPageScript() {
 
   // return a string
   return "(" + function (DOCUMENT) {
-	delete DOCUMENT.prototype.interestCohort;
+    delete DOCUMENT.prototype.interestCohort;
   // save locally to keep from getting overwritten by site code
   } + "(Document));";
 

--- a/src/js/contentscripts/floc.js
+++ b/src/js/contentscripts/floc.js
@@ -15,7 +15,7 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function getPageScript() {
+function getFlocPageScript() {
   // code below is not a content script: no chrome.* APIs /////////////////////
 
   // return a string
@@ -45,7 +45,7 @@ chrome.runtime.sendMessage({
   type: "checkFLoC"
 }, function (enabled) {
   if (enabled) {
-    window.injectScript(getPageScript());
+    window.injectScript(getFlocPageScript());
   }
 });
 

--- a/src/js/contentscripts/floc.js
+++ b/src/js/contentscripts/floc.js
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Privacy Badger <https://privacybadger.org/>
+ * Copyright (C) 2021 Electronic Frontier Foundation
+ *
+ * Privacy Badger is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * Privacy Badger is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function getPageScript() {
+  // code below is not a content script: no chrome.* APIs /////////////////////
+
+  // return a string
+  return "(" + function (DOCUMENT) {
+	delete DOCUMENT.prototype.interestCohort;
+  // save locally to keep from getting overwritten by site code
+  } + "(Document));";
+
+  // code above is not a content script: no chrome.* APIs /////////////////////
+}
+
+// END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
+
+(function () {
+
+// don't inject into non-HTML documents (such as XML documents)
+// but do inject into XHTML documents
+if (document instanceof HTMLDocument === false && (
+  document instanceof XMLDocument === false ||
+  document.createElement('div') instanceof HTMLDivElement === false
+)) {
+  return;
+}
+
+// TODO race condition; fix waiting on https://crbug.com/478183
+chrome.runtime.sendMessage({
+  type: "checkFLoC"
+}, function (enabled) {
+  if (enabled) {
+    window.injectScript(getPageScript());
+  }
+});
+
+}());

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -170,6 +170,14 @@ function loadOptions() {
       });
   }
 
+  // only show the floc override if browser supports it
+  if (document.interestCohort) {
+    $("#disable-floc").show();
+    $("#disable-floc-checkbox")
+      .prop("checked", OPTIONS_DATA.settings.disableFLoC)
+      .on("click", function () { updateDisableFloc() });
+  }
+
   if (OPTIONS_DATA.webRTCAvailable) {
     $("#webRTCToggle").show();
     $("#toggle_webrtc_mode")
@@ -536,6 +544,17 @@ function updateCheckingDNTPolicy() {
     type: "updateSettings",
     data: {
       checkForDNTPolicy: enabled
+    }
+  });
+}
+
+function updateDisableFloc() {
+  const enabled = $("#disable-floc-checkbox").prop("checked");
+
+  chrome.runtime.sendMessage({
+    type: "updateSettings",
+    data: {
+      disableFLoC: enabled
     }
   });
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -174,7 +174,7 @@ function loadOptions() {
   if (document.interestCohort) {
     $("#disable-floc").show();
     $("#disable-floc-checkbox")
-      .prop("checked", OPTIONS_DATA.settings.disableFLoC)
+      .prop("checked", OPTIONS_DATA.settings.disableFloc)
       .on("click", function () { updateDisableFloc(); });
   }
 
@@ -554,7 +554,7 @@ function updateDisableFloc() {
   chrome.runtime.sendMessage({
     type: "updateSettings",
     data: {
-      disableFLoC: enabled
+      disableFloc: enabled
     }
   });
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -175,7 +175,7 @@ function loadOptions() {
     $("#disable-floc").show();
     $("#disable-floc-checkbox")
       .prop("checked", OPTIONS_DATA.settings.disableFLoC)
-      .on("click", function () { updateDisableFloc() });
+      .on("click", function () { updateDisableFloc(); });
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -170,12 +170,19 @@ function loadOptions() {
       });
   }
 
-  // only show the floc override if browser supports it
+  // only show the FLoC override if browser supports it
   if (document.interestCohort) {
     $("#disable-floc").show();
     $("#disable-floc-checkbox")
       .prop("checked", OPTIONS_DATA.settings.disableFloc)
-      .on("click", function () { updateDisableFloc(); });
+      .on("click", function () {
+        const disableFloc = $("#disable-floc-checkbox").prop("checked");
+
+        chrome.runtime.sendMessage({
+          type: "updateSettings",
+          data: { disableFloc }
+        });
+      });
   }
 
   if (OPTIONS_DATA.webRTCAvailable) {
@@ -544,17 +551,6 @@ function updateCheckingDNTPolicy() {
     type: "updateSettings",
     data: {
       checkForDNTPolicy: enabled
-    }
-  });
-}
-
-function updateDisableFloc() {
-  const enabled = $("#disable-floc-checkbox").prop("checked");
-
-  chrome.runtime.sendMessage({
-    type: "updateSettings",
-    data: {
-      disableFloc: enabled
     }
   });
 }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -263,10 +263,13 @@ function onHeadersReceived(details) {
   let tab_host = getHostForTab(tab_id);
   let response_host = window.extractHostFromURL(url);
 
-  if (badger.isFlocOverwriteEnabled() && details.type === 'main_frame') {
-    let newHeaders = details.responseHeaders;
-    newHeaders.push({name: 'permissions-policy', value: 'interest-cohort=()'});
-    return {responseHeaders: newHeaders};
+  if (details.type == 'main_frame' && badger.isFlocOverwriteEnabled()) {
+    let responseHeaders = details.responseHeaders || [];
+    responseHeaders.push({
+      name: 'permissions-policy',
+      value: 'interest-cohort=()'
+    });
+    return { responseHeaders };
   }
 
   if (!utils.isThirdPartyDomain(response_host, tab_host)) {
@@ -1317,7 +1320,8 @@ function dispatcher(request, sender, sendResponse) {
   }
 
   case "checkFloc": {
-    // called from contentscripts/floc.js to check if we should disable document.interestCohort
+    // called from contentscripts/floc.js
+    // to check if we should disable document.interestCohort
     sendResponse(badger.isFlocOverwriteEnabled());
     break;
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -263,13 +263,13 @@ function onHeadersReceived(details) {
   let tab_host = getHostForTab(tab_id);
   let response_host = window.extractHostFromURL(url);
 
-  if (!badger.isPrivacyBadgerEnabled(tab_host)) {
-    return {};
-  }
-
   let newHeaders = details.responseHeaders;
   if (badger.isFlocOverwriteEnabled() && (details.type === 'main_frame' || details.type === 'sub_frame')) {
     newHeaders.push({name: 'permissions-policy', value: 'interest-cohort=()'})
+  }
+
+  if (!badger.isPrivacyBadgerEnabled(tab_host)) {
+    return {responseHeaders: newHeaders};
   }
 
   if (!utils.isThirdPartyDomain(response_host, tab_host)) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -847,6 +847,7 @@ function dispatcher(request, sender, sendResponse) {
     const KNOWN_CONTENT_SCRIPT_MESSAGES = [
       "allowWidgetOnSite",
       "checkDNT",
+      "checkFLoC",
       "checkEnabled",
       "checkLocation",
       "checkWidgetReplacementEnabled",
@@ -1302,6 +1303,17 @@ function dispatcher(request, sender, sendResponse) {
     // called from contentscripts/dnt.js to check if we should enable it
     sendResponse(
       badger.isDNTSignalEnabled()
+      && badger.isPrivacyBadgerEnabled(
+        window.extractHostFromURL(sender.tab.url)
+      )
+    );
+    break;
+  }
+  
+  case "checkFLoC": {
+    // called from contentscripts/floc.js to check if we should disable document.interestCohort
+    sendResponse(
+      badger.isFlocOverwriteEnabled()
       && badger.isPrivacyBadgerEnabled(
         window.extractHostFromURL(sender.tab.url)
       )

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1309,7 +1309,7 @@ function dispatcher(request, sender, sendResponse) {
     );
     break;
   }
-  
+
   case "checkFLoC": {
     // called from contentscripts/floc.js to check if we should disable document.interestCohort
     sendResponse(

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -467,7 +467,8 @@
         "js/contentscripts/clobbercookie.js",
         "js/contentscripts/clobberlocalstorage.js",
         "js/contentscripts/dnt.js",
-        "js/contentscripts/fingerprinting.js"
+        "js/contentscripts/fingerprinting.js",
+        "js/contentscripts/floc.js"
       ],
       "matches": [
         "<all_urls>"

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -217,6 +217,15 @@
           </span>
         </label>
       </div>
+      <div class="checkbox" id="disable-floc" style="display:none">
+        <label>
+          <input type="checkbox" id="disable-floc-checkbox">
+          <span>
+            <span class="i18n_options_disable_floc"></span>
+            <a href="https://www.google.com/chrome/privacy/#how-chrome-handles-your-information" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+          </span>
+        </label>
+      </div>
 
       <h4 class="i18n_options_advanced_settings"></h4>
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -222,7 +222,7 @@
           <input type="checkbox" id="disable-floc-checkbox">
           <span>
             <span class="i18n_options_disable_floc"></span>
-            <a href="https://www.google.com/chrome/privacy/#how-chrome-handles-your-information" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+            <a href="https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
           </span>
         </label>
       </div>


### PR DESCRIPTION
Fixes #2760.

Add a new checkbox to the options page, checked by default, that will disable FLoC from all pages where Privacy Badger is enabled.

Based on the DDG pull request here: https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/591/files

How to test:

1. Run chrome from the command line [with the following flags](https://web.dev/floc/?s=03#as-a-web-developer-how-can-i-try-out-floc) (do NOT install privacy badger yet):

` --enable-blink-features=InterestCohortAPI --enable-features="FederatedLearningOfCohorts:update_interval/10s/minimum_history_domain_size_required/1,FlocIdSortingLshBasedComputation,InterestCohortFeaturePolicy"`

(this will recompute your FLoC every 10 seconds, and will work with a minimum history length of 1 domain)

2. Visit at least one website that serves ads and doesn't opt out of FLoC (this should be most websites)
3. Verify that FLoC is enabled -- open up dev tools and run the following command: `document.interestCohort().then(function (i) {console.log(i)});`. This should give something like the following output:

`{id: "1764", version: "chrome.1.1"}`

Also: https://floc.glitch.me/ and https://amifloced.org/

4. Install the test version of Privacy Badger. 
5. Verify that the checkbox shows up on the options page (it should be checked by default)
6. Open up dev tools on another website. Verify that `document.interestCohort` is undefined and that requests for iframes on the page have the `permissions-policy: interest-cohort=()` response header.
7. Disable Privacy Badger on that website. Reload the site and verify that `document.interestCohort` is defined.
8. Re-enable privacy badger on the website, then go back to the options page and un-check the "disable FLoC" checkbox. Reload the website, then verify that `document.interestCohort` is defined.

Other things we could do:
- Currently the check box only shows up if document.interestCohort is defined on the extension's background page. This works for now; however, it's possible that Chrome could change what access extensions have to the Floc API in the future. It may make sense to check the user-agent string instead.
- (down the road) randomize FLoC ID instead of blocking it, so that the fact that it's blocked doesn't become a fingerprinting signal.