### PR TITLE
Add surrogate-based replacement for YouTube JS API

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -340,6 +340,7 @@
             "www.youtube-nocookie.com"
         ],
         "buttonSelectors": [
+            "iframe[src^='//youtube.com/embed/']",
             "iframe[src^='//www.youtube.com/embed/']",
             "iframe[src^='http://www.youtube.com/embed/']",
             "iframe[src^='https://www.youtube.com/embed/']",

--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -124,6 +124,13 @@ const hostnames = {
     ],
     widgetName: "Google reCAPTCHA"
   },
+  'www.youtube.com': {
+    match: MATCH_PREFIX,
+    tokens: [
+      '/iframe_api',
+    ],
+    widgetName: "YouTube"
+  },
 };
 
 /**
@@ -163,6 +170,8 @@ const surrogates = {
 
   '/recaptcha/api.js': 'grecaptcha.js',
   '/recaptcha/enterprise.js': 'grecaptcha_enterprise.js',
+
+  '/iframe_api': 'youtube.js',
 
   'noopjs': 'noop.js'
 };

--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -128,6 +128,7 @@ const hostnames = {
     match: MATCH_PREFIX,
     tokens: [
       '/iframe_api',
+      '/player_api',
     ],
     widgetName: "YouTube"
   },
@@ -172,6 +173,7 @@ const surrogates = {
   '/recaptcha/enterprise.js': 'grecaptcha_enterprise.js',
 
   '/iframe_api': 'youtube.js',
+  '/player_api': 'youtube.js',
 
   'noopjs': 'noop.js'
 };

--- a/src/data/web_accessible_resources/youtube.js
+++ b/src/data/web_accessible_resources/youtube.js
@@ -1,0 +1,104 @@
+(function () {
+    let origOnYouTubeIframeAPIReady,
+        videoIds = [],
+        targets = new Map(),
+        configs = new Map(),
+        surrogatePlayers = new Map();
+
+    class Player {
+        constructor(container, conf) {
+            if (!conf.videoId) {
+                return;
+            }
+
+            let id,
+                target;
+
+            if (Object.prototype.toString.call(container) == "[object String]") {
+                id = container;
+                target = document.getElementById(container);
+            } else {
+                if (container.id) {
+                    id = container.id;
+                } else {
+                    id = "youtube-" + Math.random().toString().replace(".", "");
+                    container.id = id;
+                }
+                target = container;
+            }
+
+            // save references for later
+            videoIds.push(conf.videoId);
+            targets.set(conf.videoId, target);
+            configs.set(target, conf);
+            surrogatePlayers.set(target, this);
+
+            let detail = {
+                type: "widgetFromSurrogate",
+                name: "YouTube",
+                widgetData: {
+                    domId: id,
+                    videoId: conf.videoId
+                }
+            };
+
+            document.dispatchEvent(new CustomEvent("pbSurrogateMessage", { detail }));
+        }
+    }
+
+    // https://developers.google.com/youtube/iframe_api_reference
+    window.YT = {
+        loaded: 1,
+        Player,
+        PlayerState: {
+            UNSTARTED: -1,
+            ENDED: 0,
+            PLAYING: 1,
+            PAUSED: 2,
+            BUFFERING: 3,
+            CUED: 5
+        }
+    };
+
+    setTimeout(function () {
+        if (typeof window.onYouTubeIframeAPIReady == "function") {
+            origOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady;
+
+            // this will have the page use our Player constructor,
+            // which will message PB to replace the appropriate page element with a placeholder
+            window.onYouTubeIframeAPIReady();
+        }
+
+        // if user clicks Allow in our placeholder, we will load the YT script,
+        // which will then call this function
+        window.onYouTubeIframeAPIReady = function () {
+            if (origOnYouTubeIframeAPIReady) {
+                // restore the original callback, just in case
+                window.onYouTubeIframeAPIReady = origOnYouTubeIframeAPIReady;
+            }
+
+            for (let id of videoIds) {
+                let target = targets.get(id),
+                    config = configs.get(target),
+                    surrogatePlayer = surrogatePlayers.get(target);
+
+                if (!target || !config || !surrogatePlayer) {
+                    continue;
+                }
+
+                // initialize the real Player object with previously
+                // saved parameters; this will create the video element
+                let player = new window.YT.Player(target, config);
+
+                // as the page may have a reference to an instance of our surrogate Player,
+                // make that instance behave as much as possible as the real thing
+                Object.setPrototypeOf(surrogatePlayer, player);
+
+                // clean up
+                targets.delete(id);
+                configs.delete(target);
+                surrogatePlayers.delete(target);
+            }
+        };
+    }, 0);
+}());

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -443,11 +443,38 @@ function createReplacementWidget(widget, elToReplace) {
     "max-height: 600px",
     "z-index: 2147483647",
   ];
-  if (elToReplace.offsetWidth > 0) {
-    styleAttrs.push(`width: ${elToReplace.offsetWidth - 2*border_width}px`);
-  }
-  if (elToReplace.offsetHeight > 0) {
-    styleAttrs.push(`height: ${elToReplace.offsetHeight - 2*border_width}px`);
+  let elToReplaceStyles = window.getComputedStyle(elToReplace);
+  if (elToReplaceStyles.position == "absolute") {
+    styleAttrs.push("position: absolute");
+    for (let prop of ["width", "height", "top", "right", "bottom", "left"]) {
+      let val = elToReplaceStyles[prop];
+      if (!val) {
+        continue;
+      }
+      if (prop == "width" || prop == "height") {
+        if (elToReplaceStyles['box-sizing'] == 'content-box') {
+          if (Number.isInteger(val) || val.endsWith("px")) {
+            val = `${parseInt(val, 10) - 2*border_width}px`;
+          }
+        }
+      }
+      styleAttrs.push(prop + ": " + val);
+    }
+  } else {
+    if (elToReplace.offsetWidth > 0) {
+      if (elToReplaceStyles['box-sizing'] == 'content-box') {
+        styleAttrs.push(`width: ${elToReplace.offsetWidth - 2*border_width}px`);
+      } else {
+        styleAttrs.push(`width: ${elToReplace.offsetWidth}px`);
+      }
+    }
+    if (elToReplace.offsetHeight > 0) {
+      if (elToReplaceStyles['box-sizing'] == 'content-box') {
+        styleAttrs.push(`height: ${elToReplace.offsetHeight - 2*border_width}px`);
+      } else {
+        styleAttrs.push(`height: ${elToReplace.offsetHeight}px`);
+      }
+    }
   }
   widgetFrame.style = styleAttrs.join(" !important;") + " !important";
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -946,6 +946,32 @@ function getSurrogateWidget(name, data, frame_url) {
     };
   }
 
+  if (name == "YouTube") {
+    if (!data || !data.domId || !data.videoId) {
+      return false;
+    }
+
+    let video_id = data.videoId,
+      dom_id = data.domId;
+
+    if (!OK.test(video_id) || !OK.test(dom_id)) {
+      return false;
+    }
+
+    let widget = {
+      name,
+      buttonSelectors: ["#" + dom_id],
+      scriptSelectors: [`script[src^='${CSS.escape("https://www.youtube.com/iframe_api")}']`],
+      replacementButton: {
+        "unblockDomains": ["www.youtube.com"],
+        "type": 4
+      },
+      directLinkUrl: `https://www.youtube.com/embed/${video_id}`
+    };
+
+    return widget;
+  }
+
   return false;
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -961,7 +961,10 @@ function getSurrogateWidget(name, data, frame_url) {
     let widget = {
       name,
       buttonSelectors: ["#" + dom_id],
-      scriptSelectors: [`script[src^='${CSS.escape("https://www.youtube.com/iframe_api")}']`],
+      scriptSelectors: [
+        `script[src^='${CSS.escape("https://www.youtube.com/iframe_api")}']`,
+        `script[src^='${CSS.escape("https://www.youtube.com/player_api")}']`
+      ],
       replacementButton: {
         "unblockDomains": ["www.youtube.com"],
         "type": 4


### PR DESCRIPTION
Fixes #2849. Follows up on #2805 and #2280.

To be followed up with another round of reviewing error reports and fixing the major remaining issues so that we can remove YouTube from the yellowlist (#1593). Should also look into handling `youtube-nocookie.com`.

Working YT JS API examples:

- https://www.aljazeera.com/program/talk-to-al-jazeera/2022/9/16/iran-raisi-no-benefit-in-direct-nuclear-negotiations-with-us
- https://www.huffpost.com/entry/trevor-noah-scheme-voter-suppression_n_5bc99e6fe4b0d38b5876e1c6
- https://www.milieucentraal.nl/minder-afval/afval-scheiden/tips-voor-een-schone-gft-bak/ (scroll to bottom, video uses a custom play/pause control that calls `YT.Player` API methods)
- https://theprovince.com/category/hot-topics/ ("LATEST VIDEOS" on the right)
- https://youglish.com/pronounce/handler/english/us?
- https://www.grundfos.com/de/learn/ecademy/all-courses/alpha2/introduction-to-balancing-in-one-family-homes
- https://returntomonkeyisland.com/trailer
- https://browardcountyfence.com/wood-fence/ (scroll to bottom, does not use `window.onYouTubeIframeAPIReady`)
- https://nationalpost.com/news/world/ivanka-trump-jared-kushner-rent-40000-per-month-condo-while-billionaire-bunker-home-gets-built
- https://www.theguardian.com/us-news/2021/jan/07/donald-trump-final-13-days-security-threat-politicians-activists-warn (scroll down)
- https://www.theguardian.com/football/video/2022/jun/19/memphis-depay-shows-off-skills-on-dirt-pitch-during-community-football-match-in-ghana-video (multiple YT videos on one page)
- https://www.france24.com/en/asia-pacific/20210428-india-s-covid-19-death-toll-passes-200-000-as-who-says-variant-found-in-17-countries (multiple videos, hero video requires `YT.PlayerState` in surrogate)
- https://kzitem.info/news/rafaa-156-reveals-from-magharebia-about-the-ambitions-of-the-ikhwane-in-the-kabylie-region/0rCamoN9kWSErJg (uses the old `/player_api` endpoint)

Examples with issues:
- https://ed.ted.com/lessons/what-is-schizophrenia-anees-bahji (placeholder shifted down from where it should be)
- https://steamcommunity.com/app/294100/videos/ (blocked `img.youtube.com` thumbnails)

Broken examples:
- https://news.uchicago.edu/story/how-one-scholar-shaped-writing-generations-students
- https://www.ainonline.com/aviation-news/video/charles-alcock-remembers-his-early-days-ain-involving-bourbon-and-gun-ains-50th-anniversary (empty `videoId` in initial `Player` config)
- https://www.vox.com/22362894/which-covid-vaccine-is-better-moderna-vs-pfizer-video (nested frame, lazy loaded)
- https://www.mediapart.fr/journal/france/290321/affaire-myriam-sakhri-la-famille-espere-une-reouverture-de-l-enquete (Embedly)
- https://medium.com/@samuelwestwood/time-saving-things-that-actually-work-trust-me-28461a6f4a41 (nested frame)
- https://www.msn.com/en-us/health/medical/super-flower-blood-moon-and-total-eclipse/vi-AAKoV1K?category=foryou

Non-JS API YT broken examples:
- https://www.esquire.com/entertainment/music/a34633291/heavy-metal-nazi-anti-fascist-movement/ (replacement fails, blocked `img.youtube.com` thumbnails)
- https://kotaku.com/peach-is-a-monster-in-smash-ultimate-pros-say-1831613178
- https://www.colegioalarcon.com/orientablog/videos-mindfulness-por-edades/
- https://apolisgreek.com/
- https://www.diyphotography.net/secret-filming-fast-moving-objects-25-million-frames-per-second-mirrors/
- https://www.borussia.de/de/aktuelles/news/2021-12-21-eberl-ein-turbulentes-und-surreales-jahr (`youtube-nocookie.com`, some sort of z-index (?) issue where replacement happens but our placeholder is covered up by page's own video placeholder)