### PR TITLE
Store some additional tracker data in tracking_map

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1261,7 +1261,7 @@ Badger.prototype = {
 
     // The order of these keys is also the order in which they should be imported.
     // It's important that snitch_map be imported before action_map (#1972)
-    ["snitch_map", "action_map", "settings_map"].forEach(function (key) {
+    ["snitch_map", "action_map", "settings_map", "tracking_map"].forEach(function (key) {
       if (utils.hasOwn(data, key)) {
         self.storage.getStore(key).merge(data[key]);
       }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -267,9 +267,7 @@ HeuristicBlocker.prototype = {
 
             // record pixel cookie sharing
             badger.storage.recordTrackingDetails(
-              request_base,
-              window.extractHostFromURL(tab_url),
-              'pixelcookieshare');
+              request_base, tab_base, 'pixelcookieshare');
 
             return;
           }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -267,7 +267,7 @@ HeuristicBlocker.prototype = {
 
             // record pixel cookie sharing
             badger.storage.recordTrackingDetails(
-              request_host,
+              request_base,
               window.extractHostFromURL(tab_url),
               'pixelcookieshare');
 

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -194,6 +194,8 @@ HeuristicBlocker.prototype = {
     const TRACKER_ENTROPY_THRESHOLD = 33,
       MIN_STR_LEN = 8;
 
+    let self = this;
+
     for (let p of searchParams) {
       let key = p[0],
         value = p[1];
@@ -261,7 +263,14 @@ HeuristicBlocker.prototype = {
             log("Found high-entropy cookie share from", tab_base, "to", request_host,
               ":", entropy, "bits\n  cookie:", cookie.name, '=', cookie.value,
               "\n  arg:", key, "=", value, "\n  substring:", s);
-            this._recordPrevalence(request_host, request_base, tab_base);
+            self._recordPrevalence(request_host, request_base, tab_base);
+
+            // record pixel cookie sharing
+            badger.storage.recordTrackingDetails(
+              request_host,
+              window.extractHostFromURL(tab_url),
+              'pixelcookieshare');
+
             return;
           }
         }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -24,7 +24,7 @@ window.SLIDERS_DONE = false;
 const TOOLTIP_CONF = {
   maxWidth: 400
 };
-const USER_DATA_EXPORT_KEYS = ["action_map", "snitch_map", "settings_map"];
+const USER_DATA_EXPORT_KEYS = ["action_map", "snitch_map", "settings_map", "tracking_map"];
 
 let i18n = chrome.i18n;
 
@@ -318,8 +318,8 @@ function parseUserDataFile(storageMapsList) {
     return alert(i18n.getMessage("invalid_json"));
   }
 
-  // validate by checking we have the same keys in the import as in the export
-  if (JSON.stringify(Object.keys(lists).sort()) != JSON.stringify(USER_DATA_EXPORT_KEYS.sort())) {
+  // validate keys (all keys must be known)
+  if (Object.keys(lists).some(key => !USER_DATA_EXPORT_KEYS.includes(key))) {
     return alert(i18n.getMessage("invalid_json"));
   }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -310,22 +310,22 @@ function importTrackerList() {
  * @param {String} storageMapsList data from JSON file that user provided
  */
 function parseUserDataFile(storageMapsList) {
-  let lists;
+  let data;
 
   try {
-    lists = JSON.parse(storageMapsList);
+    data = JSON.parse(storageMapsList);
   } catch (e) {
     return alert(i18n.getMessage("invalid_json"));
   }
 
-  // validate keys (all keys must be known)
-  if (Object.keys(lists).some(key => !USER_DATA_EXPORT_KEYS.includes(key))) {
+  // validate keys ("action_map" and "snitch_map" are required)
+  if (!['action_map', 'snitch_map'].every(i => utils.hasOwn(data, i))) {
     return alert(i18n.getMessage("invalid_json"));
   }
 
   chrome.runtime.sendMessage({
     type: "mergeUserData",
-    data: lists
+    data
   }, () => {
     alert(i18n.getMessage("import_successful"));
     location.reload();

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -475,11 +475,17 @@ BadgerPen.prototype = {
       dot_base = '.' + base_domain,
       actionMap = self.getStore('action_map'),
       actions = actionMap.getItemClones(),
-      snitchMap = self.getStore('snitch_map');
+      snitchMap = self.getStore('snitch_map'),
+      trackingMap = self.getStore('tracking_map');
 
     if (snitchMap.getItem(base_domain)) {
       log("Removing %s from snitch_map", base_domain);
       snitchMap.deleteItem(base_domain);
+    }
+
+    if (trackingMap.getItem(base_domain)) {
+      log("Removing %s from tracking_map", base_domain);
+      trackingMap.deleteItem(base_domain);
     }
 
     for (let domain in actions) {

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -146,7 +146,7 @@ BadgerPen.prototype = {
 
     // logs what kind of tracking was observed:
     // {
-    //   <tracker_fqdn>: {
+    //   <tracker_base>: {
     //     <site_fqdn>: {
     //       <tracking_type>: true,
     //       ...
@@ -509,15 +509,15 @@ BadgerPen.prototype = {
   /**
    * Simplifies updating tracking_map.
    */
-  recordTrackingDetails: function (tracker_host, site_host, tracking_type) {
+  recordTrackingDetails: function (tracker_base, site_host, tracking_type) {
     let self = this,
       trackingDataStore = self.getStore('tracking_map'),
-      entry = trackingDataStore.getItem(tracker_host) || {};
+      entry = trackingDataStore.getItem(tracker_base) || {};
     if (!utils.hasOwn(entry, site_host)) {
       entry[site_host] = {};
     }
     entry[site_host][tracking_type] = true;
-    trackingDataStore.setItem(tracker_host, entry);
+    trackingDataStore.setItem(tracker_base, entry);
   }
 };
 
@@ -713,11 +713,11 @@ BadgerStorage.prototype = {
       }
 
     } else if (self.name == "tracking_map") {
-      for (let tracker_host in mapData) {
-        for (let site_host in mapData[tracker_host]) {
-          for (let tracking_type in mapData[tracker_host][site_host]) {
+      for (let tracker_base in mapData) {
+        for (let site_host in mapData[tracker_base]) {
+          for (let tracking_type in mapData[tracker_base][site_host]) {
             badger.storage.recordTrackingDetails(
-              tracker_host, site_host, tracking_type);
+              tracker_base, site_host, tracking_type);
           }
         }
       }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -147,7 +147,7 @@ BadgerPen.prototype = {
     // logs what kind of tracking was observed:
     // {
     //   <tracker_base>: {
-    //     <site_fqdn>: {
+    //     <site_base>: {
     //       <tracking_type>: true,
     //       ...
     //     },
@@ -509,14 +509,14 @@ BadgerPen.prototype = {
   /**
    * Simplifies updating tracking_map.
    */
-  recordTrackingDetails: function (tracker_base, site_host, tracking_type) {
+  recordTrackingDetails: function (tracker_base, site_base, tracking_type) {
     let self = this,
       trackingDataStore = self.getStore('tracking_map'),
       entry = trackingDataStore.getItem(tracker_base) || {};
-    if (!utils.hasOwn(entry, site_host)) {
-      entry[site_host] = {};
+    if (!utils.hasOwn(entry, site_base)) {
+      entry[site_base] = {};
     }
-    entry[site_host][tracking_type] = true;
+    entry[site_base][tracking_type] = true;
     trackingDataStore.setItem(tracker_base, entry);
   }
 };
@@ -714,10 +714,10 @@ BadgerStorage.prototype = {
 
     } else if (self.name == "tracking_map") {
       for (let tracker_base in mapData) {
-        for (let site_host in mapData[tracker_base]) {
-          for (let tracking_type in mapData[tracker_base][site_host]) {
+        for (let site_base in mapData[tracker_base]) {
+          for (let tracking_type in mapData[tracker_base][site_base]) {
             badger.storage.recordTrackingDetails(
-              tracker_base, site_host, tracking_type);
+              tracker_base, site_base, tracking_type);
           }
         }
       }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -715,8 +715,17 @@ BadgerStorage.prototype = {
       }
 
     } else if (self.name == "tracking_map") {
+      let snitchMap = badger.storage.getStore('snitch_map');
       for (let tracker_base in mapData) {
+        // merge only if we have a corresponding snitch_map entry
+        let snitchItem = snitchMap.getItem(tracker_base);
+        if (!snitchItem) {
+          continue;
+        }
         for (let site_base in mapData[tracker_base]) {
+          if (!snitchItem.includes(site_base)) {
+            continue;
+          }
           for (let tracking_type of mapData[tracker_base][site_base]) {
             badger.storage.recordTrackingDetails(
               tracker_base, site_base, tracking_type);

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -147,10 +147,10 @@ BadgerPen.prototype = {
     // logs what kind of tracking was observed:
     // {
     //   <tracker_base>: {
-    //     <site_base>: {
-    //       <tracking_type>: true,
+    //     <site_base>: [
+    //       <tracking_type>, // "canvas" or "pixelcookieshare"
     //       ...
-    //     },
+    //     ],
     //     ...
     //   },
     //   ...
@@ -514,9 +514,11 @@ BadgerPen.prototype = {
       trackingDataStore = self.getStore('tracking_map'),
       entry = trackingDataStore.getItem(tracker_base) || {};
     if (!utils.hasOwn(entry, site_base)) {
-      entry[site_base] = {};
+      entry[site_base] = [];
     }
-    entry[site_base][tracking_type] = true;
+    if (!entry[site_base].includes(tracking_type)) {
+      entry[site_base].push(tracking_type);
+    }
     trackingDataStore.setItem(tracker_base, entry);
   }
 };
@@ -715,7 +717,7 @@ BadgerStorage.prototype = {
     } else if (self.name == "tracking_map") {
       for (let tracker_base in mapData) {
         for (let site_base in mapData[tracker_base]) {
-          for (let tracking_type in mapData[tracker_base][site_base]) {
+          for (let tracking_type of mapData[tracker_base][site_base]) {
             badger.storage.recordTrackingDetails(
               tracker_base, site_base, tracking_type);
           }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -630,6 +630,10 @@ function recordFingerprinting(tab_id, msg) {
           if (action) {
             badger.logThirdPartyOriginOnTab(tab_id, script_host, action);
           }
+
+          // record canvas fingerprinting
+          badger.storage.recordTrackingDetails(
+            script_host, document_host, 'canvas');
         }
       }
       // This is a canvas write

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -621,9 +621,11 @@ function recordFingerprinting(tab_id, msg) {
           scriptData.canvas.fingerprinting = true;
           log(script_host, 'caught fingerprinting on', document_host);
 
+          let document_base = window.getBaseDomain(document_host);
+
           // mark this as a strike
           badger.heuristicBlocking.updateTrackerPrevalence(
-            script_host, script_base, window.getBaseDomain(document_host));
+            script_host, script_base, document_base);
 
           // log for popup
           let action = checkAction(tab_id, script_host);
@@ -633,7 +635,7 @@ function recordFingerprinting(tab_id, msg) {
 
           // record canvas fingerprinting
           badger.storage.recordTrackingDetails(
-            script_base, document_host, 'canvas');
+            script_base, document_base, 'canvas');
         }
       }
       // This is a canvas write

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -633,7 +633,7 @@ function recordFingerprinting(tab_id, msg) {
 
           // record canvas fingerprinting
           badger.storage.recordTrackingDetails(
-            script_host, document_host, 'canvas');
+            script_base, document_host, 'canvas');
         }
       }
       // This is a canvas write

--- a/tests/selenium/cookie_sharing_test.py
+++ b/tests/selenium/cookie_sharing_test.py
@@ -46,8 +46,8 @@ class PixelTrackingTest(pbtest.PBSeleniumTest):
             "Failed to detect tracking")
 
         # check that we detected pixel cookie sharing specifically
-        assert self.get_badger_storage('tracking_map')\
-            .get(TRACKER_BASE_DOMAIN, {}).get(SITE_DOMAIN, {}).get("pixelcookieshare"), (
+        assert "pixelcookieshare" in self.get_badger_storage('tracking_map')\
+            .get(TRACKER_BASE_DOMAIN, {}).get(SITE_DOMAIN, []), (
                 "Failed to record pixel cookie sharing detection")
 
 

--- a/tests/selenium/cookie_sharing_test.py
+++ b/tests/selenium/cookie_sharing_test.py
@@ -11,8 +11,8 @@ class PixelTrackingTest(pbtest.PBSeleniumTest):
         - tracking domain is caught by pixel tracking heuristic, snitch map entry is updated
     """
 
-    def get_snitch_map(self):
-        return self.get_badger_storage('snitch_map').get('cloudinary.com')
+    def get_snitch_map_for(self, domain):
+        return self.get_badger_storage('snitch_map').get(domain)
 
     def setUp(self):
         # enable local learning
@@ -21,25 +21,35 @@ class PixelTrackingTest(pbtest.PBSeleniumTest):
         self.find_el_by_css('#local-learning-checkbox').click()
 
     def test_pixel_cookie_sharing(self):
+        SITE_DOMAIN = "efforg.github.io"
         FIXTURE_URL = (
-            "https://efforg.github.io/privacybadger-test-fixtures/html/"
+            f"https://{SITE_DOMAIN}/privacybadger-test-fixtures/html/"
             "pixel_cookie_sharing.html"
         )
+        TRACKER_DOMAIN = "res.cloudinary.com"
+        TRACKER_BASE_DOMAIN = "cloudinary.com"
 
         # clear seed data to prevent any potential false positives
         self.clear_tracker_data()
 
         # load the test fixture without the URL parameter to to verify there is no tracking on the page by default
         self.load_url(FIXTURE_URL)
+
         # check to make sure the domain wasn't logged in snitch map
-        assert not self.get_snitch_map(), (
+        assert not self.get_snitch_map_for(TRACKER_BASE_DOMAIN), (
             "Tracking detected but page expected to have no tracking at this point")
 
         # load the same test fixture, but pass the URL parameter for it to perform pixel cookie sharing
         self.load_url(FIXTURE_URL + "?trackMe=true")
+
         # check to make sure this domain is caught and correctly recorded in snitch map
-        assert ["efforg.github.io"] == self.get_snitch_map(), (
-            "Pixel cookie sharing tracking failed to be detected")
+        assert self.get_snitch_map_for(TRACKER_BASE_DOMAIN) == [SITE_DOMAIN], (
+            "Failed to detect tracking")
+
+        # check that we detected pixel cookie sharing specifically
+        assert self.get_badger_storage('tracking_map')\
+            .get(TRACKER_DOMAIN, {}).get(SITE_DOMAIN, {}).get("pixelcookieshare"), (
+                "Failed to record pixel cookie sharing detection")
 
 
 if __name__ == "__main__":

--- a/tests/selenium/cookie_sharing_test.py
+++ b/tests/selenium/cookie_sharing_test.py
@@ -26,7 +26,6 @@ class PixelTrackingTest(pbtest.PBSeleniumTest):
             f"https://{SITE_DOMAIN}/privacybadger-test-fixtures/html/"
             "pixel_cookie_sharing.html"
         )
-        TRACKER_DOMAIN = "res.cloudinary.com"
         TRACKER_BASE_DOMAIN = "cloudinary.com"
 
         # clear seed data to prevent any potential false positives
@@ -48,7 +47,7 @@ class PixelTrackingTest(pbtest.PBSeleniumTest):
 
         # check that we detected pixel cookie sharing specifically
         assert self.get_badger_storage('tracking_map')\
-            .get(TRACKER_DOMAIN, {}).get(SITE_DOMAIN, {}).get("pixelcookieshare"), (
+            .get(TRACKER_BASE_DOMAIN, {}).get(SITE_DOMAIN, {}).get("pixelcookieshare"), (
                 "Failed to record pixel cookie sharing detection")
 
 

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -46,8 +46,8 @@ class FingerprintingTest(pbtest.PBSeleniumTest):
             "Canvas fingerprinting domain should be reported in the popup")
 
         # check that we detected canvas fingerprinting specifically
-        assert self.get_badger_storage('tracking_map')\
-            .get(FP_BASE_DOMAIN, {}).get(SITE_DOMAIN, {}).get("canvas"), (
+        assert "canvas" in self.get_badger_storage('tracking_map')\
+            .get(FP_BASE_DOMAIN, {}).get(SITE_DOMAIN, []), (
                 "Failed to detect canvas fingerprinting script")
 
     # Privacy Badger overrides a few functions on canvas contexts to check for fingerprinting.

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -10,19 +10,6 @@ import pbtest
 class FingerprintingTest(pbtest.PBSeleniumTest):
     """Tests to make sure fingerprinting detection works as expected."""
 
-    def detected_fingerprinting(self, domain):
-        return self.js("""let tracker_origin = window.getBaseDomain("{}");
-let tabData = chrome.extension.getBackgroundPage().badger.tabData;
-return (
-  Object.keys(tabData).some(tab_id => {{
-    let fpData = tabData[tab_id].fpData;
-    return fpData &&
-      fpData.hasOwnProperty(tracker_origin) &&
-      fpData[tracker_origin].canvas &&
-      fpData[tracker_origin].canvas.fingerprinting === true;
-  }})
-);""".format(domain))
-
     def get_fillText_source(self):
         return self.js("""
             const canvas = document.getElementById("writetome");
@@ -38,11 +25,12 @@ return (
 
     @pytest.mark.flaky(reruns=3, condition=pbtest.shim.browser_type == "firefox")
     def test_canvas_fingerprinting_detection(self):
+        SITE_DOMAIN = "efforg.github.io"
         FIXTURE_URL = (
-            "https://efforg.github.io/privacybadger-test-fixtures/html/"
+            f"https://{SITE_DOMAIN}/privacybadger-test-fixtures/html/"
             "fingerprinting.html"
         )
-        FINGERPRINTING_DOMAIN = "cdn.jsdelivr.net"
+        FP_DOMAIN = "cdn.jsdelivr.net"
 
         # clear pre-trained/seed tracker data
         self.clear_tracker_data()
@@ -53,18 +41,13 @@ return (
         # open popup and check slider state
         self.load_pb_ui(FIXTURE_URL)
         sliders = self.get_tracker_state()
-        self.assertIn(
-            FINGERPRINTING_DOMAIN,
-            sliders['notYetBlocked'],
-            "Canvas fingerprinting domain should be reported in the popup"
-        )
+        assert FP_DOMAIN in sliders['notYetBlocked'], (
+            "Canvas fingerprinting domain should be reported in the popup")
 
         # check that we detected canvas fingerprinting specifically
-        self.load_url(self.options_url)
-        self.assertTrue(
-            self.detected_fingerprinting(FINGERPRINTING_DOMAIN),
-            "Canvas fingerprinting resource was detected as a fingerprinter."
-        )
+        assert self.get_badger_storage('tracking_map')\
+            .get(FP_DOMAIN, {}).get(SITE_DOMAIN, {}).get("canvas"), (
+                "Failed to detect canvas fingerprinting script")
 
     # Privacy Badger overrides a few functions on canvas contexts to check for fingerprinting.
     # In previous versions, it would restore the native function after a single call. Unfortunately,
@@ -80,9 +63,8 @@ return (
         self.load_url(FIXTURE_URL)
 
         # check that we did not restore the native function (should be hipdi polyfill)
-        self.assertNotIn("[native code]", self.get_fillText_source(),
-            "Canvas context fillText is not native version (polyfill has been retained)."
-        )
+        assert "[native code]" not in self.get_fillText_source(), (
+            "Canvas context fillText is not native version (polyfill has been retained)")
 
 
 if __name__ == "__main__":

--- a/tests/selenium/fingerprinting_test.py
+++ b/tests/selenium/fingerprinting_test.py
@@ -31,6 +31,7 @@ class FingerprintingTest(pbtest.PBSeleniumTest):
             "fingerprinting.html"
         )
         FP_DOMAIN = "cdn.jsdelivr.net"
+        FP_BASE_DOMAIN = "jsdelivr.net"
 
         # clear pre-trained/seed tracker data
         self.clear_tracker_data()
@@ -46,7 +47,7 @@ class FingerprintingTest(pbtest.PBSeleniumTest):
 
         # check that we detected canvas fingerprinting specifically
         assert self.get_badger_storage('tracking_map')\
-            .get(FP_DOMAIN, {}).get(SITE_DOMAIN, {}).get("canvas"), (
+            .get(FP_BASE_DOMAIN, {}).get(SITE_DOMAIN, {}).get("canvas"), (
                 "Failed to detect canvas fingerprinting script")
 
     # Privacy Badger overrides a few functions on canvas contexts to check for fingerprinting.


### PR DESCRIPTION
This adds `tracking_map`, a new Badger storage area. It is similar to [`snitch_map`](https://github.com/EFForg/privacybadger/blob/master/doc/DESIGN-AND-ROADMAP.md#data-structures), but instead of tracker base domains pointing to arrays of site base domains, tracker base domains point to objects keyed by site base domains with arrays of detected tracking types for values. For example:

```json
"arkoselabs.com": {
  "cheaptickets.com": [
    "canvas"
  ],
  "expedia.ca": [
    "canvas"
  ],
  "expedia.co.uk": [
    "canvas"
  ]
},

```

For now, just two tracking types are being tracked: `"canvas"` (fingerprinting) and `"pixelcookieshare"`.

Here is a recent 20K site Chrome run: [results.zip](https://github.com/EFForg/privacybadger/files/8557896/results.zip). Let's compare this/bigger scans to [Disconnect's `FingerprintingInvasive` domains](https://github.com/disconnectme/disconnect-tracking-protection/blob/master/descriptions.md) and [Tracker Radar fingerprinters](https://github.com/duckduckgo/tracker-radar/blob/main/docs/FAQ.md#what-does-the-fingerprinting-score-mean).

Should help with #1527 by at least helping us understand the extent of the problem.

Could be followed up by calling out domains that engage in particularly invasive tracking (such as canvas fingeprinting) in the UI (related to #963).

Replaces https://github.com/EFForg/privacybadger/tree/explain-blocking.