### PR TITLE
Fix action for non-tracking domains

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -229,9 +229,10 @@ BadgerPen.prototype = {
    * @returns {String} the best action for the FQDN
    */
   getBestAction: function (fqdn) {
-    let best_action = constants.NO_TRACKING;
-    let subdomains = utils.explodeSubdomains(fqdn);
-    let action_map = this.getStore('action_map');
+    let self = this,
+      action_map = self.getStore('action_map'),
+      best_action = constants.NO_TRACKING,
+      subdomains = utils.explodeSubdomains(fqdn);
 
     function getScore(action) {
       switch (action) {
@@ -255,10 +256,10 @@ BadgerPen.prototype = {
     // Loop through each subdomain we have a rule for
     // from least (base domain) to most (FQDN) specific
     // and keep the one which has the best score.
-    for (let i = subdomains.length; i >= 0; i--) {
+    for (let i = subdomains.length - 1; i >= 0; i--) {
       let domain = subdomains[i];
       if (action_map.hasItem(domain)) {
-        let action = this.getAction(
+        let action = self.getAction(
           action_map.getItem(domain),
           // ignore DNT unless it's directly on the FQDN being checked
           domain != fqdn
@@ -432,27 +433,8 @@ var _newActionMapObject = function() {
 };
 
 /**
- * Privacy Badger Storage Object. Has methods for getting, setting and deleting
- * should be used for all storage needs, transparently handles data presistence
- * syncing and private browsing.
- * Usage:
- * example_map = getStore('example_map');
- * # instance of BadgerStorage
- * example_map.setItem('foo', 'bar')
- * # null
- * example_map
- * # { foo: "bar" }
- * example_map.hasItem('foo')
- * # true
- * example_map.getItem('foo');
- * # 'bar'
- * example_map.getItem('not_real');
- * # undefined
- * example_map.deleteItem('foo');
- * # null
- * example_map.hasItem('foo');
- * # false
- *
+ * Privacy Badger Storage Object.
+ * Should be used for all storage needs.
  */
 
 /**

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -295,6 +295,31 @@ QUnit.test("snitch map merging", (assert) => {
   assert.equal(actionMap.getItem(DOMAIN).heuristicAction, "block");
 });
 
+QUnit.test("unknown domains are reported as non-tracking", (assert) => {
+  const UHOST = "thisdomainshouldnotbepresentinprivacybadgerstorage.com";
+
+  let done = assert.async();
+
+  assert.notOk(actionMap.getItem(UHOST));
+  assert.notOk(snitchMap.getItem(UHOST));
+  assert.equal(
+    storage.getBestAction(UHOST),
+    constants.NO_TRACKING,
+    "best action for unknown domain is 'no tracking'"
+  );
+
+  badger.loadSeedData(function () {
+    assert.notOk(actionMap.getItem(UHOST));
+    assert.notOk(snitchMap.getItem(UHOST));
+    assert.equal(
+      storage.getBestAction(UHOST),
+      constants.NO_TRACKING,
+      "best action for unknown domain is still 'no tracking'"
+    );
+    done();
+  });
+});
+
 QUnit.test("blocking cascades", (assert) => {
   // mark domain for blocking
   storage.setupHeuristicAction(DOMAIN, constants.BLOCK);


### PR DESCRIPTION
Non-tracking domains are always reported as tracking-but-not-yet-blocked. This got broken ever since we recorded the `"undefined"` domain in pre-trained action map (1bd52e5e62e3d4e72c23de09a071545e52317604).

A separate off-by-one bug causes us to always do a lookup for `undefined` when looking up the action to take for a domain. Since we do in fact have an `"undefined"` domain, the lookup always returns true and so we have a floor of whatever action the `"undefined"` domain has; non-tracking domains will never be reported as non-tracking.

This PR fixes the off-by-one bug.

To be followed by finding and fixing where we record tracking by `undefined`. (Start by looking through something like `git lg -G 'in snitch_map:.*undefined' -- log.txt` in Badger Sett.)