### PR TITLE
Show Google Sign-In "breakage note" tooltip for accounts.google.com

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -160,7 +160,7 @@
         "description": "Tooltip for a warning icon that appears when move a domain slider to 'red' (block) for a domain that was automatically set to 'yellow' (block cookies)."
     },
     "google_signin_tooltip": {
-        "message": "To enable logging in with your Google account:<ol><li>Move this slider right to allow accounts.google.com</li><li>Reload the page</li></ol>",
+        "message": "To enable logging into websites with your Google account, move this slider right, and reload the page",
         "description": "Tooltip for a notification icon that appears next to the slider for accounts.google.com when it is blocked by default."
     },
     "feed_the_badger_title": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -159,6 +159,10 @@
         "message": "Blocking this domain is known to break websites",
         "description": "Tooltip for a warning icon that appears when move a domain slider to 'red' (block) for a domain that was automatically set to 'yellow' (block cookies)."
     },
+    "google_signin_tooltip": {
+        "message": "To enable logging in with your Google account:<ol><li>Move this slider right to allow accounts.google.com</li><li>Reload the page</li></ol>",
+        "description": "Tooltip for a notification icon that appears next to the slider for accounts.google.com when it is blocked by default."
+    },
     "feed_the_badger_title": {
         "message": "Click to return control of this domain to Privacy Badger",
         "description": "Tooltip shown over an undo arrow that appears when you move a domain slider away from its automatic setting."

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -763,6 +763,7 @@ Badger.prototype = {
       blockThreshold: constants.TRACKING_THRESHOLD,
       firstRunTimerFinished: true,
       showLearningPrompt: false,
+      shownBreakageNotes: [],
     };
     for (let key of Object.keys(privateDefaultSettings)) {
       if (!privateStore.hasItem(key)) {

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -159,7 +159,6 @@ let htmlUtils = {
   getOriginHtml: (function () {
 
     const breakage_warning_tooltip = i18n.getMessage('breakage_warning_tooltip'),
-      google_signin_tooltip = i18n.getMessage('google_signin_tooltip'),
       undo_arrow_tooltip = i18n.getMessage('feed_the_badger_title'),
       dnt_icon_url = chrome.runtime.getURL('/icons/dnt-16.png');
 
@@ -169,21 +168,19 @@ let htmlUtils = {
 
       // Get classes for main div.
       let classes = ['clicker'];
-      if (action.startsWith('user')) {
-        classes.push('userset');
-        action = action.slice(5);
-      }
       // show warning when manually blocking a domain
       // that would have been cookieblocked otherwise
       if (show_breakage_warning) {
         classes.push('show-breakage-warning');
       }
-
-      let breakage_note_icon = '';
-      if (origin == "accounts.google.com" && action == constants.BLOCK && document.location.pathname == "/skin/popup.html") {
-        breakage_note_icon = `
-<span class="ui-icon ui-icon-info tooltip breakage-note" title="${google_signin_tooltip}" data-tooltipster='{"contentAsHTML": true}'></span>
-        `.trim();
+      // for explaining how to restore Google Sign-In
+      if (origin == "accounts.google.com" && (action == constants.BLOCK || action == constants.COOKIEBLOCK) && document.location.pathname == "/skin/popup.html") {
+        classes.push('breakage-note');
+      }
+      // manually-set sliders get an undo arrow
+      if (action.startsWith('user')) {
+        classes.push('userset');
+        action = action.slice(5);
       }
 
       // show the DNT icon for DNT-compliant domains
@@ -202,7 +199,6 @@ let htmlUtils = {
 <div class="${classes.join(' ')}" data-origin="${origin}">
   <div class="origin" role="heading" aria-level="4">
     <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}"></span>
-    ${breakage_note_icon}
     <span class="origin-inner tooltip" title="${origin_tooltip}">${dnt_html}${origin}</span>
   </div>
   <a href="" class="removeOrigin">&#10006</a>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -159,6 +159,7 @@ let htmlUtils = {
   getOriginHtml: (function () {
 
     const breakage_warning_tooltip = i18n.getMessage('breakage_warning_tooltip'),
+      google_signin_tooltip = i18n.getMessage('google_signin_tooltip'),
       undo_arrow_tooltip = i18n.getMessage('feed_the_badger_title'),
       dnt_icon_url = chrome.runtime.getURL('/icons/dnt-16.png');
 
@@ -178,6 +179,13 @@ let htmlUtils = {
         classes.push('show-breakage-warning');
       }
 
+      let breakage_note_icon = '';
+      if (origin == "accounts.google.com" && action == constants.BLOCK && document.location.pathname == "/skin/popup.html") {
+        breakage_note_icon = `
+<span class="ui-icon ui-icon-info tooltip breakage-note" title="${google_signin_tooltip}" data-tooltipster='{"contentAsHTML": true}'></span>
+        `.trim();
+      }
+
       // show the DNT icon for DNT-compliant domains
       let dnt_html = '';
       if (action == constants.DNT) {
@@ -194,6 +202,7 @@ let htmlUtils = {
 <div class="${classes.join(' ')}" data-origin="${origin}">
   <div class="origin" role="heading" aria-level="4">
     <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}"></span>
+    ${breakage_note_icon}
     <span class="origin-inner tooltip" title="${origin_tooltip}">${dnt_html}${origin}</span>
   </div>
   <a href="" class="removeOrigin">&#10006</a>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -150,10 +150,12 @@ let htmlUtils = {
 
   /**
    * Generates HTML for given origin.
+   * TODO origin --> domain
    *
    * @param {String} origin Origin to get HTML for.
    * @param {String} action Action for given origin.
-   * @param {Boolean} show_breakage_warning
+   * @param {Boolean} [show_breakage_warning]
+   * @param {Boolean} [show_breakage_note]
    * @returns {String} Origin HTML.
    */
   getOriginHtml: (function () {
@@ -162,7 +164,7 @@ let htmlUtils = {
       undo_arrow_tooltip = i18n.getMessage('feed_the_badger_title'),
       dnt_icon_url = chrome.runtime.getURL('/icons/dnt-16.png');
 
-    return function (origin, action, show_breakage_warning) {
+    return function (origin, action, show_breakage_warning, show_breakage_note) {
       action = escape_html(action);
       origin = escape_html(origin);
 
@@ -173,8 +175,7 @@ let htmlUtils = {
       if (show_breakage_warning) {
         classes.push('show-breakage-warning');
       }
-      // for explaining how to restore Google Sign-In
-      if (origin == "accounts.google.com" && (action == constants.BLOCK || action == constants.COOKIEBLOCK) && document.location.pathname == "/skin/popup.html") {
+      if (show_breakage_note) {
         classes.push('breakage-note');
       }
       // manually-set sliders get an undo arrow

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -500,6 +500,51 @@ function revertDomainControl(event) {
 }
 
 /**
+ * Tooltip that explains how to enable signing into websites with Google.
+ */
+function createBreakageNote(domain, i18n_message_key) {
+  let $slider_allow = $(`#blockedResourcesInner label[for="allow-${domain.replace(/\./g, '-')}"]`);
+
+  // first remove the Allow tooltip so that future tooltipster calls
+  // return the tooltip we want (the breakage note, not Allow)
+  $slider_allow.tooltipster('destroy').tooltipster({
+    autoClose: false,
+    content: chrome.i18n.getMessage(i18n_message_key),
+    functionReady: function (tooltip) {
+      // record that this breakage note was shown
+      chrome.runtime.sendMessage({
+        type: "seenBreakageNote",
+        domain
+      });
+
+      // close on tooltip click/tap
+      $(tooltip.elementTooltip()).on('click', function (e) {
+        e.preventDefault();
+        tooltip.hide();
+      });
+      // also when Report Broken Site or Share overlays get activated
+      $('#error, #share').off('click.breakage-note').on('click.breakage-note', function (e) {
+        e.preventDefault();
+        tooltip.hide();
+      });
+    },
+    interactive: true,
+    position: ['top'],
+    trigger: 'custom',
+    theme: 'tooltipster-badger-breakage-note'
+
+  // now restore the Allow tooltip
+  }).tooltipster(Object.assign({}, htmlUtils.DOMAIN_TOOLTIP_CONF, {
+    content: chrome.i18n.getMessage('domain_slider_allow_tooltip'),
+    multiple: true
+  }));
+
+  if (POPUP_DATA.settings.seenComic && !POPUP_DATA.showLearningPrompt) {
+    $slider_allow.tooltipster('show');
+  }
+}
+
+/**
  * Refresh the content of the popup window
  *
  * @param {Integer} tabId The id of the tab
@@ -553,6 +598,10 @@ function refreshPopup() {
   // show sliders when sliders were shown last
   // or when there is at least one breakage warning
   if (POPUP_DATA.settings.showExpandedTrackingSection || (
+    !POPUP_DATA.shownBreakageNotes.includes('accounts.google.com') && (
+      POPUP_DATA.origins['accounts.google.com'] == constants.BLOCK ||
+      POPUP_DATA.origins['accounts.google.com'] == constants.COOKIEBLOCK)
+  ) || (
     POPUP_DATA.cookieblocked && Object.keys(POPUP_DATA.cookieblocked).some(
       d => POPUP_DATA.origins[d] == constants.USER_BLOCK)
   )) {
@@ -610,6 +659,11 @@ function refreshPopup() {
       let slider_html = htmlUtils.getOriginHtml(origin, action, show_breakage_warning);
       if (show_breakage_warning) {
         printableWarningSliders.push(slider_html);
+      } else if (origin == 'accounts.google.com' &&
+        !POPUP_DATA.shownBreakageNotes.includes('accounts.google.com') &&
+        (action == constants.BLOCK || action == constants.COOKIEBLOCK)
+      ) {
+        printableWarningSliders.unshift(slider_html);
       } else {
         printable.push(slider_html);
       }
@@ -692,6 +746,13 @@ function refreshPopup() {
     // activate tooltips
     $('#blockedResourcesInner .tooltip:not(.tooltipstered)').tooltipster(
       htmlUtils.DOMAIN_TOOLTIP_CONF);
+    if ($printable.hasClass('breakage-note')) {
+      let domain = $printable[0].dataset.origin;
+      if (!POPUP_DATA.shownBreakageNotes.includes(domain)) {
+        // note: there is only one breakage note at this time (Google Sign-In)
+        createBreakageNote(domain, 'google_signin_tooltip');
+      }
+    }
 
     if (printable.length) {
       requestAnimationFrame(renderDomains);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1266,6 +1266,7 @@ function dispatcher(request, sender, sendResponse) {
       origins: trackers,
       settings: badger.getSettings().getItemClones(),
       showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
+      shownBreakageNotes: badger.getPrivateSettings().getItem("shownBreakageNotes"),
       tabHost: tab_host,
       tabId: tab_id,
       tabUrl: request.tabUrl,
@@ -1401,6 +1402,19 @@ function dispatcher(request, sender, sendResponse) {
 
   case "seenLearningPrompt": {
     badger.getPrivateSettings().setItem("showLearningPrompt", false);
+    sendResponse();
+    break;
+  }
+
+  case "seenBreakageNote": {
+    if (request.domain) {
+      let privateStore = badger.getPrivateSettings(),
+        shownBreakageNotes = privateStore.getItem("shownBreakageNotes");
+      if (!shownBreakageNotes.includes(request.domain)) {
+        shownBreakageNotes.push(request.domain);
+      }
+      badger.getPrivateSettings().setItem("shownBreakageNotes", shownBreakageNotes);
+    }
     sendResponse();
     break;
   }

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -128,13 +128,13 @@ button {
     color: red;
 }
 
-#blockedResources .breakage-warning {
+#blockedResources .breakage-warning, #blockedResources .breakage-note {
     color: red;
     display: none;
     font-size: 1.3em;
     margin: 0 2px 2px 0;
 }
-#blockedResources .show-breakage-warning .breakage-warning {
+#blockedResources .show-breakage-warning .breakage-warning, #blockedResources .breakage-note {
     display: inline-block;
 }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -128,13 +128,13 @@ button {
     color: red;
 }
 
-#blockedResources .breakage-warning, #blockedResources .breakage-note {
+#blockedResources .breakage-warning {
     color: red;
     display: none;
     font-size: 1.3em;
     margin: 0 2px 2px 0;
 }
-#blockedResources .show-breakage-warning .breakage-warning, #blockedResources .breakage-note {
+#blockedResources .show-breakage-warning .breakage-warning {
     display: inline-block;
 }
 
@@ -463,6 +463,20 @@ div.overlay.active {
 }
 .tooltipster-sidetip .tooltipster-arrow-border {
     border: none;
+}
+
+.tooltipster-badger-breakage-note.tooltipster-sidetip .tooltipster-box {
+    background-color: #F06A0A;
+    padding: 10px 0;
+}
+.tooltipster-badger-breakage-note.tooltipster-sidetip .tooltipster-content {
+    color: #fefefe;
+    cursor: pointer;
+    font-size: 15px;
+}
+.tooltipster-badger-breakage-note.tooltipster-sidetip .tooltipster-arrow-background {
+    border-top-color: #F06A0A;
+    cursor: pointer;
 }
 
 #firstparty-protections-container {


### PR DESCRIPTION
Should help with #137.

![Screenshot from 2022-11-15 11-05-49](https://user-images.githubusercontent.com/794578/202036531-a0e7bbc0-9d0a-4aa7-a878-2d6158e3412b.png)

The tooltip is shown once, when you first open the popup for a page where Privacy Badger (cookie)blocked `accounts.google.com` by default.

The sliders section will then be open, same as when there are any breakage warnings. The slider for `accounts.google.com` will get shown at the top, before any other sliders. Same as breakage warning sliders, but above them too.

The tooltip stays open while you click (or tap) to move the slider.

You can dismiss the tooltip by clicking on it. There is currently no way to show it again.

We don't do any of this for sliders on the options page.

This could be followed up by adding other breakage notes, perhaps for Twitch (#2540 / #2785).