### PR TITLE
Add replacement placeholder for Rumble widget

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -203,6 +203,18 @@
             "type": 0
         }
     },
+    "Rumble Video Player": {
+        "domain": "rumble.com",
+        "buttonSelectors": [
+            "iframe[src^='https://rumble.com/embed/']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "rumble.com"
+            ],
+            "type": 3
+        }
+    },
     "SoundCloud": {
         "domain": "w.soundcloud.com",
         "buttonSelectors": [

--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -18,6 +18,7 @@
 require.scopes.surrogatedb = (function () {
 
 const MATCH_SUFFIX = 'suffix',
+  MATCH_PREFIX = 'prefix',
   MATCH_ANY = 'any';
 
 /**
@@ -86,6 +87,13 @@ const hostnames = {
       '/apstag.js',
     ]
   },
+  'rumble.com': {
+    match: MATCH_PREFIX,
+    tokens: [
+      '/embedJS/',
+    ],
+    widget: "Rumble Video Player"
+  },
 };
 
 /**
@@ -121,6 +129,8 @@ const surrogates = {
 
   '/apstag.js': 'amazon_apstag.js',
 
+  '/embedJS/': 'rumble_embedjs.js',
+
   'noopjs': 'noop.js'
 };
 
@@ -132,6 +142,7 @@ Object.keys(surrogates).forEach(key => {
 
 const exports = {
   MATCH_ANY,
+  MATCH_PREFIX,
   MATCH_SUFFIX,
   hostnames,
   surrogates,

--- a/src/data/web_accessible_resources/rumble_embedjs.js
+++ b/src/data/web_accessible_resources/rumble_embedjs.js
@@ -1,0 +1,38 @@
+(function () {
+    if ("Rumble" in window && "_" in window.Rumble) {
+        for (let args of window.Rumble._) {
+            args = [].slice.apply(args);
+
+            let cmd = args[0],
+                conf = args[1],
+                script_src = document.currentScript.src,
+                idx = script_src.indexOf("/embedJS/"),
+                pub_code;
+
+            if (idx != -1) {
+                script_src = script_src.slice(idx + "/embedJS/".length);
+                idx = script_src.indexOf("/");
+                if (idx != -1) {
+                    script_src = script_src.slice(0, idx);
+                    idx = script_src.indexOf(".");
+                    if (idx != -1) {
+                        pub_code = script_src.slice(0, idx);
+                    }
+                }
+            }
+
+            if (pub_code && cmd == "play" && "div" in conf && "video" in conf) {
+                document.dispatchEvent(new CustomEvent("pbSurrogateMessage", {
+                    detail: {
+                        type: "widgetFromSurrogate",
+                        widgetData: {
+                            name: "Rumble Video Player",
+                            pubCode: pub_code,
+                            args
+                        }
+                    }
+                }));
+            }
+        }
+    }
+}());

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -233,6 +233,8 @@ Badger.prototype = {
             <frame_id>: {
               url: {String}
               host: {String}
+              widgetReplacementReady: {Boolean}
+              widgetQueue: {Array} widget objects
               warAccessTokens: {
                 <extension_resource_URL>: {String} access token
                 ...

--- a/src/js/surrogates.js
+++ b/src/js/surrogates.js
@@ -19,6 +19,17 @@ require.scopes.surrogates = (function () {
 
 const db = require('surrogatedb');
 
+const WIDGET_SURROGATES = (function () {
+  let memo = {};
+  for (let host of Object.keys(db.hostnames)) {
+    let widget_name = db.hostnames[host].widget;
+    if (widget_name) {
+      memo[host] = widget_name;
+    }
+  }
+  return memo;
+}());
+
 /**
  * Blocking tracking scripts (trackers) can cause parts of webpages to break.
  * Surrogate scripts are dummy pieces of JavaScript meant to supply just enough
@@ -80,6 +91,20 @@ function getSurrogateUri(script_url, script_hostname) {
     return false;
   }
 
+  // one or more prefix tokens:
+  // does the script URL's path component begin with one of these tokens?
+  case db.MATCH_PREFIX: {
+    let script_path_onwards = script_url.slice(
+      script_url.indexOf(script_hostname) + script_hostname.length);
+    for (const token of conf.tokens) {
+      if (script_path_onwards.startsWith(token)) {
+        return db.surrogates[token];
+      }
+    }
+
+    return false;
+  }
+
   }
 
   return false;
@@ -87,7 +112,9 @@ function getSurrogateUri(script_url, script_hostname) {
 
 const exports = {
   getSurrogateUri,
+  WIDGET_SURROGATES
 };
 
 return exports;
-})();
+
+}());


### PR DESCRIPTION
Fixes #2796 in part by implementing a new, surrogate script-driven widget replacement flow.

Follows up on #2512.

To be followed up with an explicit render v2 reCAPTCHA surrogate (#2739); and then later improved Facebook and YouTube surrogates that should let us finally remove Facebook/YouTube domains from the yellowlist.