### PR TITLE
Update onboarding page pt i -- remove tour prompts

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -105,10 +105,6 @@
         "message": "Click to return control of this domain to Privacy Badger",
         "description": "Tooltip shown when you hover over an undo arrow that appears when you move a domain slider away from its automatic setting."
     },
-    "next_section": {
-        "message": "next section",
-        "description": "Image alt. text on a couple of \"scroll down\" arrow buttons on the intro page."
-    },
     "extension_error_text": {
         "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
         "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
@@ -322,10 +318,6 @@
     "options_advanced_settings": {
         "message": "Advanced",
         "description": "Subheading on the general settings options page."
-    },
-    "intro_next_button": {
-        "message": "Take the tour",
-        "description": "Intro page welcome button."
     },
     "badger_status_cookieblock": {
         "message": "Blocked cookies from $DOMAIN$",

--- a/src/skin/firstRun.html
+++ b/src/skin/firstRun.html
@@ -36,9 +36,6 @@
       <div class="small-12 medium-10 large-4 text cell">
         <p class="i18n_intro_welcome"></p>
       </div>
-      <div class="small-12 text-center cell">
-        <a href="#pb-features-1" class="i18n_intro_next_button button large scroll-it"></a>
-      </div>
     </div>
 
     <!-- privacy badger features -->
@@ -73,9 +70,6 @@
         <p class="i18n_intro_not_an_adblocker_paragraph"></p>
       </div>
     </div>
-    <div class="caret-down align-center">
-      <a href="#pb-settings" class="scroll-it"><img src="images/carrot-down.svg" alt="i18n_next_section"></a>
-    </div>
 
     <!-- privacy badger settings -->
     <div id="pb-settings" class="align-center">
@@ -85,9 +79,6 @@
         <p class="i18n_intro_report_button"></p>
         <p class="i18n_intro_privacy_note"></p>
       </div>
-    </div>
-    <div class="caret-down align-center">
-      <a href="#pb-donate" class="scroll-it"><img src="images/carrot-down.svg" alt="i18n_next_section"></a>
     </div>
 
     <!-- donate ask -->


### PR DESCRIPTION
First in a series of small PR's set out to incrementally update the first download page new users see when they install Privacy Badger. 

This PR removes the "take the tour" prompt and subsequent click-to-scroll carrot icons from the page.