### PR TITLE
Work around welcome page disappearing post install

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -132,7 +132,19 @@ function Badger() {
     // set up periodic fetching of hashes from eff.org
     setInterval(self.updateDntPolicyHashes.bind(self), utils.oneDay() * 4);
 
+    let privateStore = self.getPrivateSettings();
     if (self.isFirstRun) {
+      // work around the welcome page getting closed by an extension restart
+      // such as in response to being granted Private Browsing permission
+      // from the post-install doorhanger on Firefox
+      setTimeout(function () {
+        privateStore.setItem("firstRunTimerFinished", true);
+      }, utils.oneMinute());
+
+      self.showFirstRunPage();
+
+    } else if (!privateStore.getItem("firstRunTimerFinished")) {
+      privateStore.setItem("firstRunTimerFinished", true);
       self.showFirstRunPage();
     }
   });
@@ -880,8 +892,14 @@ Badger.prototype = {
     }
 
     // initialize any other private store (not-for-export) settings
-    if (!privateStore.hasItem("showLearningPrompt")) {
-      privateStore.setItem("showLearningPrompt", false);
+    let privateDefaultSettings = {
+      "firstRunTimerFinished": false,
+      "showLearningPrompt": false,
+    };
+    for (let key of Object.keys(privateDefaultSettings)) {
+      if (!privateStore.hasItem(key)) {
+        privateStore.setItem(key, privateDefaultSettings[key]);
+      }
     }
     badger.initDeprecations();
 


### PR DESCRIPTION
This is meant to help Firefox users not lose the welcome page when it gets inadvertently closed when the user chooses to first interact with the post-install Private browsing permission hanger (a reasonable choice) and allows Privacy Badger to run in Private windows.

Related to #2781.

To test:

1. Get Firefox Nightly
2. Toggle `xpinstall.signatures.required` to `false` in `about:config`
3. Create an XPI:  `cd src` and then `zip -r badger.xpi *`
4. Drag and drop the XPI into `about:addons`, switch to the Firefox window, click "Add" in the unverified extension prompt 
5. Check "Allow this extension to run in Private Windows", click "Okay"

If you interact with the welcome page first, finish reading it, and respond to the Private browsing permission hanger in under a minute, we are going to reopen the welcome page, which is a bit annoying.

We could shorten the timer duration, but then we run the opposite risk of not reopening the welcome page if the user took too long to interact with the permission hanger. Is one minute a good compromise?