### PR TITLE
added Norton Shopping Guarantee widget

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -230,6 +230,18 @@
             "type": 3
         }
     },
+    "Norton Shopping Guarantee": {
+        "domain": "nsg.symantec.com",
+        "buttonSelectors": [
+            "span#BuySafeSealSpan"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "nsg.symantec.com"
+            ],
+            "type": 3
+        }
+    },
     "Twitch Player": {
         "domain": "player.twitch.tv",
         "buttonSelectors": [


### PR DESCRIPTION
Fixes #1702

Replaces widget on sites which use Norton Shopping Guarantee which makes requests to the site nsg.symantec.com .