### PR TITLE
Add meta.miraheze.org to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -383,6 +383,7 @@ graph.microsoft.com
 wcpstatic.microsoft.com
 www.microsoft.com
 static.miraheze.org
+meta.miraheze.org
 mixcloud.com
 mlive.com
 mncdn.com


### PR DESCRIPTION
Blocked on publictestwiki.com as a tracker for some reason.