### PR TITLE
Deprecate WebRTC IP leak protection

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -709,5 +709,23 @@
     "invalid_domain": {
         "message": "Please add a valid domain or URL",
         "description": "Error shown when attempting to add an invalid domain to the list of disabled sites"
+    },
+    "deprecated_setting": {
+        "message": "The following setting has been deprecated and will be removed in a future Privacy Badger update:",
+        "description": "Followed by the options_webrtc_setting message ('Prevent WebRTC...')"
+    },
+    "learn_more_link": {
+        "message": "Visit $LINK$ to learn more.",
+        "description": "Reusable 'learn more link' message",
+        "placeholders": {
+            "link": {
+                "content": "$1",
+                "example": "<a href='https://example.com'>example.com</a>"
+            }
+        }
+    },
+    "acknowledgement_action": {
+        "message": "I understand",
+        "description": "Acknowledgement button text"
     }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -883,10 +883,30 @@ Badger.prototype = {
     if (!privateStore.hasItem("showLearningPrompt")) {
       privateStore.setItem("showLearningPrompt", false);
     }
+    badger.initDeprecations();
+
+    if (self.isUpdate) {
+      // remove obsolete settings
+      if (settings.hasItem("showTrackingDomains")) {
+        settings.deleteItem("showTrackingDomains");
+      }
+    }
+  },
+
+  /**
+   * Initializes private flags that keep track of deprecated features.
+   *
+   * Called on Badger startup and user data import.
+   */
+  initDeprecations: function () {
+    let self = this,
+      privateStore = self.getPrivateSettings();
+
     if (!privateStore.hasItem("legacyWebRtcProtectionUser")) {
       // initialize "legacy WebRTC IP leak protection user" flag
       privateStore.setItem("legacyWebRtcProtectionUser",
         self.getSettings().getItem("preventWebRTCIPLeak"));
+
     } else if (!privateStore.getItem("legacyWebRtcProtectionUser")) {
       // set legacy flag to true if the IP protection gets enabled
       // for whatever reason (testing, user data import)
@@ -894,18 +914,12 @@ Badger.prototype = {
         privateStore.setItem("legacyWebRtcProtectionUser", true);
       }
     }
+
     if (!privateStore.hasItem("showWebRtcDeprecation")) {
       // will show WebRTC protection deprecation message
       // iff showWebRtcDeprecation exists and is set to true
       if (privateStore.getItem("legacyWebRtcProtectionUser")) {
         privateStore.setItem("showWebRtcDeprecation", true);
-      }
-    }
-
-    if (self.isUpdate) {
-      // remove obsolete settings
-      if (settings.hasItem("showTrackingDomains")) {
-        settings.deleteItem("showTrackingDomains");
       }
     }
   },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -894,6 +894,13 @@ Badger.prototype = {
         privateStore.setItem("legacyWebRtcProtectionUser", true);
       }
     }
+    if (!privateStore.hasItem("showWebRtcDeprecation")) {
+      // will show WebRTC protection deprecation message
+      // iff showWebRtcDeprecation exists and is set to true
+      if (privateStore.getItem("legacyWebRtcProtectionUser")) {
+        privateStore.setItem("showWebRtcDeprecation", true);
+      }
+    }
 
     if (self.isUpdate) {
       // remove obsolete settings

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -879,8 +879,20 @@ Badger.prototype = {
       privateStore.setItem("badgerVersion", version);
     }
 
+    // initialize any other private store (not-for-export) settings
     if (!privateStore.hasItem("showLearningPrompt")) {
       privateStore.setItem("showLearningPrompt", false);
+    }
+    if (!privateStore.hasItem("legacyWebRtcProtectionUser")) {
+      // initialize "legacy WebRTC IP leak protection user" flag
+      privateStore.setItem("legacyWebRtcProtectionUser",
+        self.getSettings().getItem("preventWebRTCIPLeak"));
+    } else if (!privateStore.getItem("legacyWebRtcProtectionUser")) {
+      // set legacy flag to true if the IP protection gets enabled
+      // for whatever reason (testing, user data import)
+      if (self.getSettings().getItem("preventWebRTCIPLeak")) {
+        privateStore.setItem("legacyWebRtcProtectionUser", true);
+      }
     }
 
     if (self.isUpdate) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -338,18 +338,9 @@ function parseUserDataFile(storageMapsList) {
   chrome.runtime.sendMessage({
     type: "mergeUserData",
     data: lists
-  }, (response) => {
-    OPTIONS_DATA.origins = response.origins;
-    OPTIONS_DATA.settings = response.settings;
-
-    // TODO general settings are not updated
-    reloadDisabledSites();
-    reloadTrackingDomainsTab();
-    // TODO widget replacement toggle not updated
-    // TODO widget replacement exceptions not updated
-    reloadWidgetSiteExceptions();
-
+  }, () => {
     alert(i18n.getMessage("import_successful"));
+    location.reload();
   });
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -168,7 +168,7 @@ function loadOptions() {
       });
   }
 
