### PR TITLE
stripe.com -> js.stripe.com in yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -526,7 +526,7 @@ staticflickr.com
 statuspage.io
 steampowered.com
 streamtheworld.com
-stripe.com
+js.stripe.com
 m.stripe.network
 stripecdn.com
 substack.com


### PR DESCRIPTION
m.stripe.com, q.stripe.com, and r.stripe.com are tracking domains in their entirety, according to uBlock Origin. The only breaking domain is js.stripe.com.