### PR TITLE
Apply current MDFP data to tracker data on data import and extension updates/installation

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -335,7 +335,7 @@ Badger.prototype = {
         return cb(new Error("Failed to parse seed data JSON"));
       }
 
-      self.mergeUserData(data, true);
+      self.mergeUserData(data);
       log("Loaded seed data successfully");
       return cb(null);
     });
@@ -1233,10 +1233,26 @@ Badger.prototype = {
    * Merge data exported from a different badger into this badger's storage.
    *
    * @param {Object} data the user data to merge in
-   * @param {Boolean} [skip_migrations=false] set when running from a migration to avoid infinite loop
    */
-  mergeUserData: function (data, skip_migrations) {
+  mergeUserData: function (data) {
     let self = this;
+
+    // fix incoming snitch map entries with current MDFP data
+    if (data.hasOwnProperty("snitch_map")) {
+      let correctedSites = {};
+
+      for (let domain in data.snitch_map) {
+        let newSnitches = data.snitch_map[domain].filter(
+          site => utils.isThirdPartyDomain(site, domain));
+
+        if (newSnitches.length) {
+          correctedSites[domain] = newSnitches;
+        }
+      }
+
+      data.snitch_map = correctedSites;
+    }
+
     // The order of these keys is also the order in which they should be imported.
     // It's important that snitch_map be imported before action_map (#1972)
     ["snitch_map", "action_map", "settings_map"].forEach(function (key) {
@@ -1247,9 +1263,7 @@ Badger.prototype = {
 
     // for exports from older Privacy Badger versions:
     // fix yellowlist getting out of sync, remove non-tracking domains, etc.
-    if (!skip_migrations) {
-      self.runMigrations();
-    }
+    self.runMigrations();
   }
 
 };

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1230,7 +1230,10 @@ Badger.prototype = {
   },
 
   /**
-   * Merge data exported from a different badger into this badger's storage.
+   * Merges Privacy Badger user data.
+   *
+   * Used to load pre-trained/"seed" data on installation and updates.
+   * Also used to import user data from other Privacy Badger instances.
    *
    * @param {Object} data the user data to merge in
    */
@@ -1260,10 +1263,6 @@ Badger.prototype = {
         self.storage.getStore(key).merge(data[key]);
       }
     });
-
-    // for exports from older Privacy Badger versions:
-    // fix yellowlist getting out of sync, remove non-tracking domains, etc.
-    self.runMigrations();
   }
 
 };

--- a/src/js/migrations.js
+++ b/src/js/migrations.js
@@ -235,36 +235,7 @@ exports.Migrations= {
     }
   },
 
