### PR TITLE
Fix incorrect detection of various MediaWiki domains

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -654,3 +654,4 @@ zohopublic.com
 zohostatic.com
 zopim.com
 static.miraheze.org
+mediawiki.org

--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -653,3 +653,4 @@ zoho.eu
 zohopublic.com
 zohostatic.com
 zopim.com
+static.miraheze.org

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -5525,10 +5525,13 @@ let multiDomainFirstPartiesArray = [
   ],
   ["wellsfargo.com", "wf.com"],
   ["wetter.com", "tiempo.es", "wettercomassets.com"],
-  ["wikipedia.org", "wikimedia.org", "wikimediafoundation.org", "wiktionary.org",
+  [
+    "wikipedia.org", "wikimedia.org", "wikimediafoundation.org", "wiktionary.org",
     "wikiquote.org", "wikibooks.org", "wikisource.org", "wikinews.org",
     "wikiversity.org", "mediawiki.org", "wikidata.org", "wikivoyage.org",
-    "wmfusercontent.org", "tools.wmflabs.org"],
+    "wmfusercontent.org", "tools.wmflabs.org",
+    "mediawiki.org"
+  ],
   [
     "williams-sonomainc.com",
 

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -5530,7 +5530,6 @@ let multiDomainFirstPartiesArray = [
     "wikiquote.org", "wikibooks.org", "wikisource.org", "wikinews.org",
     "wikiversity.org", "mediawiki.org", "wikidata.org", "wikivoyage.org",
     "wmfusercontent.org", "tools.wmflabs.org",
-    "mediawiki.org"
   ],
   [
     "williams-sonomainc.com",


### PR DESCRIPTION
Reason: static.miraheze.org is not a tracker. It is a lot like Wikimedia's static files. It is being misidentified as a tracker. mediawiki.org is a Wikimedia Foundation domain and shouldn't be identified as a tracker.

matomo.miraheze.org is sort of a tracker, but not as invasive of one. Anyway, it's okay for Matomo to be blocked by Privacy Badger, so I am not adding it to the yellowlist.

login.miraheze.org should NOT get blocked, so see #2879.