### PR TITLE
Add tooltips that show where a domain was seen tracking to the list of domains in options

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -7,6 +7,10 @@
         "message": "Privacy Badger automatically learns to block invisible trackers.",
         "description": "Extension description sometimes used by extension stores. See also 'intro_welcome', 'share_base_message' and 'intro_learns' messages."
     },
+    "canvas_fingerprinting": {
+        "message": "canvas fingerprinting",
+        "description": "Canvas fingerprinting is the tracking method described in https://en.wikipedia.org/wiki/Canvas_fingerprinting"
+    },
     "popup_help_button": {
         "message": "Help",
         "description": "Tooltip shown over the question mark button in the upper right corner of the popup."
@@ -551,6 +555,16 @@
     "options_show_not_yet_blocked": {
         "message": "Show domains your Badger hasn't decided yet to block:",
         "description": "Label for a checkbox on the Tracking Domains options page tab. Should match wording used in the 'not_yet_blocked_header' message."
+    },
+    "options_domain_list_sites": {
+        "message": "$DOMAIN$ was seen tracking on the following sites:",
+        "description": "Part of a tooltip available for each domain in the tracking domains list on the options page.",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
     },
     "options_remove_origin_confirm": {
         "message": "Are you sure you want to remove this domain from Privacy Badger?",

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -132,22 +132,6 @@ let htmlUtils = {
   }()),
 
   /**
-   * Get HTML for tracker container.
-   *
-   * @returns {String} HTML for empty tracker container.
-   */
-  getTrackerContainerHtml: function() {
-    return `
-<div class="keyContainer">
-  <div class="key">
-    <img src="/icons/UI-icons-red.svg" class="tooltip" title="${i18n.getMessage("tooltip_block")}"><img src="/icons/UI-icons-yellow.svg" class="tooltip" title="${i18n.getMessage("tooltip_cookieblock")}"><img src="/icons/UI-icons-green.svg" class="tooltip" title="${i18n.getMessage("tooltip_allow")}">
-  </div>
-</div>
-<div id="blockedResourcesInner" class="clickerContainer"></div>
-    `.trim();
-  },
-
-  /**
    * Generates HTML for given origin.
    * TODO origin --> domain
    *

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -290,6 +290,34 @@ let htmlUtils = {
     return (base_minus_tld + '.' + rest_of_it_reversed);
   },
 
+  /**
+   * Checks whether an element is at least partially visible
+   * within its scrollable container.
+   *
+   * @param {Element} elm
+   * @param {Element} container
+   *
+   * @returns {Boolean}
+   */
+  isScrolledIntoView: (elm, container) => {
+    let ctop = container.scrollTop,
+      cbot = ctop + container.clientHeight,
+      etop = elm.offsetTop,
+      ebot = etop + elm.clientHeight;
+
+    // completely in view
+    if (etop >= ctop && ebot <= cbot) {
+      return true;
+    }
+
+    // partially in view
+    if ((etop < ctop && ebot > ctop) || (ebot > cbot && etop < cbot)) {
+      return true;
+    }
+
+    return false;
+  },
+
 };
 
 htmlUtils.escape = escape_html;

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -36,6 +36,7 @@ let htmlUtils = {
 
   // default Tooltipster config
   TOOLTIPSTER_DEFAULTS: {
+    delay: 100,
     // allow per-instance option overriding
     functionInit: function (instance, helper) {
       let dataOptions = helper.origin.dataset.tooltipster;
@@ -54,12 +55,6 @@ let htmlUtils = {
     },
   },
 
-  // Tooltipster config for domain list tooltips
-  DOMAIN_TOOLTIP_CONF: {
-    delay: 100,
-    side: 'bottom',
-  },
-
   /**
    * Gets localized description for given action and origin.
    *
@@ -76,6 +71,10 @@ let htmlUtils = {
       dntTooltip: i18n.getMessage('dnt_tooltip')
     };
     return function (action, origin) {
+      if (action.startsWith('user')) {
+        action = action.slice(5);
+      }
+
       if (action == constants.DNT) {
         return messages.dntTooltip;
       }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -644,12 +644,11 @@ function updateSummary() {
   // if there are no tracking domains
   let allTrackingDomains = Object.keys(OPTIONS_DATA.origins);
   if (!allTrackingDomains || !allTrackingDomains.length) {
-    // hide the number of trackers and slider instructions message
+    // hide the number of trackers message
     $("#options_domain_list_trackers").hide();
 
     // show "no trackers" message
     $("#options_domain_list_no_trackers").show();
-    $("#blockedResources").html('');
     $("#tracking-domains-div").hide();
 
     // activate tooltips
@@ -678,9 +677,6 @@ function updateSummary() {
  */
 function reloadTrackingDomainsTab() {
   updateSummary();
-
-  // Get containing HTML for domain list along with toggle legend icons.
-  $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
 
   // activate tooltips
   $('.tooltip:not(.tooltipstered)').tooltipster(TOOLTIP_CONF);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -778,12 +778,9 @@ function showTrackingDomains(domains, cb) {
 
     let $printable = $(out.splice(0, CHUNK).join(""));
 
-    $printable.appendTo('#blockedResourcesInner');
+    activateDomainListTooltips($printable);
 
-    // activate tooltips
-    // TODO disabled for performance reasons
-    //$('#blockedResourcesInner .tooltip:not(.tooltipstered)').tooltipster(
-    //  htmlUtils.DOMAIN_TOOLTIP_CONF);
+    $printable.appendTo('#blockedResourcesInner');
 
     if (out.length) {
       requestAnimationFrame(renderDomains);
@@ -805,6 +802,30 @@ function showTrackingDomains(domains, cb) {
     window.SLIDERS_DONE = true;
     cb();
   }
+}
+
+/**
+ * Activates fancy tooltips for each row in the list of tracking domains.
+ *
+ * The tooltips over domain names are constructed dynamically
+ * in preparation for fetching and showing extra information
+ * that is not already available on the options page
+ * on mouseenter/touchstart.
+ */
+function activateDomainListTooltips($html) {
+  $html.find('.origin-inner.tooltip').tooltipster({
+    functionBefore: function (tooltip, ev) {
+      let $domainEl = $(ev.origin).parents('.clicker').first(),
+        domain = $domainEl.data('origin');
+      tooltip.content(htmlUtils.getActionDescription(
+        OPTIONS_DATA.origins[domain], domain));
+    }
+  });
+
+  // TODO disabled for performance reasons
+  //$html.find('.breakage-warning.tooltip').tooltipster();
+  //$html.find('.switch-toggle > label.tooltip').tooltipster();
+  //$html.find('.honeybadgerPowered.tooltip').tooltipster();
 }
 
 /**
@@ -846,13 +867,6 @@ function updateOrigin(origin, action, userset) {
   );
 
   htmlUtils.toggleBlockedStatus($clicker, userset, show_breakage_warning);
-
-  // reinitialize the domain tooltip
-  // TODO disabled for performance reasons
-  //$clicker.find('.origin-inner').tooltipster('destroy');
-  //$clicker.find('.origin-inner').attr(
-  //  'title', htmlUtils.getActionDescription(action, origin));
-  //$clicker.find('.origin-inner').tooltipster(htmlUtils.DOMAIN_TOOLTIP_CONF);
 }
 
 /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -974,6 +974,8 @@ function removeOrigin(event) {
     OPTIONS_DATA.origins = response.origins;
     // if we removed domains, the summary text may have changed
     updateSummary();
+    // and we probably now have new visible rows in the tracking domains list
+    activateDomainListTooltips();
   });
 }
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -759,7 +759,8 @@ function showTrackingDomains(domains, cb) {
   }
 
   window.SLIDERS_DONE = false;
-  $('#tracking-domains-div').css('visibility', 'hidden');
+  $('#tracking-domains-filters').hide();
+  $('#blockedResources').hide();
   $('#tracking-domains-loader').show();
 
   domains = htmlUtils.sortDomains(domains);
@@ -787,7 +788,8 @@ function showTrackingDomains(domains, cb) {
       requestAnimationFrame(renderDomains);
     } else {
       $('#tracking-domains-loader').hide();
-      $('#tracking-domains-div').css('visibility', 'visible');
+      $('#tracking-domains-filters').show();
+      $('#blockedResources').show();
 
       if ($('#blockedResourcesInner').is(':visible')) {
         activateDomainListTooltips();
@@ -804,7 +806,7 @@ function showTrackingDomains(domains, cb) {
     requestAnimationFrame(renderDomains);
   } else {
     $('#tracking-domains-loader').hide();
-    $('#tracking-domains-div').css('visibility', 'visible');
+    $('#tracking-domains-filters').show();
     window.SLIDERS_DONE = true;
     cb();
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -647,6 +647,7 @@ function refreshPopup() {
 
   if (!originsArr.length) {
     // show "no trackers" message
+    $('#blockedResources').hide();
     $("#instructions-no-trackers").show();
 
     if (POPUP_DATA.settings.learnLocally && POPUP_DATA.settings.showNonTrackingDomains) {
@@ -728,11 +729,6 @@ function refreshPopup() {
         htmlUtils.getOriginHtml(nonTracking[i], constants.NO_TRACKING)
       );
     }
-  }
-
-  if (printable.length) {
-    // get containing HTML for domain list along with toggle legend icons
-    $("#blockedResources")[0].innerHTML = htmlUtils.getTrackerContainerHtml();
   }
 
   // activate tooltips

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -36,6 +36,10 @@ let BREAKAGE_NOTE_DOMAINS = {
   "accounts.google.com": "google_signin_tooltip" // Google Sign-In
 };
 
+const DOMAIN_TOOLTIP_CONF = {
+  side: 'bottom',
+};
+
 /* if they aint seen the comic*/
 function showNagMaybe() {
   var $nag = $("#instruction");
@@ -553,7 +557,7 @@ function createBreakageNote(domain, i18n_message_key) {
     theme: 'tooltipster-badger-breakage-note'
 
   // now restore the Allow tooltip
-  }).tooltipster(Object.assign({}, htmlUtils.DOMAIN_TOOLTIP_CONF, {
+  }).tooltipster(Object.assign({}, DOMAIN_TOOLTIP_CONF, {
     content: chrome.i18n.getMessage('domain_slider_allow_tooltip'),
     multiple: true
   }));
@@ -767,8 +771,7 @@ function refreshPopup() {
     $printable.appendTo('#blockedResourcesInner');
 
     // activate tooltips
-    $('#blockedResourcesInner .tooltip:not(.tooltipstered)').tooltipster(
-      htmlUtils.DOMAIN_TOOLTIP_CONF);
+    $printable.find('.tooltip:not(.tooltipstered)').tooltipster(DOMAIN_TOOLTIP_CONF);
     if ($printable.hasClass('breakage-note')) {
       let domain = $printable[0].dataset.origin;
       if (!POPUP_DATA.shownBreakageNotes.includes(domain)) {
@@ -822,7 +825,7 @@ function updateOrigin() {
   $clicker.find('.origin-inner').tooltipster('destroy');
   $clicker.find('.origin-inner').attr(
     'title', htmlUtils.getActionDescription(action, origin));
-  $clicker.find('.origin-inner').tooltipster(htmlUtils.DOMAIN_TOOLTIP_CONF);
+  $clicker.find('.origin-inner').tooltipster(DOMAIN_TOOLTIP_CONF);
 
   // persist the change
   saveToggle(origin, action);

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1303,6 +1303,16 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
+  case "getOptionsDomainTooltip": {
+    let base = getBaseDomain(request.domain);
+    sendResponse({
+      base,
+      snitchMap: badger.storage.getStore('snitch_map').getItem(base),
+      trackingMap: badger.storage.getStore('tracking_map').getItem(base)
+    });
+    break;
+  }
+
   case "resetData": {
     badger.storage.clearTrackerData();
     badger.loadSeedData(err => {

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -195,6 +195,29 @@ p, #settingsForm {
     max-height: 400px; /* override popup.css */
 }
 
+/* domain more info tooltips */
+.origin-inner {
+    cursor: pointer;
+    text-decoration: underline dotted #505050;
+    text-underline-offset: 2px;
+}
+.tooltipster-badger-domain-more-info.tooltipster-sidetip .tooltipster-box {
+    padding: 10px 0;
+}
+.tooltipster-badger-domain-more-info.tooltipster-sidetip .tooltipster-content {
+    font-size: 15px;
+}
+.tooltipster-badger-domain-more-info.tooltipster-sidetip .tooltipster-content a,
+.tooltipster-badger-domain-more-info.tooltipster-sidetip .tooltipster-content a:visited {
+    color: #fff;
+}
+.tooltipster-badger-domain-more-info.tooltipster-sidetip .tooltipster-content a:hover  {
+    color: #f06a0a;
+}
+.tooltipster-badger-domain-more-info.tooltipster-sidetip .tooltipster-content ul {
+    padding-inline-start: 25px;
+}
+
 label[for=hide-widgets-select] {
     display: block;
 }

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -114,7 +114,14 @@
                 <input type="checkbox" id="tracking-domains-show-not-yet-blocked">
               </li>
           </ul>
-          <div id="blockedResources"></div>
+          <div id="blockedResources">
+            <div class="keyContainer">
+              <div class="key">
+                <img src="/icons/UI-icons-red.svg" class="tooltip" title="i18n_tooltip_block"><img src="/icons/UI-icons-yellow.svg" class="tooltip" title="i18n_tooltip_cookieblock"><img src="/icons/UI-icons-green.svg" class="tooltip" title="i18n_tooltip_allow">
+              </div>
+            </div>
+            <div id="blockedResourcesInner" class="clickerContainer"></div>
+          </div>
       </div>
     </div>
   </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -137,7 +137,14 @@
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </div>
   </div>
-  <div id="blockedResources" style="display:none"></div>
+  <div id="blockedResources" style="display:none">
+    <div class="keyContainer">
+      <div class="key">
+        <img src="/icons/UI-icons-red.svg" class="tooltip" title="i18n_tooltip_block"><img src="/icons/UI-icons-yellow.svg" class="tooltip" title="i18n_tooltip_cookieblock"><img src="/icons/UI-icons-green.svg" class="tooltip" title="i18n_tooltip_allow">
+      </div>
+    </div>
+    <div id="blockedResourcesInner" class="clickerContainer"></div>
+  </div>
 </div>
 
 <div id="special-browser-page" style="display:none">

--- a/src/tests/tests/htmlutils.js
+++ b/src/tests/tests/htmlutils.js
@@ -9,17 +9,32 @@ QUnit.test("getActionDescription", (assert) => {
     origin = "pbtest.org";
   const tests = [
     {
-      action: "block",
+      action: constants.BLOCK,
       origin,
       expectedResult: getMessage('badger_status_block', origin)
     },
     {
-      action: "cookieblock",
+      action: constants.COOKIEBLOCK,
       origin,
       expectedResult: getMessage('badger_status_cookieblock', origin)
     },
     {
-      action: "allow",
+      action: constants.ALLOW,
+      origin,
+      expectedResult: getMessage('badger_status_allow', origin)
+    },
+    {
+      action: constants.USER_BLOCK,
+      origin,
+      expectedResult: getMessage('badger_status_block', origin)
+    },
+    {
+      action: constants.USER_COOKIEBLOCK,
+      origin,
+      expectedResult: getMessage('badger_status_cookieblock', origin)
+    },
+    {
+      action: constants.USER_ALLOW,
       origin,
       expectedResult: getMessage('badger_status_allow', origin)
     },

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -86,7 +86,7 @@ class OptionsTest(pbtest.PBSeleniumTest):
         except NoSuchElementException:
             self.fail("Tracking origin is not displayed")
 
-    def test_removed_origin_display(self):
+    def test_removing_domain(self):
         """Ensure origin is removed properly."""
         self.clear_tracker_data()
         self.add_domain("pbtest.org", "block")
@@ -94,33 +94,35 @@ class OptionsTest(pbtest.PBSeleniumTest):
         self.load_options_page()
         self.select_domain_list_tab()
 
-        # Remove displayed origin.
-        remove_origin_element = self.find_el_by_xpath(
+        domains = self.driver.find_elements(By.CSS_SELECTOR, 'div.clicker')
+        assert len(domains) == 1, "Should see exactly one domain in the list"
+
+        # remove displayed domain
+        remove_domain_element = self.find_el_by_xpath(
             './/div[@data-origin="pbtest.org"]'
             '//a[@class="removeOrigin"]')
-        remove_origin_element.click()
+        remove_domain_element.click()
 
         # Make sure the alert is present. Otherwise we get intermittent errors.
         WebDriverWait(self.driver, 3).until(EC.alert_is_present())
         self.driver.switch_to.alert.accept()
 
-        # Check that only the 'no trackers' message is displayed.
+        # verify that only the 'no trackers' message is displayed
         try:
             WebDriverWait(self.driver, 5).until(
                 EC.visibility_of_element_located((By.ID, "options_domain_list_no_trackers")))
         except TimeoutException:
-            self.fail("There should be a 'no trackers' message after deleting origin")
+            self.fail("There should be a 'no trackers' message after deleting domain")
 
-        error_message = "Only the 'no trackers' message should be displayed before adding an origin"
+        error_message = "Only the 'no trackers' message should be displayed"
         assert not self.driver.find_element(By.ID, "options_domain_list_trackers").is_displayed(), error_message
 
-        # Check that no origins are displayed.
+        # verify that no domains are displayed
         try:
-            origins = self.driver.find_element(By.ID, "blockedResourcesInner")
+            domains = self.driver.find_elements(By.CSS_SELECTOR, 'div.clicker')
         except NoSuchElementException:
-            origins = None
-        error_message = "Origin should not be displayed after removal"
-        assert origins is None, error_message
+            domains = []
+        assert len(domains) == 0, "No domains should be displayed after removal"
 
     def test_reset_data(self):
         self.load_options_page()


### PR DESCRIPTION
Fixes #1289.

This follows up on #2839 by querying `tracking_map` for canvas fingerprinting.

This also follows up on #2664 by restoring fancy tooltips for the list of tracking domains on the options page.

![Screenshot from 2023-02-24 14-23-55](https://user-images.githubusercontent.com/794578/221272557-ac486a8a-92e6-45cb-ba4a-67e4e546cdd1.png)