### PR TITLE
Avoid twitch embed logins

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -707,7 +707,6 @@ twimg.com
 api.twisto.cz
 static.twisto.cz
 api.twisto.pl
-twitch.tv
 twitter.com
 platform.twitter.com
 syndication.twitter.com

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -575,6 +575,25 @@ function invert(obj) {
   return result;
 }
 
+/**
+* checks if domain is part of a known login (oauth or otherwise) process
+* expand on list of known login domains by adding to knownLoginParts array
+*/
+
+function isLoginUrl(url) {
+  const knownLoginParts = ['twitch'];
+  // split on both '/' and '.' in a url
+  const urlParts = url.split(/\/|\./);
+  let isLogin;
+
+  for (let loginType of knownLoginParts) {
+    if (urlParts.includes(loginType)) {
+      isLogin = true;
+    }
+  }
+  return isLogin;
+}
+
 /************************************** exports */
 let exports = {
   arrayBufferToBase64,
@@ -587,6 +606,7 @@ let exports = {
   firstPartyProtectionsEnabled,
   getHostFromDomainInput,
   invert,
+  isLoginUrl,
   isRestrictedUrl,
   isThirdPartyDomain,
   nDaysFromNow,

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -586,6 +586,21 @@ QUnit.test("estimateMaxEntropy", assert => {
 
 });
 
+// Tests method to find commonly known login parts in a url
+QUnit.test("isLoginUrl", assert => {
+
+  assert.ok(
+    utils.isLoginUrl("g00gl3.com/twitch/authorize/buzz/bar"),
+    "correctly identifies a url with commonly known oauth substrings in it"
+  );
+
+  assert.notOk(
+    utils.isLoginUrl("g00gl3.com/o4uth/authy/buzz/bar"),
+    "doesn't flag a url with no known oauth substrings"
+  );
+
+});
+
 QUnit.test("firstPartyProtectionsEnabled", assert => {
   assert.ok(
     utils.firstPartyProtectionsEnabled("www.google.com"),


### PR DESCRIPTION
Fixes #2540.

Originally part of `avoid-oauth-flows`  -- most of the changes were laid out in that branch, but this generalizes the naming and implementation

This fixes a breakage when dealing with embedded Twitch.tv login on a given page. It also lays out the groundwork for adding other known login flows to it (think OAuth, OAuth2, etc) -- though those still need to be tested.