-  forgetFirstPartySnitches: function (badger) {
-    console.log("Removing first parties from snitch map...");
-    let snitchMap = badger.storage.getStore("snitch_map"),
-      actionMap = badger.storage.getStore("action_map"),
-      snitchClones = snitchMap.getItemClones(),
-      actionClones = actionMap.getItemClones(),
-      correctedSites = {};
-
-    for (let domain in snitchClones) {
-      // creates new array of domains checking against the isThirdParty utility
-      let newSnitches = snitchClones[domain].filter(
-        item => utils.isThirdPartyDomain(item, domain));
-
-      if (newSnitches.length) {
-        correctedSites[domain] = newSnitches;
-      }
-    }
-
-    // clear existing maps and then use mergeUserData to rebuild them
-    actionMap.updateObject({});
-    snitchMap.updateObject({});
-
-    const data = {
-      snitch_map: correctedSites,
-      action_map: actionClones
-    };
-
-    // pass in boolean 2nd parameter to flag that it's run in a migration, preventing infinite loop
-    badger.mergeUserData(data, true);
-  },
+  forgetFirstPartySnitches: noop,
 
   forgetCloudflare: noop,
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1238,8 +1238,8 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
+  // called when the user manually sets a slider on the options page
   case "saveOptionsToggle": {
-    // called when the user manually sets a slider on the options page
     badger.saveAction(request.action, request.origin);
     sendResponse({
       origins: badger.storage.getTrackingDomains()
@@ -1247,12 +1247,17 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
+  // called when a user imports data exported from another Badger instance
   case "mergeUserData": {
-    // called when a user imports data exported from another Badger instance
     badger.mergeUserData(request.data);
     badger.blockWidgetDomains();
     badger.setPrivacyOverrides();
     badger.initDeprecations();
+
+    // for exports from older Privacy Badger versions:
+    // fix yellowlist getting out of sync, remove non-tracking domains, etc.
+    badger.runMigrations();
+
     sendResponse();
     break;
   }

--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -14,7 +14,6 @@ const DNT_COMPLIANT_DOMAIN = 'eff.org',
 
 let utils = require('utils'),
   constants = require('constants'),
-  migrations = require('migrations').Migrations,
   mdfp = require('multiDomainFP');
 
 let clock,
@@ -359,16 +358,16 @@ QUnit.test("subdomains on the yellowlist are preserved", (assert) => {
   );
 });
 
-QUnit.test("forgetFirstPartySnitches migration properly handles snitch entries with no MDFP entries", (assert) => {
+QUnit.test("mergeUserData() preserves snitch map data when no MDFP", (assert) => {
   const actionMap = badger.storage.getStore('action_map'),
-    snitchMap = badger.storage.getStore('snitch_map');
+    snitchMap = badger.storage.getStore('snitch_map'),
+    TRACKER = 'amazon.com';
 
-  let snitchNoMDFP = {
-    'amazon.com': ['amazonads.com', 'amazing.com', 'amazonrainforest.com']
+  let snitch_map = {
+    [TRACKER]: ['amazonads.com', 'amazing.com', 'amazonrainforest.com']
   };
-
-  let actionNoMDFP = {
-    'amazon.com': {
+  let action_map = {
+    [TRACKER]: {
       heuristicAction: "cookieblock",
       userAction: "",
       dnt: false,
@@ -376,33 +375,33 @@ QUnit.test("forgetFirstPartySnitches migration properly handles snitch entries w
     }
   };
 
-  snitchMap.updateObject(snitchNoMDFP);
-  actionMap.updateObject(actionNoMDFP);
-  migrations.forgetFirstPartySnitches(badger);
+  assert.notOk(actionMap.getItem(TRACKER), "no data before test");
+  assert.notOk(snitchMap.getItem(TRACKER), "no data before test");
+
+  badger.mergeUserData({ action_map, snitch_map });
 
   assert.deepEqual(
-    actionMap.getItem('amazon.com'),
-    actionNoMDFP['amazon.com'],
+    actionMap.getItem(TRACKER),
+    action_map[TRACKER],
     "action map preserved for domain with no MDFP snitch entries"
   );
-
   assert.deepEqual(
-    snitchMap.getItem('amazon.com'),
-    snitchNoMDFP['amazon.com'],
+    snitchMap.getItem(TRACKER),
+    snitch_map[TRACKER],
     "snitch map entry with no MDFP domains remains the same after migration runs"
   );
 });
 
-QUnit.test("forgetFirstPartySnitches migration properly handles snitch entries with some MDFP entries", (assert) => {
+QUnit.test("mergeUserData() removes MDFP entries from snitch map", (assert) => {
   const actionMap = badger.storage.getStore('action_map'),
-    snitchMap = badger.storage.getStore('snitch_map');
+    snitchMap = badger.storage.getStore('snitch_map'),
+    TRACKER = 'amazon.com';
 
-  let snitchSomeMDFP = {
-    'amazon.com': ['amazon.ca', 'amazon.co.jp', 'amazing.com']
+  let snitch_map = {
+    [TRACKER]: ['amazon.ca', 'amazon.co.jp', 'amazing.com']
   };
-
-  let actionSomeMDFP = {
-    'amazon.com': {
+  let action_map = {
+    [TRACKER]: {
       heuristicAction: "cookieblock",
       userAction: "",
       dnt: false,
@@ -410,31 +409,33 @@ QUnit.test("forgetFirstPartySnitches migration properly handles snitch entries w
     }
   };
 
-  snitchMap.updateObject(snitchSomeMDFP);
-  actionMap.updateObject(actionSomeMDFP);
-  migrations.forgetFirstPartySnitches(badger);
+  assert.notOk(actionMap.getItem(TRACKER), "no data before test");
+  assert.notOk(snitchMap.getItem(TRACKER), "no data before test");
+
+  badger.mergeUserData({ action_map, snitch_map });
 
   assert.equal(
-    badger.storage.getAction('amazon.com'),
+    badger.storage.getAction(TRACKER),
     constants.ALLOW,
-    "Action downgraded for partial MDFP domain"
+    "action downgraded to not-yet-blocked for partial MDFP domain"
   );
-
-  assert.deepEqual(snitchMap.getItem('amazon.com'),
+  assert.deepEqual(
+    snitchMap.getItem(TRACKER),
     ["amazing.com"],
-    'forget first party migration properly removes MDFP domains and leaves regular domains');
+    "MDFP entries were removed, non-MDFP entries were left alone"
+  );
 });
 
-QUnit.test("forgetFirstPartySnitches migration properly handles snitch entries with all MDFP entries", (assert) => {
+QUnit.test("mergeUserData() clears snitch_map when all items are MDFP", (assert) => {
   const actionMap = badger.storage.getStore('action_map'),
-    snitchMap = badger.storage.getStore('snitch_map');
+    snitchMap = badger.storage.getStore('snitch_map'),
+    TRACKER = 'amazon.com';
 
-  let snitchAllMDFP = {
-    'amazon.com': ['amazon.ca', 'amazon.co.jp', 'amazon.es']
+  let snitch_map = {
+    [TRACKER]: ['amazon.ca', 'amazon.co.jp', 'amazon.es']
   };
-
-  let actionAllMDFP = {
-    'amazon.com': {
+  let action_map = {
+    [TRACKER]: {
       heuristicAction: "cookieblock",
       userAction: "",
       dnt: false,
@@ -442,25 +443,27 @@ QUnit.test("forgetFirstPartySnitches migration properly handles snitch entries w
     }
   };
 
+  assert.notOk(actionMap.getItem(TRACKER), "no data before test");
+  assert.notOk(snitchMap.getItem(TRACKER), "no data before test");
+
   // confirm all entries are MDFP
-  snitchAllMDFP["amazon.com"].forEach((domain) => {
+  snitch_map[TRACKER].forEach(domain => {
     assert.ok(
-      mdfp.isMultiDomainFirstParty('amazon.com', domain),
-      domain + " is indeed MDFP to amazon.com"
+      mdfp.isMultiDomainFirstParty(TRACKER, domain),
+      `${domain} is indeed MDFP to ${TRACKER}`
     );
   });
 
-  snitchMap.updateObject(snitchAllMDFP);
-  actionMap.updateObject(actionAllMDFP);
-  migrations.forgetFirstPartySnitches(badger);
-
-  assert.notOk(snitchMap.getItem('amazon.com'),
-    'forget first party migration properly removes a snitch map entry with all MDFP domains attributed to it');
+  badger.mergeUserData({ action_map, snitch_map });
 
   assert.equal(
-    badger.storage.getAction('amazon.com'),
+    badger.storage.getAction(TRACKER),
     constants.NO_TRACKING,
-    "Action downgraded for all MDFP domain"
+    "all MDFP domain is no longer known as a tracker"
+  );
+  assert.notOk(
+    snitchMap.getItem(TRACKER),
+    "all-MDFP snitch_map data was removed entirely"
   );
 });
 


### PR DESCRIPTION
This replaces the migration to clean tracker data; older Badgers will get data cleaned on extension update.

Following up on #2377.