### PR TITLE
Add newrelic.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -389,6 +389,7 @@ nbcuni.com
 netdna-ssl.com
 nos.netease.com
 nextcloud.com
+newrelic.com
 ngfiles.com
 ngpvan.com
 nosto.com


### PR DESCRIPTION
Hi there! 
I'm an architect working at NewRelic - and noticed that PrivacyBadger is blocking some functionality of our website.

Namely, we're transitioning our authentication from being hosted directly on newrelic.com to using a third-party auth provider. The 3P auth provider loads an HTML/CSS template hosted from our website (foo.newrelic.com). This is being blocked by PrivacyBadger, and when that is blocked, the 3P auth provider errors - leading to customers not being able to signup or authenticate to NewRelic.

I'm uncertain that we'd be able to commit to the [EFF Do Not Track](https://www.eff.org/dnt-policy) policy, however, these are conversations that have started.

I have confirmed that after I add in the `newrelic.com` domain into the "green" allowlist, then the functionality works as expected.


```
**** ACTION_MAP for newrelic.com
newrelic.com {
  "dnt": false,
  "heuristicAction": "block",
  "nextUpdateTime": 0,
  "userAction": ""
}
staging-login.newrelic.com {
  "dnt": false,
  "heuristicAction": "",
  "nextUpdateTime": 1676409632389,
  "userAction": ""
}
**** SNITCH_MAP for newrelic.com
newrelic.com [
  "markmonitor.com",
  "qualtrics.com",
  "nypost.com"
]
```