### PR TITLE
Remove domain list acknowledgement

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -321,10 +321,6 @@
         "message": "partially-blocked",
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
-    "show_tracking_domains_acknowledgement": {
-        "message": "I understand; please show me the tracking domains list anyway",
-        "description": "Acknowledgement shown next to the checkbox required to reveal the tracking domains list on the options page."
-    },
     "firstRun_title": {
         "message": "Thank you for installing Privacy Badger!",
         "description": ""
@@ -380,10 +376,6 @@
     "intro_donate_heading": {
         "message": "Privacy is a team sport!",
         "description": "Part of the 'donate' section on the intro page."
-    },
-    "show_tracking_domains_message": {
-        "message": "You shouldn't need to modify anything here.",
-        "description": "Shown above the acknowledgement checkbox required to reveal the tracking domains list on the options page. This is the second paragraph; the first paragraph is the message under the \"intro_not_an_adblocker_paragraph\" key."
     },
     "options_domain_filter_all": {
         "message": "all",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -818,7 +818,6 @@ Badger.prototype = {
     showExpandedTrackingSection: false,
     showIntroPage: true,
     showNonTrackingDomains: false,
-    showTrackingDomains: false,
     socialWidgetReplacementEnabled: true,
     widgetReplacementExceptions: [],
     widgetSiteAllowlist: {},
@@ -866,6 +865,13 @@ Badger.prototype = {
 
     if (!privateStore.hasItem("showLearningPrompt")) {
       privateStore.setItem("showLearningPrompt", false);
+    }
+
+    if (self.isUpdate) {
+      // remove obsolete settings
+      if (settings.hasItem("showTrackingDomains")) {
+        settings.deleteItem("showTrackingDomains");
+      }
     }
   },
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -54,23 +54,6 @@ function loadOptions() {
   $('#removeAllData').on("click", removeAllData);
   $('#widget-site-exceptions-remove-button').on("click", removeWidgetSiteExceptions);
 
-  if (OPTIONS_DATA.settings.showTrackingDomains) {
-    $('#tracking-domains-overlay').hide();
-  } else {
-    $('#blockedResourcesContainer').hide();
-
-    $('#show-tracking-domains-checkbox').on("click", () => {
-      $('#tracking-domains-overlay').hide();
-      $('#blockedResourcesContainer').show();
-      chrome.runtime.sendMessage({
-        type: "updateSettings",
-        data: {
-          showTrackingDomains: true
-        }
-      });
-    });
-  }
-
   // Set up input for searching through tracking domains.
   $("#trackingDomainSearch").on("input", filterTrackingDomains);
   $("#tracking-domains-type-filter").on("change", filterTrackingDomains);

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -78,17 +78,6 @@
   </ul>
 
   <div id="tab-tracking-domains">
-    <div id="tracking-domains-overlay">
-        <p class="i18n_description"></p>
-        <p class="i18n_intro_not_an_adblocker_paragraph"></p>
-        <p class="i18n_show_tracking_domains_message"></p>
-        <p>
-        <label>
-          <input type="checkbox" id="show-tracking-domains-checkbox">
-          <span class="i18n_show_tracking_domains_acknowledgement"></span>
-        </label>
-        </p>
-    </div>
     <div id="blockedResourcesContainer">
       <p id="pbInstructions">
         <span id="options_domain_list_trackers"></span>

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -7,8 +7,6 @@ import unittest
 import pbtest
 
 from selenium.common.exceptions import (
-    ElementNotInteractableException,
-    ElementNotVisibleException,
     NoSuchElementException,
     TimeoutException,
 )
@@ -49,11 +47,6 @@ class OptionsTest(pbtest.PBSeleniumTest):
 
     def select_domain_list_tab(self):
         self.find_el_by_css('a[href="#tab-tracking-domains"]').click()
-        try:
-            self.driver.find_element_by_id('show-tracking-domains-checkbox').click()
-        except (ElementNotInteractableException, ElementNotVisibleException):
-            # The list will be loaded directly if we're opening the tab for the second time in this test
-            pass
 
     def select_manage_data_tab(self):
         self.find_el_by_css('a[href="#tab-manage-data"]').click()

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -255,7 +255,6 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # assert the undo arrow is not displayed
         self.driver.find_element_by_css_selector('a[href="#tab-tracking-domains"]').click()
-        self.driver.find_element_by_id('show-tracking-domains-checkbox').click()
         self.assertFalse(
             self.driver.find_element_by_css_selector(
                 'div[data-origin="{}"] a.honeybadgerPowered'.format(DOMAIN)


### PR DESCRIPTION
Removes the acknowledgement overlay that gates the list of domains on the Tracking Domains tab for new users (#1804).

This overlay should no longer be necessary following #2478 (not-yet-blocked domains gated by default-off not-yet-blocked filter) and #2679 (not-yet-blocked filter itself is hidden unless learning is enabled).

In addition, it's not clear how effective this feature is at clearing up confusion in the first place. What is known though is that some users were bothered that there was no way to restore the overlay once dismissed.