### PR TITLE
Avoid oauth flows

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -691,7 +691,6 @@ twimg.com
 api.twisto.cz
 static.twisto.cz
 api.twisto.pl
-twitch.tv
 twitter.com
 platform.twitter.com
 syndication.twitter.com

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -127,6 +127,11 @@ HeuristicBlocker.prototype = {
       return {};
     }
 
+    // ignore requests coming from oauth systems
+    if (!tab_origin || !utils.isOAuthUrl(details.url)) {
+      return {};
+    }
+
     // short-circuit if we already observed this origin tracking on this site
     let firstParties = self.storage.getStore('snitch_map').getItem(request_origin);
     if (firstParties && firstParties.indexOf(tab_origin) > -1) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -474,7 +474,7 @@ function isOAuthUrl(url) {
   const urlParts = url.split(/\/|\./);
   let isOAuth;
 
-  for (let oauthType in oAuthUrlParts) {
+  for (let oauthType of oAuthUrlParts) {
     if (urlParts.includes(oauthType)) {
       isOAuth = true;
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -463,6 +463,33 @@ function isRestrictedUrl(url) {
   );
 }
 
+/**
+* checks if given domain is part of an oauth process
+* lifted and modified from here: https://github.com/cliqz-oss/browser-core/blob/d9ee171d7d59ec9fbcd3a899613017b87ec849e9/modules/antitracking/sources/steps/oauth-detector.es#L144-L170
+*/
+
+// TODO: is it URL or domain?
+// does there need to be /oauth2/
+// get rid of all the vars here we don't have or know
+function checkIsOAuth(url, type) {
+  const oAuthUrls = ['/oauth', '/authorize'];
+  // checking against -1 is super fugly
+  const mapper = oAuthUrl => state.urlParts.pathname.indexOf(oAuthUrl) > -1;
+  const reducer = (accumulator, currentValue) => accumulator || currentValue;
+  const isOAuthFlow = oAuthUrls.map(mapper).reduce(reducer);
+
+  if (isOAuthFlow
+    && this.clickActivity[state.tabId] && this.siteActivitiy[state.urlParts.hostname]) {
+    const clickedPage = parse(this.clickActivity[state.tabId]);
+    if (clickedPage !== null && clickedPage.hostname === state.tabUrlParts.hostname) {
+      state.incrementStat(`${type}_allow_oauth`);
+      return false;
+    }
+  }
+  return true;
+}
+
+
 /************************************** exports */
 let exports = {
   arrayBufferToBase64,

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -465,28 +465,20 @@ function isRestrictedUrl(url) {
 
 /**
 * checks if given domain is part of an oauth process
-* lifted and modified from here: https://github.com/cliqz-oss/browser-core/blob/d9ee171d7d59ec9fbcd3a899613017b87ec849e9/modules/antitracking/sources/steps/oauth-detector.es#L144-L170
+*
 */
 
-// TODO: is it URL or domain?
-// does there need to be /oauth2/
-// get rid of all the vars here we don't have or know
-function checkIsOAuth(url, type) {
-  const oAuthUrls = ['/oauth', '/authorize'];
-  // checking against -1 is super fugly
-  const mapper = oAuthUrl => state.urlParts.pathname.indexOf(oAuthUrl) > -1;
-  const reducer = (accumulator, currentValue) => accumulator || currentValue;
-  const isOAuthFlow = oAuthUrls.map(mapper).reduce(reducer);
+function isOAuthUrl(url) {
+  const oAuthUrls = ['oauth', 'authorize', 'oauth2'];
+  const urlParts = url.split('/');
+  let isOAuth;
 
-  if (isOAuthFlow
-    && this.clickActivity[state.tabId] && this.siteActivitiy[state.urlParts.hostname]) {
-    const clickedPage = parse(this.clickActivity[state.tabId]);
-    if (clickedPage !== null && clickedPage.hostname === state.tabUrlParts.hostname) {
-      state.incrementStat(`${type}_allow_oauth`);
-      return false;
+  for (let oauthType in oAuthUrls) {
+    if (urlParts.includes(oauthType)) {
+      isOAuth = true;
     }
   }
-  return true;
+  return isOAuth;
 }
 
 
@@ -497,6 +489,7 @@ let exports = {
   explodeSubdomains,
   findCommonSubstrings,
   getHostFromDomainInput,
+  isOAuthUrl,
   isRestrictedUrl,
   isThirdPartyDomain,
   nDaysFromNow,

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -470,7 +470,8 @@ function isRestrictedUrl(url) {
 
 function isOAuthUrl(url) {
   const oAuthUrls = ['oauth', 'authorize', 'oauth2'];
-  const urlParts = url.split('/');
+  // split on both '/' and '.' in a url
+  const urlParts = url.split(/\/|\./);
   let isOAuth;
 
   for (let oauthType in oAuthUrls) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -469,12 +469,12 @@ function isRestrictedUrl(url) {
 */
 
 function isOAuthUrl(url) {
-  const oAuthUrls = ['oauth', 'authorize', 'oauth2'];
+  const oAuthUrlParts = ['oauth', 'authorize', 'oauth2'];
   // split on both '/' and '.' in a url
   const urlParts = url.split(/\/|\./);
   let isOAuth;
 
-  for (let oauthType in oAuthUrls) {
+  for (let oauthType in oAuthUrlParts) {
     if (urlParts.includes(oauthType)) {
       isOAuth = true;
     }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -726,7 +726,7 @@ let getWidgetList = (function () {
 }());
 
 /**
- * Checks if given request FQDN is temporarily unblocked on a tab.
+ * Checks if given request FQDN is temporarily unblocked on a tab or if we suspect it is used for an OAuth process.
  *
  * The request is allowed if any of the following is true:
  *
@@ -734,6 +734,7 @@ let getWidgetList = (function () {
  *   - 1b) Request FQDN ends with a wildcard entry from the exception list
  *   - 2a) Request is from a subframe whose FQDN matches an entry on the list
  *   - 2b) Same but subframe's FQDN ends with a wildcard entry
+ *   - 3)  The request FQDN is suspected to be used in an oauth process
  *
  * @param {Integer} tab_id the ID of the tab to check
  * @param {String} request_host the request FQDN to check
@@ -744,6 +745,10 @@ let getWidgetList = (function () {
 function allowedOnTab(tab_id, request_host, frame_id) {
   if (!tempAllowlist.hasOwnProperty(tab_id)) {
     return false;
+  }
+
+  if (utils.isOAuthUrl(request_host)) {
+    return true;
   }
 
   let exceptions = tempAllowlist[tab_id];

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -139,7 +139,7 @@ function onBeforeSendHeaders(details) {
     type = details.type,
     url = details.url;
 
-  if (_isTabChromeInternal(tab_id)) {
+  if (_isTabChromeInternal(tab_id) && !utils.isOAuthUrl(url)) {
     // DNT policy requests: strip cookies
     if (type == "xmlhttprequest" && url.endsWith("/.well-known/dnt-policy.txt")) {
       // remove Cookie headers
@@ -234,7 +234,7 @@ function onHeadersReceived(details) {
   let tab_id = details.tabId,
     url = details.url;
 
-  if (_isTabChromeInternal(tab_id)) {
+  if (_isTabChromeInternal(tab_id) && !utils.isOAuthUrl(url)) {
     // DNT policy responses: strip cookies, reject redirects
     if (details.type == "xmlhttprequest" && url.endsWith("/.well-known/dnt-policy.txt")) {
       // if it's a redirect, cancel it

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -571,4 +571,19 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 });
 
+// Tests method to find commonly known oauth parts in a url
+QUnit.test("isOAuthUrl", assert => {
+
+  assert.ok(
+    utils.isOAuthUrl("g00gl3.com/oauth/authorize/buzz/bar"),
+    "correctly identifies a url with commonly known oauth substrings in it"
+  );
+
+  assert.notOk(
+    utils.isOAuthUrl("g00gl3.com/o4uth/authy/buzz/bar"),
+    "doesn't flag a url with no known oauth substrings"
+  );
+
+});
+
 })();


### PR DESCRIPTION
Allows requests and avoids learning about urls that are suspected to be part of an oauth process. It's neither exact or exhaustive -- as far as I know, there isn't a foolproof way to do it. This ought to come close, every oauth flow url I've seen includes one of the given substring types `'oauth', 'authorize', 'oauth2'`

I'm still scouting good test sites in the wild to confirm this on, I'll add them here.