### PR TITLE
Make disable on site more prominent

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -218,8 +218,8 @@
         "description": "Tooltip that comes up when you hover over the 'tracking domains' link under the Tracking Domains tab on the options page."
     },
     "intro_report_button": {
-        "message": "Please don't forget to click on 'Did Privacy Badger break this site'. We respect your privacy so we don't send automatic reports.",
-        "description": "Intro page paragraph. The quoted message ('Did Privacy Badger break this site') should match the first part of the translation for the 'report_broken_site' message."
+        "message": "Please don't forget to click on 'Report broken site'. We respect your privacy so we don't send automatic reports.",
+        "description": "Intro page paragraph. The quoted message ('Report broken site') should match the first part of the translation for the 'report_broken_site' message."
     },
     "options_title": {
         "message": "Privacy Badger Options",
@@ -334,7 +334,7 @@
         "description": ""
     },
     "report_broken_site": {
-        "message": "Did Privacy Badger break this site? Let us know!",
+        "message": "Report broken site",
         "description": "Button in the popup."
     },
     "tooltip_cookieblock": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -230,7 +230,7 @@
         "description": ""
     },
     "popup_enable_for_site": {
-        "message": "Enable Privacy Badger for this site",
+        "message": "Enable for this site",
         "description": ""
     },
     "options_domain_type_filter": {
@@ -476,7 +476,7 @@
         "description": ""
     },
     "popup_disable_for_site": {
-        "message": "Disable Privacy Badger for this site",
+        "message": "Disable for this site",
         "description": "Button in the popup."
     },
     "intro_privacy_note": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -1,4 +1,34 @@
 {
+    "name": {
+        "message": "Privacy Badger",
+        "description": ""
+    },
+    "description": {
+        "message": "Privacy Badger automatically learns to block invisible trackers.",
+        "description": ""
+    },
+    "popup_disable_for_site": {
+        "message": "Disable for this site",
+        "description": "Button in the popup."
+    },
+    "popup_enable_for_site": {
+        "message": "Enable for this site",
+        "description": "Button in the popup, visible if Privacy Badger is disabled on the current site"
+    },
+    "report_broken_site": {
+        "message": "Report broken site",
+        "description": "Button in the popup."
+    },
+    "version": {
+        "message": "version $VERSION_STRING$",
+        "description": "Shows Privacy Badger's version in the popup. For example, \"version 2018.8.1\".",
+        "placeholders": {
+            "version_string": {
+                "content": "$1",
+                "example": "2018.8.1"
+            }
+        }
+    },
     "badger_status_block": {
         "message": "Blocked $DOMAIN$",
         "description": "Tooltip shown when you hover over a domain name with a red slider in the list of domains in the popup or under the Tracking Domains tab on the options page.",
@@ -37,7 +67,7 @@
     },
     "donate_to_eff": {
         "message": "Donate to EFF",
-        "description": "Button shown in the popup and on the intro page."
+        "description": "Link shown in the popup; also a button on the intro page"
     },
     "intro_donate_subheading": {
         "message": "Help us by donating and sharing your support for our tools",
@@ -219,7 +249,7 @@
     },
     "intro_report_button": {
         "message": "Please don't forget to click on 'Report broken site'. We respect your privacy so we don't send automatic reports.",
-        "description": "Intro page paragraph. The quoted message ('Report broken site') should match the first part of the translation for the 'report_broken_site' message."
+        "description": "Intro page paragraph. The quoted message ('Report broken site') should match the translation for the 'report_broken_site' message."
     },
     "options_title": {
         "message": "Privacy Badger Options",
@@ -227,10 +257,6 @@
     },
     "report_terms": {
         "message": "This will automatically send the following information to EFF: the page you're currently visiting, your browser version, the version of Privacy Badger, and the state of all of the sliders on this page.",
-        "description": ""
-    },
-    "popup_enable_for_site": {
-        "message": "Enable for this site",
         "description": ""
     },
     "options_domain_type_filter": {
@@ -301,16 +327,6 @@
         "message": "Take the tour",
         "description": "Intro page welcome button."
     },
-    "version": {
-        "message": "version $VERSION_STRING$",
-        "description": "Shows Privacy Badger's version in the popup. For example, \"version 2018.8.1\".",
-        "placeholders": {
-            "version_string": {
-                "content": "$1",
-                "example": "2018.8.1"
-            }
-        }
-    },
     "badger_status_cookieblock": {
         "message": "Blocked cookies from $DOMAIN$",
         "description": "Tooltip shown when you hover over a domain name with a yellow slider in the list of domains in the popup or under the Tracking Domains tab on the options page.",
@@ -332,10 +348,6 @@
     "import_select_file": {
         "message": "Please select a file to import.",
         "description": ""
-    },
-    "report_broken_site": {
-        "message": "Report broken site",
-        "description": "Button in the popup."
     },
     "tooltip_cookieblock": {
         "message": "Center the slider to block cookies",
@@ -475,10 +487,6 @@
         "message": "Move the slider right to allow a domain",
         "description": ""
     },
-    "popup_disable_for_site": {
-        "message": "Disable for this site",
-        "description": "Button in the popup."
-    },
     "intro_privacy_note": {
         "message": "Privacy Badger will NEVER share data about your browsing unless you choose to share it.",
         "description": "Intro page paragraph."
@@ -503,10 +511,6 @@
     "options_domain_list_no_trackers": {
         "message": "Privacy Badger hasn't detected any <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domains</a> yet. Keep browsing!",
         "description": "Shown on the Tracking Domains tab on the options page if all tracking domains have been removed."
-    },
-    "name": {
-        "message": "Privacy Badger",
-        "description": ""
     },
     "intro_not_an_adblocker_paragraph": {
         "message": "Privacy Badger starts blocking once it sees the same tracker on three different websites. Three strikes and it's out!",
@@ -559,10 +563,6 @@
     "share_button_title_facebook": {
         "message": "Share on Facebook",
         "description": "Text that comes up when you hover over the social sharing buttons on the intro page."
-    },
-    "description": {
-        "message": "Privacy Badger automatically learns to block invisible trackers.",
-        "description": ""
     },
     "report_fail": {
         "message": "Oops. Something went wrong.",

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -388,9 +388,7 @@ function send_error(message) {
  * activate PB for site event handler
  */
 function activateOnSite() {
-  $("#activate_site_btn").toggle();
-  $("#deactivate_site_btn").toggle();
-  $("#blockedResourcesContainer").show();
+  $("#activate_site_btn").prop("disabled", true);
 
   chrome.runtime.sendMessage({
     type: "activateOnSite",
@@ -398,6 +396,7 @@ function activateOnSite() {
     tabId: POPUP_DATA.tabId,
     tabUrl: POPUP_DATA.tabUrl
   }, () => {
+    // reload tab and close popup
     chrome.tabs.reload(POPUP_DATA.tabId);
     window.close();
   });
@@ -407,9 +406,7 @@ function activateOnSite() {
  * de-activate PB for site event handler
  */
 function deactivateOnSite() {
-  $("#activate_site_btn").toggle();
-  $("#deactivate_site_btn").toggle();
-  $("#blockedResourcesContainer").hide();
+  $("#deactivate_site_btn").prop("disabled", true);
 
   chrome.runtime.sendMessage({
     type: "deactivateOnSite",
@@ -417,6 +414,7 @@ function deactivateOnSite() {
     tabId: POPUP_DATA.tabId,
     tabUrl: POPUP_DATA.tabUrl
   }, () => {
+    // reload tab and close popup
     chrome.tabs.reload(POPUP_DATA.tabId);
     window.close();
   });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -550,6 +550,9 @@ function refreshPopup() {
     $('#deactivate_site_btn').hide();
     $('#error').hide();
 
+    // expand donate button to full row width when by itself
+    $("#donate").css("width", "100%")
+
     // activate tooltips
     $('.tooltip').tooltipster();
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -173,11 +173,6 @@ function init() {
 
   $("#activate_site_btn").on("click", activateOnSite);
   $("#deactivate_site_btn").on("click", deactivateOnSite);
-  $("#donate").on("click", function() {
-    chrome.tabs.create({
-      url: "https://supporters.eff.org/donate/support-privacy-badger"
-    });
-  });
 
   $('#error_input').on('input propertychange', function() {
     // No easy way of sending message on popup close, send message for every change
@@ -549,9 +544,6 @@ function refreshPopup() {
     // hide inapplicable buttons
     $('#deactivate_site_btn').hide();
     $('#error').hide();
-
-    // expand donate button to full row width when by itself
-    $("#donate").css("width", "100%")
 
     // activate tooltips
     $('.tooltip').tooltipster();

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -56,7 +56,7 @@ function setTextDirection() {
   // popup page
   if (ON_POPUP) {
     // fix floats
-    ['#badger-header-logo', '#header-image-stack', '#header-image-stack a', '#header-image-stack img', '#version'].forEach((selector) => {
+    ['#badger-header-logo', '#header-image-stack', '#header-image-stack a', '#header-image-stack img'].forEach((selector) => {
       toggle_css_value(selector, "float", "left", "right");
     });
     ['#fittslaw', '#options', '#help', '#share', '.overlay_close'].forEach((selector) => {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -52,6 +52,11 @@ a { text-decoration: none }
 
 a:hover { color: #ec9329 }
 
+button {
+    /* needed for Firefox */
+    color: #333;
+}
+
 .clear {
     clear: both;
 }

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -345,6 +345,9 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     text-align: center;
     width: 49%;
 }
+.pbButton:active {
+    transform: translateY(1px);
+}
 .pbButton:hover:enabled {
     border: 2px solid #F06A0A;
 }

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -348,7 +348,7 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     color: #666;
     cursor: auto;
 }
-#donate {
+#deactivate_site_btn, #activate_site_btn {
     width: 100%;
 }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -57,10 +57,6 @@ button {
     color: #333;
 }
 
-.clear {
-    clear: both;
-}
-
 .clicker {
     border-top: 1px solid #aaaaaa;
     padding: 5px;
@@ -339,7 +335,6 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     /* fix overly bold text on macOS */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    line-height: 16px;
     margin-top: 8px;
     padding: 10px;
     text-align: center;
@@ -455,7 +450,6 @@ div.overlay.active {
 }
 #donate {
     font-size: 14px;
-    line-height: 16px;
     margin: 5px 0;
     padding: 10px;
     text-align: center;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -356,6 +356,9 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     color: #666;
     cursor: auto;
 }
+#deactivate_site_btn, #activate_site_btn, #error {
+    font-size: 16px;
+}
 
 #not-yet-blocked-header, #non-trackers-header {
   text-align: center;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -340,7 +340,7 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     text-align: center;
     width: 49%;
 }
-.pbButton:active {
+.pbButton:not(:disabled):active {
     transform: translateY(1px);
 }
 .pbButton:hover:enabled {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -330,7 +330,7 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
 .pbButton {
     background-color: #fefefe;
     border: 2px solid;
-    border-radius: 6px;
+    border-radius: 3px;
     cursor: pointer;
     /* systemfontstack.com */
     font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif;
@@ -355,14 +355,6 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     background-color: #ccc;
     color: #666;
     cursor: auto;
-}
-#deactivate_site_btn, #activate_site_btn {
-    box-shadow: 0 3px #ddd;
-    font-size: 16px;
-    line-height: 20px;
-}
-#deactivate_site_btn:active, #activate_site_btn:active {
-    box-shadow: 0 2px #ddd;
 }
 
 #not-yet-blocked-header, #non-trackers-header {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -296,12 +296,12 @@ button.cta-button:hover, a.cta-button:hover {
     margin: 0;
 }
 /* body#main to avoid applying this to options page */
-body#main #pbInstructions a, #firstparty-protections-container a, #webrtc-deprecation-div a {
+body#main #pbInstructions a, #firstparty-protections-container a, #webrtc-deprecation-div a, #donate a {
     text-decoration: underline;
     color: black;
     font-weight: bold;
 }
-body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #webrtc-deprecation-div a:hover {
+body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #webrtc-deprecation-div a:hover, #donate a:hover {
     color: #ec9329;
 }
 #instructions-firstparty-description {
@@ -360,7 +360,6 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     box-shadow: 0 3px #ddd;
     font-size: 16px;
     line-height: 20px;
-    width: 100%;
 }
 #deactivate_site_btn:active, #activate_site_btn:active {
     box-shadow: 0 2px #ddd;
@@ -453,11 +452,20 @@ div.overlay.active {
   font-size: 13px;
 }
 
-#version{
-  color: #707070;
-  font-size: 10px;
-  float: left;
+#version {
+    color: #707070;
+    font-size: 10px;
+    position: absolute;
+    bottom: 5px;
 }
+#donate {
+    font-size: 14px;
+    line-height: 16px;
+    margin: 5px 0;
+    padding: 10px;
+    text-align: center;
+}
+
 .faded-bw-color-scheme {
     filter: grayscale(1) opacity(0.6);
 }
@@ -568,6 +576,7 @@ div.overlay.active {
     body#main #pbInstructions a,
     #firstparty-protections-container a,
     #webrtc-deprecation-div a,
+    #donate a,
     #pbInstructions,
     .toggle-header-title,
     #special-browser-page,

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -354,6 +354,9 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
 #deactivate_site_btn, #activate_site_btn, #error {
     font-size: 16px;
 }
+#error .ui-icon {
+    font-size: 12px;
+}
 
 #not-yet-blocked-header, #non-trackers-header {
   text-align: center;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -357,7 +357,13 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     cursor: auto;
 }
 #deactivate_site_btn, #activate_site_btn {
+    box-shadow: 0 3px #ddd;
+    font-size: 16px;
+    line-height: 20px;
     width: 100%;
+}
+#deactivate_site_btn:active, #activate_site_btn:active {
+    box-shadow: 0 2px #ddd;
 }
 
 #not-yet-blocked-header, #non-trackers-header {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -330,7 +330,7 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
 .pbButton {
     background-color: #fefefe;
     border: 2px solid;
-    border-radius: 3px;
+    border-radius: 6px;
     cursor: pointer;
     /* systemfontstack.com */
     font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -169,11 +169,14 @@ button {
 }
 
 /* body#main to avoid applying this to options page */
-body#main #blockedResourcesContainer {
+body#main #blockedResourcesContainer, #special-browser-page, #disabled-site-message {
     flex: 1;
     display: flex;
     flex-direction: column;
     justify-content: center;
+}
+#special-browser-page, #disabled-site-message {
+    text-align: center;
 }
 
 button.cta-button, a.cta-button {
@@ -306,11 +309,6 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #w
     color: #555;
     padding: 8px;
     font-size: 12px;
-}
-#special-browser-page, #disabled-site-message {
-    text-align: center;
-    margin: 40px 0;
-    padding: 0;
 }
 #no-third-parties {
     display: block;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -129,7 +129,6 @@
       <h2 id="title-name"><span class="i18n_name"></span></h2>
     </div>
   </div>
-  <div class='clear'></div>
 </div>
 
 <div id="firstparty-protections-container" style="display:none">

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -172,8 +172,8 @@
 </div>
 
 <div id="siteControls">
-    <button id="deactivate_site_btn" class="i18n_popup_disable_for_site pbButton"></button>
-    <button id="activate_site_btn" class="i18n_popup_enable_for_site pbButton" style="display:none"></button>
+    <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power" style="color:#ec9329"></span><span class="i18n_popup_disable_for_site"></span></button>
+    <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power" style="color:#ec9329"></span><span class="i18n_popup_enable_for_site"></span></button>
     <button id="error" class="i18n_report_broken_site pbButton"></button>
     <button id="donate" class="pbButton" target="_blank"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff"></span></button>
 </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -172,8 +172,8 @@
 </div>
 
 <div id="siteControls">
-    <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power" style="color:#ec9329"></span><span class="i18n_popup_disable_for_site"></span></button>
-    <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power" style="color:#ec9329"></span><span class="i18n_popup_enable_for_site"></span></button>
+    <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power"></span><span class="i18n_popup_disable_for_site"></span></button>
+    <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power"></span><span class="i18n_popup_enable_for_site"></span></button>
     <button id="error" class="i18n_report_broken_site pbButton"></button>
     <button id="donate" class="pbButton" target="_blank"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff"></span></button>
 </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -172,8 +172,8 @@
 </div>
 
 <div id="siteControls">
-    <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power"></span><span class="i18n_popup_disable_for_site"></span></button>
-    <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power"></span><span class="i18n_popup_enable_for_site"></span></button>
+    <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power"></span> <span class="i18n_popup_disable_for_site"></span></button>
+    <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power"></span> <span class="i18n_popup_enable_for_site"></span></button>
     <button id="error" class="i18n_report_broken_site pbButton"></button>
     <button id="donate" class="pbButton" target="_blank"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff"></span></button>
 </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -173,7 +173,7 @@
 <div id="siteControls">
     <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power"></span> <span class="i18n_popup_disable_for_site"></span></button>
     <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power"></span> <span class="i18n_popup_enable_for_site"></span></button>
-    <button id="error" class="i18n_report_broken_site pbButton"></button>
+    <button id="error" class="pbButton"><span class="ui-icon ui-icon-mail-send"></span> <span class="i18n_report_broken_site"></span></button>
 </div>
 
 <footer>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -175,9 +175,13 @@
     <button id="deactivate_site_btn" class="pbButton"><span class="ui-icon ui-icon-power"></span> <span class="i18n_popup_disable_for_site"></span></button>
     <button id="activate_site_btn" class="pbButton" style="display:none"><span class="ui-icon ui-icon-power"></span> <span class="i18n_popup_enable_for_site"></span></button>
     <button id="error" class="i18n_report_broken_site pbButton"></button>
-    <button id="donate" class="pbButton" target="_blank"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff"></span></button>
 </div>
-<span id="version" class="i18n_version"></span>
-<div class='clear'></div>
+
+<footer>
+  <div id="donate">
+    <a href="https://supporters.eff.org/donate/support-privacy-badger" target="_blank"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff"></span></a>
+  </div>
+  <div id="version" class="i18n_version"></div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
Related to #2781, #2021. Supersedes #2660.

This makes some more cosmetic changes to the popup to make the disable and enable buttons more prominent.

* adds a colored "power" icon to make it more visually clear what the button does
* simplifies the language on the button by removing "Privacy Badger" from the message (it's obvious that the control is for Privacy Badger)
* changes the disable and enable buttons to be stacked at 100% width with the other two buttons below sharing a single row.

<img width="440" alt="Screen Shot 2021-07-21 at 5 28 20 PM" src="https://user-images.githubusercontent.com/25778052/126575884-d6d535eb-70d9-47a0-ba79-6af31ebaf962.png">