-  if (OPTIONS_DATA.webRTCAvailable) {
+  if (OPTIONS_DATA.webRTCAvailable && OPTIONS_DATA.legacyWebRtcProtectionUser) {
     $("#webRTCToggle").show();
     $("#toggle_webrtc_mode")
       .prop("checked", OPTIONS_DATA.settings.preventWebRTCIPLeak)

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -45,6 +45,12 @@ function showNagMaybe() {
     }, cb);
   }
 
+  function _setSeenWebRtcDeprecation(cb) {
+    chrome.runtime.sendMessage({
+      type: "seenWebRtcDeprecation"
+    }, cb);
+  }
+
   function _hideNag() {
     $nag.fadeOut();
     $outer.fadeOut();
@@ -83,8 +89,9 @@ function showNagMaybe() {
   function _showError(error_text) {
     $('#instruction-text').hide();
     $('#error-text').show().find('a')
-      .attr('id', 'critical-error-link')
+      .addClass('cta-button')
       .css({
+        borderRadius: '3px',
         padding: '5px',
         display: 'inline-block',
         width: 'auto',
@@ -124,7 +131,29 @@ function showNagMaybe() {
     $outer.show();
   }
 
-  if (POPUP_DATA.showLearningPrompt) {
+  function _showWebRtcDeprecationPrompt() {
+    $('#instruction-text').hide();
+
+    $("#webrtc-deprecation-ack-btn").on("click", function () {
+      _setSeenWebRtcDeprecation(function () {
+        _hideNag();
+      });
+    });
+
+    $('#fittslaw').on("click", function (e) {
+      e.preventDefault();
+      _hideNag();
+    });
+
+    $('#webrtc-deprecation-div').show();
+    $nag.show();
+    $outer.show();
+  }
+
+  if (POPUP_DATA.showWebRtcDeprecation) {
+    _showWebRtcDeprecationPrompt();
+
+  } else if (POPUP_DATA.showLearningPrompt) {
     _showLearningPrompt();
 
   } else if (!POPUP_DATA.settings.seenComic) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -140,12 +140,8 @@ function showNagMaybe() {
       });
     });
 
-    $('#fittslaw').on("click", function (e) {
-      e.preventDefault();
-      _hideNag();
-    });
-
     $('#webrtc-deprecation-div').show();
+    $('#fittslaw').hide();
     $nag.show();
     $outer.show();
   }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -583,8 +583,10 @@ BadgerStorage.prototype = {
 
         // default: overwrite existing setting with setting from import
         } else {
-          if (prop != "isFirstRun") {
+          if (badger.defaultSettings.hasOwnProperty(prop)) {
             self._store[prop] = mapData[prop];
+          } else {
+            console.error("Unknown Badger setting:", prop);
           }
         }
       }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1091,8 +1091,9 @@ function dispatcher(request, sender, sendResponse) {
       isOnFirstParty: utils.firstPartyProtectionsEnabled(tab_host),
       noTabData: false,
       origins,
-      showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
       settings: badger.getSettings().getItemClones(),
+      showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
+      showWebRtcDeprecation: !!badger.getPrivateSettings().getItem("showWebRtcDeprecation"),
       tabHost: tab_host,
       tabId: tab_id,
       tabUrl: request.tabUrl,
@@ -1153,6 +1154,12 @@ function dispatcher(request, sender, sendResponse) {
 
   case "seenLearningPrompt": {
     badger.getPrivateSettings().setItem("showLearningPrompt", false);
+    sendResponse();
+    break;
+  }
+
+  case "seenWebRtcDeprecation": {
+    badger.getPrivateSettings().setItem("showWebRtcDeprecation", false);
     sendResponse();
     break;
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1253,10 +1253,7 @@ function dispatcher(request, sender, sendResponse) {
     badger.blockWidgetDomains();
     badger.setPrivacyOverrides();
     badger.initDeprecations();
-    sendResponse({
-      origins: badger.storage.getTrackingDomains(),
-      settings: badger.getSettings().getItemClones(),
-    });
+    sendResponse();
     break;
   }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1115,6 +1115,7 @@ function dispatcher(request, sender, sendResponse) {
 
     sendResponse({
       cookieblocked,
+      legacyWebRtcProtectionUser: badger.getPrivateSettings().getItem("legacyWebRtcProtectionUser"),
       origins,
       settings: badger.getSettings().getItemClones(),
       webRTCAvailable: badger.webRTCAvailable,

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1252,6 +1252,7 @@ function dispatcher(request, sender, sendResponse) {
     badger.mergeUserData(request.data);
     badger.blockWidgetDomains();
     badger.setPrivacyOverrides();
+    badger.initDeprecations();
     sendResponse({
       origins: badger.storage.getTrackingDomains(),
       settings: badger.getSettings().getItemClones(),

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -103,11 +103,12 @@ function loadI18nStrings() {
     el[prop] = chrome.i18n.getMessage(key, placeholders);
   }
 
-  // also replace alt, placeholder and title attributes
+  // also replace alt, placeholder, title and aria-label attributes
   const ATTRS = [
     'alt',
     'placeholder',
     'title',
+    'aria-label',
   ];
 
   // get all the elements that contain one or more of these attributes

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -175,7 +175,7 @@ body#main #blockedResourcesContainer {
     justify-content: center;
 }
 
-#intro-reminder-btn, #critical-error-link, #learning-prompt-btn {
+button.cta-button, a.cta-button {
     background-color: #ff641c;
     border: 2px solid #ff641c;
     color: #fff;
@@ -186,14 +186,10 @@ body#main #blockedResourcesContainer {
     transition: background-color 0.3s ease;
     width: 100%;
 }
-
-#critical-error-link {
-    border-radius: 3px;
-}
-
-#intro-reminder-btn:hover, #critical-error-link:hover, #learning-prompt-btn:hover {
+button.cta-button:hover, a.cta-button:hover {
     background-color: #f58728;
 }
+
 .clickerContainer {
     max-height: 290px;
     overflow-y: auto;
@@ -222,6 +218,7 @@ body#main #blockedResourcesContainer {
 .flex-wrapper {
     display: flex;
     align-items: center;
+    overflow-wrap: anywhere;
 }
 
 #instruction-outer {
@@ -265,7 +262,7 @@ body#main #blockedResourcesContainer {
 #instruction .flex-wrapper > div {
     padding-inline-end: 5px;
 }
-#intro-reminder-btn, #error-message, #learning-prompt-btn {
+#intro-reminder-btn, #error-message, #learning-prompt-btn, #webrtc-deprecation-ack-btn {
     margin-top: 1em;
 }
 #error-message {
@@ -291,13 +288,13 @@ body#main #blockedResourcesContainer {
     margin: 0;
 }
 /* body#main to avoid applying this to options page */
-body#main #pbInstructions a, #firstparty-protections-container a {
+body#main #pbInstructions a, #firstparty-protections-container a, #webrtc-deprecation-div a {
     text-decoration: underline;
     color: black;
     font-weight: bold;
 }
-body#main #pbInstructions a:hover, #firstparty-protections-container a:hover {
-    color: #ec9329
+body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #webrtc-deprecation-div a:hover {
+    color: #ec9329;
 }
 #instructions-firstparty-description {
     font-size: 14px;
@@ -553,6 +550,7 @@ div.overlay.active {
     /* body#main to avoid applying this to options page */
     body#main #pbInstructions a,
     #firstparty-protections-container a,
+    #webrtc-deprecation-div a,
     #pbInstructions,
     .toggle-header-title,
     #special-browser-page,

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -265,6 +265,9 @@ button.cta-button:hover, a.cta-button:hover {
 #intro-reminder-btn, #error-message, #learning-prompt-btn, #webrtc-deprecation-ack-btn {
     margin-top: 1em;
 }
+#webrtc-deprecation-ack-btn {
+    padding: 10px;
+}
 #error-message {
     text-align: center;
 }

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -47,7 +47,7 @@
   <div id="instruction-outer">
   </div>
   <div id="instruction">
-    <a href="" id="fittslaw"><svg width="26" height="22" fill="white">
+    <a href="" id="fittslaw" role="button" aria-label="i18n_report_close"><svg width="26" height="22" fill="white">
       <line x1="5" y1="5" x2="20" y2="20" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
       <line x1="5" y1="20" x2="20" y2="5" style="stroke:rgb(22,22,22);stroke-width:3;fill:transparent"/>
     </svg></a>
@@ -99,7 +99,7 @@
 
   <div id="overlay" class="overlay">
     <h1 id="report_title" class="i18n_report_title overlay_title"></h1>
-    <a href="" id="report_close" class="i18n_report_close overlay_close"></a>
+    <a href="" id="report_close" class="i18n_report_close overlay_close" role="button"></a>
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
@@ -113,7 +113,7 @@
   </div>
   <div id="share_overlay" class="overlay">
     <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
-    <a href="" id="share_close" class="i18n_report_close overlay_close"></a>
+    <a href="" id="share_close" class="i18n_report_close overlay_close" role="button"></a>
     <textarea id="share_output" name="share_output" spellcheck="false"></textarea>
     <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
   </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -60,7 +60,7 @@
           <div class="i18n_intro_text2" style="margin-top:0.5em"></div>
         </div>
       </div>
-      <button id="intro-reminder-btn" class="i18n_first_run_text pbButton"></button>
+      <button id="intro-reminder-btn" class="i18n_first_run_text pbButton cta-button"></button>
     </div>
 
     <div id="error-text" style="display:none">
@@ -79,7 +79,20 @@
           <div class="i18n_learning_prompt_text2" style="margin-top:0.5em"></div>
         </div>
       </div>
-      <button id="learning-prompt-btn" class="i18n_learning_prompt_button pbButton"></button>
+      <button id="learning-prompt-btn" class="i18n_learning_prompt_button pbButton cta-button"></button>
+    </div>
+
+    <div id="webrtc-deprecation-div" style="display:none">
+      <div class="flex-wrapper">
+        <div>
+          <div class="i18n_deprecated_setting"></div>
+          <ul>
+            <li><span class="i18n_options_webrtc_setting"></span></li>
+          </ul>
+          <div class="i18n_learn_more_link" data-i18n_contents_placeholders="<a href='https://github.com/EFForg/privacybadger/issues/2782' target=_blank title='https://github.com/EFForg/privacybadger/issues/2782' class='tooltip'>https://git.io/badger-webrtc</a>"></div>
+        </div>
+      </div>
+      <button id="webrtc-deprecation-ack-btn" class="i18n_acknowledgement_action pbButton cta-button"></button>
     </div>
 
   </div><!-- end of div#instruction -->


### PR DESCRIPTION
Implements the first part of https://github.com/EFForg/privacybadger/issues/2782#issuecomment-874987177.

Since we reuse #2782 as the "learn more" page, need to add a short and clear summary of what's happening and what you could install instead to the top of that page prior to release.

Deprecation notice:

![Screenshot from 2021-07-08 17-15-33](https://user-images.githubusercontent.com/794578/124992010-6ac00600-e010-11eb-9f1a-16d182fb26ed.png)