### PR TITLE
Fix detection of service worker-initiated navigation in Chrome

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1617,7 +1617,7 @@ function dispatcher(request, sender, sendResponse) {
 
 /*************** Event Listeners *********************/
 function startListeners() {
-  chrome.webNavigation.onBeforeNavigate.addListener(onNavigate);
+  chrome.webNavigation.onCommitted.addListener(onNavigate);
 
   chrome.webRequest.onBeforeRequest.addListener(onBeforeRequest, {urls: ["http://*/*", "https://*/*"]}, ["blocking"]);
 


### PR DESCRIPTION
Fixes #2706, fixes #2737 as it appears that `chrome.webNavigation.onCommitted`, unlike `onBeforeNavigate`, does get triggered on service worker-initiated navigation.

Follows up on #2454. We went with `onBeforeNavigate` rather than `onCommitted` there because

>Listening to webNavigation.onBeforeNavigate() events instead of onCommitted() fixes [the "you are offline" scenario]

However, I am now unable to reproduce "you are offline" in Firefox, even when I remove our `chrome.webNavigation` listener entirely.

There should be no change in behavior in Firefox.

