### PR TITLE
Create a special error message for Firefox users

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -265,6 +265,20 @@
         "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
         "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
     },
+    "popup_error_text_low_disk_space_issue": {
+      "message": "Failed to write to extension storage: '$ERROR_TEXT$'. Is your disk low on space? $LEARN_MORE_LINK$",
+      "description": "Special error message for the 'Unkown Error Occurred' text that sometimes occurs on Firefox browsers with low disk space",
+      "placeholders": {
+        "error_text": {
+          "content": "$1",
+          "example": "Unkown error occurred"
+        },
+        "learn_more_link": {
+          "content": "$2",
+          "example": "Visit <a href='https://eff.org/'>here</a> to learn more."
+        }
+      }
+    },
     "firstRun_title": {
         "message": "Thank you for installing Privacy Badger!",
         "description": "Title and header of the intro page."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -266,16 +266,12 @@
         "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
     },
     "popup_error_text_low_disk_space_issue": {
-      "message": "Failed to write to extension storage: '$ERROR_TEXT$'. Is your disk low on space? $LEARN_MORE_LINK$",
-      "description": "Special error message for the 'Unkown Error Occurred' text that sometimes occurs on Firefox browsers with low disk space",
+      "message": "Failed to write to extension storage: '$ERROR_TEXT$'. Is your disk low on space? Visit <a href='https://www.privacybadger.org/#faq-I-found-a-bug!-What-do-I-do-now?'>privacybadger.org</a> to learn more.",
+      "description": "Special error message for the 'An unexpected error occurred' text that sometimes occurs on Firefox browsers with low disk space",
       "placeholders": {
         "error_text": {
           "content": "$1",
-          "example": "Unkown error occurred"
-        },
-        "learn_more_link": {
-          "content": "$2",
-          "example": "Visit <a href='https://eff.org/'>here</a> to learn more."
+          "example": "An unexpected error occurred"
         }
       }
     },

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -263,11 +263,17 @@
     },
     "extension_error_text": {
         "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
-        "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
+        "description": "Shown in the popup when there is an extension error we want to encourage the user to tell us about."
     },
     "popup_error_text_low_disk_space_issue": {
-      "message": "<div style='color:red'>Failed to write to extension storage.</div> Is your disk low on space? Visit <a href='https://www.privacybadger.org/#faq-I-found-a-bug!-What-do-I-do-now?'>FAQ</a> to learn more.",
-      "description": "Special error message for the 'An unexpected error occurred' text that sometimes occurs on Firefox browsers with low disk space"
+      "message": "Failed to write to extension storage: $ERROR_TEXT$.<br><br>Is your disk low on space?",
+      "description": "Special error message for the 'An unexpected error occurred' text that sometimes occurs on Firefox browsers with low disk space",
+      "placeholders": {
+        "error_text": {
+          "content": "$1",
+          "example": "An unexpected error occurred"
+        }
+      }
     },
     "firstRun_title": {
         "message": "Thank you for installing Privacy Badger!",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -266,14 +266,8 @@
         "description": "Shown in the popup when there is a problem with the user's Privacy Badger extension that we want to encourage the user to tell us about."
     },
     "popup_error_text_low_disk_space_issue": {
-      "message": "Failed to write to extension storage: '$ERROR_TEXT$'. Is your disk low on space? Visit <a href='https://www.privacybadger.org/#faq-I-found-a-bug!-What-do-I-do-now?'>privacybadger.org</a> to learn more.",
-      "description": "Special error message for the 'An unexpected error occurred' text that sometimes occurs on Firefox browsers with low disk space",
-      "placeholders": {
-        "error_text": {
-          "content": "$1",
-          "example": "An unexpected error occurred"
-        }
-      }
+      "message": "<div style='color:red'>Failed to write to extension storage.</div> Is your disk low on space? Visit <a href='https://www.privacybadger.org/#faq-I-found-a-bug!-What-do-I-do-now?'>FAQ</a> to learn more.",
+      "description": "Special error message for the 'An unexpected error occurred' text that sometimes occurs on Firefox browsers with low disk space"
     },
     "firstRun_title": {
         "message": "Thank you for installing Privacy Badger!",

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -84,28 +84,26 @@ function showNagMaybe() {
 
   function _showError(error_text) {
     $('#instruction-text').hide();
-    $('#error-message').text(error_text);
-
-    $('#error-text').show().find('a')
-      .addClass('cta-button')
-      .css({
-        borderRadius: '3px',
-        padding: '5px',
-        display: 'inline-block',
-        width: 'auto',
-      });
 
     // if error is the 'unexpected error occurred' Firefox issue commonly associated with low disk space, show special message
-    if (error_text.includes("An unexpected error occurred")) {
+    if (error_text == "An unexpected error occurred") {
       // replace current error text with this special message
-      $('#error-text').html(chrome.i18n.getMessage("popup_error_text_low_disk_space_issue"));
-      // hide the error message output from appearing down below this special message
-      $('#error-message').hide();
-      $('#error-text').find('a').css({
-        textDecoration: "underline",
-        color: "black",
-        fontWeight: "bold"
-      });
+      $('#error-text').show().html([
+        chrome.i18n.getMessage("popup_error_text_low_disk_space_issue", [error_text]),
+        chrome.i18n.getMessage("learn_more_link", ["<a href='https://privacybadger.org/#I-found-a-bug%21-What-do-I-do-now'>privacybadger.org</a>"]),
+      ].join(" "));
+
+    } else {
+      $('#error-message').text(error_text);
+
+      $('#error-text').show().find('a')
+        .addClass('cta-button')
+        .css({
+          borderRadius: '3px',
+          padding: '5px',
+          display: 'inline-block',
+          width: 'auto',
+        });
     }
 
     $('#fittslaw').on("click", function (e) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -85,13 +85,7 @@ function showNagMaybe() {
   function _showError(error_text) {
     $('#instruction-text').hide();
     $('#error-message').text(error_text);
-    // if error is the 'unexpected error occurred' Firefox issue commonly associated with low disk space, show special message
-    if (error_text.includes("An unexpected error occurred")) {
-      // replace current error text with this special message
-      $('#error-text').html(chrome.i18n.getMessage("popup_error_text_low_disk_space_issue", [error_text]));
-      // hide the error message output from appearing down below this special message
-      $('#error-message').hide();
-    }
+
     $('#error-text').show().find('a')
       .addClass('cta-button')
       .css({
@@ -100,6 +94,19 @@ function showNagMaybe() {
         display: 'inline-block',
         width: 'auto',
       });
+
+    // if error is the 'unexpected error occurred' Firefox issue commonly associated with low disk space, show special message
+    if (error_text.includes("An unexpected error occurred")) {
+      // replace current error text with this special message
+      $('#error-text').html(chrome.i18n.getMessage("popup_error_text_low_disk_space_issue"));
+      // hide the error message output from appearing down below this special message
+      $('#error-message').hide();
+      $('#error-text').find('a').css({
+        textDecoration: "underline",
+        color: "black",
+        fontWeight: "bold"
+      });
+    }
 
     $('#fittslaw').on("click", function (e) {
       e.preventDefault();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -84,6 +84,20 @@ function showNagMaybe() {
 
   function _showError(error_text) {
     $('#instruction-text').hide();
+    $('#error-message').text(error_text);
+    // if error is the 'unexpected error occurred' Firefox issue commonly associated with low disk space, show special message
+    if (typeof browser == "object" && typeof browser.runtime.getBrowserInfo == "function" && error_text.includes("unexpected")) {
+      browser.runtime.getBrowserInfo().then(function (info) {
+        if (info.name == "Firefox") {
+          // fetch the "learn more" message and populate with our FAQ link
+          let learn_more_link = chrome.i18n.getMessage("learn_more_link", ["<a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?'>our FAQ</a>"]);
+          // replace current error text with this special message
+          $('#error-text').html(chrome.i18n.getMessage("popup_error_text_low_disk_space_issue", [error_text, learn_more_link]));
+          // hide the error message output from appearing down below this special message
+          $('#error-message').hide();
+        }
+      });
+    }
     $('#error-text').show().find('a')
       .addClass('cta-button')
       .css({
@@ -92,7 +106,6 @@ function showNagMaybe() {
         display: 'inline-block',
         width: 'auto',
       });
-    $('#error-message').text(error_text);
 
     $('#fittslaw').on("click", function (e) {
       e.preventDefault();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -100,8 +100,9 @@ function showNagMaybe() {
         .addClass('cta-button')
         .css({
           borderRadius: '3px',
-          padding: '5px',
           display: 'inline-block',
+          padding: '5px',
+          textDecoration: 'none',
           width: 'auto',
         });
     }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -86,17 +86,11 @@ function showNagMaybe() {
     $('#instruction-text').hide();
     $('#error-message').text(error_text);
     // if error is the 'unexpected error occurred' Firefox issue commonly associated with low disk space, show special message
-    if (typeof browser == "object" && typeof browser.runtime.getBrowserInfo == "function" && error_text.includes("unexpected")) {
-      browser.runtime.getBrowserInfo().then(function (info) {
-        if (info.name == "Firefox") {
-          // fetch the "learn more" message and populate with our FAQ link
-          let learn_more_link = chrome.i18n.getMessage("learn_more_link", ["<a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?'>our FAQ</a>"]);
-          // replace current error text with this special message
-          $('#error-text').html(chrome.i18n.getMessage("popup_error_text_low_disk_space_issue", [error_text, learn_more_link]));
-          // hide the error message output from appearing down below this special message
-          $('#error-message').hide();
-        }
-      });
+    if (error_text.includes("An unexpected error occurred")) {
+      // replace current error text with this special message
+      $('#error-text').html(chrome.i18n.getMessage("popup_error_text_low_disk_space_issue", [error_text]));
+      // hide the error message output from appearing down below this special message
+      $('#error-message').hide();
     }
     $('#error-text').show().find('a')
       .addClass('cta-button')

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -5,14 +5,6 @@ body {
     width: 100%;
 }
 
-body.options a:not(.ui-tabs-anchor):not(.honeybadgerPowered):not(.removeOrigin) {
-    text-decoration: underline;
-}
-body.options a:hover:not(.ui-tabs-anchor):not(.honeybadgerPowered):not(.removeOrigin),
-body.options a:focus:not(.ui-tabs-anchor):not(.honeybadgerPowered):not(.removeOrigin) {
-    color: #f06a0a;
-}
-
 h1 {
     font-size: 17px;
     font-weight: bold;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -48,9 +48,12 @@ body#main {
     src: url("./fonts/Chunk.ttf");
 }
 
-a { text-decoration: none }
-
-a:hover { color: #ec9329 }
+a, a:visited {
+    color: #222;
+}
+a:hover {
+    color: #f06a0a;
+}
 
 button {
     /* needed for Firefox */
@@ -119,13 +122,14 @@ button {
     background: url('/icons/badger-pin.png') no-repeat;
 }
 
-.removeOrigin {
+a.removeOrigin {
     float: right;
     margin-right: 0;
     width: 10px;
+    text-decoration: none;
 }
-.removeOrigin:hover {
-    color: red;
+a.removeOrigin:hover {
+    color: red !important;
 }
 
 #blockedResources .breakage-warning {
@@ -407,17 +411,21 @@ div.overlay.active {
 #report-terms {
     margin: 10px 0 !important;
 }
-.overlay_close {
+a.overlay_close {
   display: inline-block;
   float: right;
   background: none;
   border: 0;
   font-size: 1.4em;
   color: #ccc;
+  text-decoration: none;
 }
-.overlay_close:before {
+a.overlay_close:before {
   content: '\2716';
   margin: 4px;
+}
+a.overlay_close:hover {
+    color: #f06a0a;
 }
 #share_output {
   display: block;
@@ -546,7 +554,14 @@ div.overlay.active {
     :root {
         color-scheme: dark;
     }
-    
+
+    a, a:visited {
+        color: #ddd;
+    }
+    a:hover {
+        color: #f06a0a;
+    }
+
     body, #instruction, .key {
         background-color: #333;
         color: #ddd;


### PR DESCRIPTION
Related to #2750 and #2804

This adds a line into the block of error text that users get in the popup, and creates another link to direct users to the FAQ entry on the website where we describe how to fix the common memory error they see and otherwise get an unhelpful "UNEXPECTED ERROR OCCURRED" message.

Hopefully we can remove this and the other related minor fixes in the future when this is no longer an issue for Firefox users with low disk space.

