### PR TITLE
Add ARIA labels to popup sliders

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -80,7 +80,7 @@
         "description": ""
     },
     "domain_slider_cookieblock_tooltip": {
-        "message": "Click here to block this domain from setting cookies",
+        "message": "Block cookies",
         "description": "Tooltip shown when you hover over the center part of a slider shown for each domain in the domain list."
     },
     "options_domain_filter_block": {
@@ -294,7 +294,7 @@
         "description": "Intro page welcome button."
     },
     "domain_slider_block_tooltip": {
-        "message": "Click here to block this domain entirely",
+        "message": "Block entirely",
         "description": "Tooltip shown when you hover over the leftmost part of a slider shown for each domain in the domain list."
     },
     "version": {
@@ -476,7 +476,7 @@
         "description": "Button in the popup."
     },
     "domain_slider_allow_tooltip": {
-        "message": "Click here to allow this domain",
+        "message": "Allow",
         "description": "Tooltip shown when you hover over the rightmost part of a slider shown for each domain in the domain list."
     },
     "intro_privacy_note": {

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -115,11 +115,11 @@ let htmlUtils = {
       return `
 <div class="switch-container ${action}">
   <div class="switch-toggle switch-3 switch-candy">
-    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" ${is_checked(constants.BLOCK, action)}>
+    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="block ${origin}" ${is_checked(constants.BLOCK, action)}>
     <label title="${tooltips.block}" class="tooltip" for="block-${origin_id}"></label>
-    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" ${is_checked(constants.COOKIEBLOCK, action)}>
+    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="cookie-block ${origin}" ${is_checked(constants.COOKIEBLOCK, action)}>
     <label title="${tooltips.cookieblock}" class="tooltip" for="cookieblock-${origin_id}"></label>
-    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" ${is_checked(constants.ALLOW, action)}>
+    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="allow ${origin}" ${is_checked(constants.ALLOW, action)}>
     <label title="${tooltips.allow}" class="tooltip" for="allow-${origin_id}"></label>
     <a></a>
   </div>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -115,11 +115,11 @@ let htmlUtils = {
       return `
 <div class="switch-container ${action}">
   <div class="switch-toggle switch-3 switch-candy">
-    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="${tooltips.block}: ${origin}" ${is_checked(constants.BLOCK, action)}>
+    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="${tooltips.block}" ${is_checked(constants.BLOCK, action)}>
     <label title="${tooltips.block}" class="tooltip" for="block-${origin_id}"></label>
-    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="${tooltips.cookieblock}: ${origin}" ${is_checked(constants.COOKIEBLOCK, action)}>
+    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="${tooltips.cookieblock}" ${is_checked(constants.COOKIEBLOCK, action)}>
     <label title="${tooltips.cookieblock}" class="tooltip" for="cookieblock-${origin_id}"></label>
-    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="${tooltips.allow}: ${origin}" ${is_checked(constants.ALLOW, action)}>
+    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="${tooltips.allow}" ${is_checked(constants.ALLOW, action)}>
     <label title="${tooltips.allow}" class="tooltip" for="allow-${origin_id}"></label>
     <a></a>
   </div>
@@ -189,10 +189,10 @@ let htmlUtils = {
       let origin_tooltip = htmlUtils.getActionDescription(action, origin);
       return `
 <div class="${classes.join(' ')}" data-origin="${origin}">
-  <div class="origin">
+  <h4 class="origin">
     <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}"></span>
     <span class="origin-inner tooltip" title="${origin_tooltip}">${dnt_html}${origin}</span>
-  </div>
+  </h4>
   <a href="" class="removeOrigin">&#10006</a>
   ${htmlUtils.getToggleHtml(origin, action)}
   <a href="" class="honeybadgerPowered tooltip" title="${undo_arrow_tooltip}"></a>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -115,11 +115,11 @@ let htmlUtils = {
       return `
 <div class="switch-container ${action}">
   <div class="switch-toggle switch-3 switch-candy">
-    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="${i18n.getMessage("domain_slider_block_tooltip")}: ${origin}" ${is_checked(constants.BLOCK, action)}>
+    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="${tooltips.block}: ${origin}" ${is_checked(constants.BLOCK, action)}>
     <label title="${tooltips.block}" class="tooltip" for="block-${origin_id}"></label>
-    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="${i18n.getMessage("domain_slider_cookieblock_tooltip")}: ${origin}" ${is_checked(constants.COOKIEBLOCK, action)}>
+    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="${tooltips.cookieblock}: ${origin}" ${is_checked(constants.COOKIEBLOCK, action)}>
     <label title="${tooltips.cookieblock}" class="tooltip" for="cookieblock-${origin_id}"></label>
-    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="${i18n.getMessage("domain_slider_allow_tooltip")}: ${origin}" ${is_checked(constants.ALLOW, action)}>
+    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="${tooltips.allow}: ${origin}" ${is_checked(constants.ALLOW, action)}>
     <label title="${tooltips.allow}" class="tooltip" for="allow-${origin_id}"></label>
     <a></a>
   </div>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -188,11 +188,11 @@ let htmlUtils = {
       // construct HTML for domain
       let origin_tooltip = htmlUtils.getActionDescription(action, origin);
       return `
-<div class="${classes.join(' ')}" data-origin="${origin}">
-  <h4 class="origin">
+<div class="${classes.join(' ')}" data-origin="${origin}" role="heading" aria-level="4">
+  <div class="origin">
     <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}"></span>
     <span class="origin-inner tooltip" title="${origin_tooltip}">${dnt_html}${origin}</span>
-  </h4>
+  </div>
   <a href="" class="removeOrigin">&#10006</a>
   ${htmlUtils.getToggleHtml(origin, action)}
   <a href="" class="honeybadgerPowered tooltip" title="${undo_arrow_tooltip}"></a>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -115,11 +115,11 @@ let htmlUtils = {
       return `
 <div class="switch-container ${action}">
   <div class="switch-toggle switch-3 switch-candy">
-    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="block ${origin}" ${is_checked(constants.BLOCK, action)}>
+    <input id="block-${origin_id}" name="${origin}" value="${constants.BLOCK}" type="radio" aria-label="${i18n.getMessage("domain_slider_block_tooltip")}: ${origin}" ${is_checked(constants.BLOCK, action)}>
     <label title="${tooltips.block}" class="tooltip" for="block-${origin_id}"></label>
-    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="cookie-block ${origin}" ${is_checked(constants.COOKIEBLOCK, action)}>
+    <input id="cookieblock-${origin_id}" name="${origin}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="${i18n.getMessage("domain_slider_cookieblock_tooltip")}: ${origin}" ${is_checked(constants.COOKIEBLOCK, action)}>
     <label title="${tooltips.cookieblock}" class="tooltip" for="cookieblock-${origin_id}"></label>
-    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="allow ${origin}" ${is_checked(constants.ALLOW, action)}>
+    <input id="allow-${origin_id}" name="${origin}" value="${constants.ALLOW}" type="radio" aria-label="${i18n.getMessage("domain_slider_allow_tooltip")}: ${origin}" ${is_checked(constants.ALLOW, action)}>
     <label title="${tooltips.allow}" class="tooltip" for="allow-${origin_id}"></label>
     <a></a>
   </div>

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -73,8 +73,6 @@ a:hover { color: #ec9329 }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: normal;
-  margin-top: 0;
 }
 
 .switch-container {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -73,6 +73,8 @@ a:hover { color: #ec9329 }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: normal;
+  margin-top: 0;
 }
 
 .switch-container {


### PR DESCRIPTION
Closes #2764 by adding some ARIA label descriptions to the html that's generated for every slider in the popup. 

Tested with VoiceOver screen reader tool on MacOS.

This adds a brief description for the purpose of each slider state (radio button under the hood) and the tracker domain it's associated with.