### PR TITLE
Fix Google Search link unwrapping in desktop Firefox

### DIFF
--- a/src/js/firstparties/google-search.js
+++ b/src/js/firstparties/google-search.js
@@ -5,7 +5,7 @@
 //
 // Ignore internal links in Chrome and desktop Firefox
 // to avoid unwrapping (and breaking the dropdown on) the settings link
-let trap_link = "a[onmousedown^='return rwt(this,']:not([href^='/']), a[ping]:not([href^='/']), a[href^='/url?q=']";
+let trap_link = "a[onmousedown^='return rwt(this,']:not([href^='/']), a[ping]:not([href^='/']), a[href^='/url?q='], a[data-jsarwt='1']";
 
 // Remove excessive attributes and event listeners from link a
 function cleanLink(a) {

--- a/tests/selenium/google_test.py
+++ b/tests/selenium/google_test.py
@@ -88,7 +88,7 @@ class GoogleTest(pbtest.PBSeleniumTest):
         # use the browser-appropriate selector
         SELECTOR = "a[ping]"
         if pbtest.shim.browser_type == "firefox":
-            SELECTOR = "a[data-jsarwt='1']"
+            SELECTOR = "a[onmousedown^='return rwt(this,']"
 
         # turn off link unwrapping on Google
         # so that we can test our selectors


### PR DESCRIPTION
Apparently Google rolled out a new version of search result link tracking for desktop Firefox a couple of days ago. Is this change discussed or documented anywhere?

Keeping the old desktop Firefox link selector because maybe it'll return and maybe it still gets used under some circumstances.