### PR TITLE
Remove Cloudflare __cfduid cookie configs

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -11,9 +11,6 @@ The Privacy API lets extensions modify browser-wide privacy settings. Privacy Ba
 
 In addition, Privacy Badger allows users to set a stricter WebRTC IP handling policy in order to prevent leaking local network address information.
 
-## Cookies
-Privacy Badger needs access to the cookies API in order to detect and correct a common error where Cloudflare domains are identified as trackers and blocked.
-
 ## Storage
 The storage API lets extensions store information that persists after the browser is closed. Privacy Badger uses it to save user settings and information it has learned about trackers.
 

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -652,9 +652,9 @@ function hasCookieTracking(details, origin) {
         continue;
       }
 
-      // ignore CloudFlare
+      // ignore Cloudflare
       // https://support.cloudflare.com/hc/en-us/articles/200170156-Understanding-the-Cloudflare-Cookies
-      if (name == "__cfduid" || name == "__cf_bm") {
+      if (name == "__cf_bm") {
         continue;
       }
 

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -266,52 +266,7 @@ exports.Migrations= {
     badger.mergeUserData(data, true);
   },
 
-  forgetCloudflare: function (badger) {
-    let config = {
-      name: '__cfduid'
-    };
-    if (badger.firstPartyDomainPotentiallyRequired) {
-      config.firstPartyDomain = null;
-    }
-
-    chrome.cookies.getAll(config, function (cookies) {
-      console.log("Forgetting Cloudflare domains ...");
-
-      let actionMap = badger.storage.getStore("action_map"),
-        actionClones = actionMap.getItemClones(),
-        snitchMap = badger.storage.getStore("snitch_map"),
-        snitchClones = snitchMap.getItemClones(),
-        correctedSites = {},
-        // assume the tracking domains seen on these sites are all Cloudflare
-        cfduidFirstParties = new Set();
-
-      cookies.forEach(function (cookie) {
-        // get the base domain (also removes the leading dot)
-        cfduidFirstParties.add(window.getBaseDomain(cookie.domain));
-      });
-
-      for (let domain in snitchClones) {
-        let newSnitches = snitchClones[domain].filter(
-          item => !cfduidFirstParties.has(item));
-
-        if (newSnitches.length) {
-          correctedSites[domain] = newSnitches;
-        }
-      }
-
-      // clear existing maps and then use mergeUserData to rebuild them
-      actionMap.updateObject({});
-      snitchMap.updateObject({});
-
-      const data = {
-        snitch_map: correctedSites,
-        action_map: actionClones
-      };
-
-      // pass in boolean 2nd parameter to flag that it's run in a migration, preventing infinite loop
-      badger.mergeUserData(data, true);
-    });
-  },
+  forgetCloudflare: noop,
 
   // https://github.com/EFForg/privacybadger/pull/2245#issuecomment-545545717
   forgetConsensu: (badger) => {

--- a/src/tests/tests/heuristic.js
+++ b/src/tests/tests/heuristic.js
@@ -146,19 +146,19 @@ QUnit.test("Cookie attributes shouldn't add to entropy", (assert) => {
   }
 });
 
-QUnit.test("CloudFlare cookies should get ignored", (assert) => {
+QUnit.test("Cloudflare cookies should get ignored", (assert) => {
   let CLOUDFLARE_COOKIES = [
-    '__cfduid=d3c728f97e01b1ab6969828f24b42ab111493693758',
-    '__cfduid=d9758e8613dd4acbba3248dde15e74f8d1493774432; expires=Thu, 03-May-18 01:20:32 GMT; path=/; domain=.medium.com; HttpOnly',
-    '__cfduid=de8a1734f91060dba20e2833705018b911493771353; expires=Thu, 03-May-18 02:25:53 GMT; path=/; domain=.fightforthefuture.org; HttpOnly',
-    '__cfduid=d712bcfe8e20469cc4b9129a4ab89b7501576598707; expires=Thu, 16-Jan-20 16:05:07 GMT; path=/; domain=.githack.com; HttpOnly; SameSite=Lax',
+    '__cf_bm=41291dab3ea0acac77440ce5179210efc952648e-1620759670-1800-Aai2i10uB7h69qQam38pgAnnI3AZjZaDKW6gctNbD54bmvINWrAa5PlZJP08vfwnznDXKj89Dv+KAACkN2jj/kG/U5wE7cuCdPt+aFsQpRS2',
+    '__cf_bm=aaf43ab6670e26b12c22d578ece2f2fb13f8f16a-1620759670-1800-ARWywN+AW1wPUXy0o5WE0I11Wr84t0AwEiiI3A4/6DAaLj89DPXyLTfqr8Tu0Yof93032kduEoWnqLyRO8bATfFHAh7ze/hn/HbNyaTU+fvF; expires=Thu, 11-May-21 20:41:10 GMT; path=/; domain=.medium.com; HttpOnly',
+    '__cf_bm=7b3426417a79710cae6510def4e67bababf351db-1631527211-1800-Ae1jafJ7L1dzUj+vT3WIvmxqU+bb9mUyAYGy2L5p8gXVFV2s7I5nPrk+Ja7N6OZEoDdrmax+szcLUsFy01jc758eGVUvVSqzTSvYhanpHFfI; expires=Thu, 13-Sep-21 11:30:11 GMT; path=/; domain=.fightforthefuture.org; HttpOnly; Secure',
+    '__cf_bm=0614c3dee2253c9d32da8b43147adec4834b250e-1648770070-1800-AcXvXDfb4xwdDwz/mOdGKjAC0b3A+TnGWgY2ladNaW+TGrAdgp6s0XIXeLorlA4DcRTf5PLFprDYkcQ1BCv8u3dYCWAf3l3C6ELOHu9pKVQi; expires=Thu, 01-Apr-22 01:11:10 GMT; path=/; domain=.githack.com; HttpOnly; Secure; SameSite=None',
   ];
 
   let details = JSON.parse(JSON.stringify(chromeDetails));
   for (let i = 0; i < CLOUDFLARE_COOKIES.length; i++) {
     details.requestHeaders[CHROME_COOKIE_INDEX].value = CLOUDFLARE_COOKIES[i];
     assert.notOk(hb.hasCookieTracking(details),
-      "CloudFlare cookie test #" + i);
+      "Cloudflare cookie test #" + i);
   }
 });
 


### PR DESCRIPTION
This cookie is no longer set for any requests proxied via Cloudflare and
thus the configs that were added for it can be removed.

Further context from Cloudflare's blog:
https://blog.cloudflare.com/deprecating-cfduid-cookie/

The last `__cfduid` cookies will expire on June 10th.
