### PR TITLE
Update yellowlist.txt for additional Google map tile servers

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -301,6 +301,8 @@ maps.google.com
 mapsengine.google.com
 mt0.google.com
 mt1.google.com
+mt2.google.com
+mt3.google.com
 mts0.google.com
 mts1.google.com
 mw1.google.com


### PR DESCRIPTION
Google's Map Tile servers `mt0.google.com` and `mt1.google.com` are in the yellow list, but sometimes `mt2.google.com` and `mt3.google.com` are also used to server map tiles, and should therefore also be in the yellow list. Example of a failing site: <https://map.treetracker.org/>. Thanks.