### PR TITLE
Disable Google's Topics API by default

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -403,6 +403,10 @@
         "message": "Disable sending web addresses you visit to Google. This disables suggestions for similar pages when a page can't be found.",
         "description": "(Chrome only) Checkbox label found on the general settings page"
     },
+    "options_disable_floc": {
+        "message": "Disable Google's Topics API",
+        "description": "(Chrome only) Checkbox label on the general settings page."
+    },
     "options_advanced_settings": {
         "message": "Advanced",
         "description": "Subheading on the general settings options page."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -377,59 +377,59 @@
     },
     "show_counter_checkbox": {
         "message": "Show count of trackers",
-        "description": "Checkbox label on the general settings page"
+        "description": "Checkbox label in general settings."
     },
     "options_enable_dnt_checkbox": {
         "message": "Send websites the \"<a href='https://globalprivacycontrol.org/' target='_blank'>Global Privacy Control</a>\" and \"<a href='https://www.eff.org/issues/do-not-track' target='_blank'>Do Not Track</a>\" signals",
-        "description": "Checkbox label for enabling/disabling the Sec-GPC and DNT signals, found on the general settings page"
+        "description": "Checkbox label for toggling GPC and DNT signals, found in general settings."
     },
     "options_dnt_policy_setting": {
         "message": "Check if <a target='_blank' href='https://www.eff.org/privacybadger/faq#What-is-a-third-party-tracker'>third-party domains</a> comply with <a target='_blank' href='https://www.eff.org/dnt-policy'>EFF's Do Not Track policy</a>",
-        "description": "Checkbox label on the general settings page"
+        "description": "Checkbox label in general settings."
     },
     "options_privacy_settings": {
         "message": "Privacy",
-        "description": "Subheading on the general settings options page."
+        "description": "Subheading in general settings."
     },
     "options_disable_hyperlink_auditing": {
         "message": "Prevent sites from tracking which links you click (\"hyperlink auditing\")",
-        "description": "Checkbox label found on the general settings page"
+        "description": "Checkbox label in general settings."
     },
     "options_disable_network_prediction": {
         "message": "Disable prefetching",
-        "description": "Checkbox label found on the general settings page"
+        "description": "Checkbox label in general settings."
     },
     "options_disable_google_nav_error_service": {
         "message": "Disable sending web addresses you visit to Google. This disables suggestions for similar pages when a page can't be found.",
-        "description": "(Chrome only) Checkbox label found on the general settings page"
+        "description": "(Chrome only) Checkbox label in general settings."
     },
     "options_disable_floc": {
         "message": "Disable Google's Topics API",
-        "description": "(Chrome only) Checkbox label on the general settings page."
+        "description": "Checkbox label in general settings. For what this disables, see https://brave.com/web-standards-at-brave/7-googles-topics-api/"
     },
     "options_advanced_settings": {
         "message": "Advanced",
-        "description": "Subheading on the general settings options page."
+        "description": "Subheading in general settings."
     },
     "options_learn_setting": {
         "message": "Learn to block new trackers from your browsing",
-        "description": "Checkbox label on the general settings page"
+        "description": "Checkbox label in general settings."
     },
     "local_learning_warning": {
         "message": "Enabling learning may make you more identifiable to websites",
-        "description": "Tooltip on the general settings page"
+        "description": "Tooltip in general settings."
     },
     "options_show_nontracking_domains_checkbox": {
         "message": "Show domains that don't appear to be tracking you",
-        "description": "Checkbox label on the general settings page. Should match wording used in the 'non_tracker' message."
+        "description": "Checkbox label in general settings. Should match wording used in the 'non_tracker' message."
     },
     "options_incognito_setting": {
         "message": "Learn in Private/Incognito windows",
-        "description": "Checkbox label on the general settings page"
+        "description": "Checkbox label in general settings."
     },
     "options_incognito_warning": {
         "message": "Enabling learning in Private/Incognito windows may leave traces of your private browsing history on your computer. By default, Privacy Badger will block trackers it already knows about in Private/Incognito windows, but it won't learn about new trackers. You might want to enable this option if a lot of your browsing happens in Private/Incognito windows.",
-        "description": "Tooltip on the general settings page"
+        "description": "Tooltip in general settings."
     },
     "disabled_sites": {
         "message": "Disabled Sites",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -749,6 +749,7 @@ Badger.prototype = {
     disableGoogleNavErrorService: true,
     disableHyperlinkAuditing: true,
     disableNetworkPrediction: true,
+    disableTopics: true,
     hideBlockedElements: true,
     learnInIncognito: false,
     learnLocally: false,
@@ -990,6 +991,13 @@ Badger.prototype = {
 
   isCheckingDNTPolicyEnabled: function() {
     return this.getSettings().getItem("checkForDNTPolicy");
+  },
+
+  isTopicsOverwriteEnabled: function () {
+    if (document.browsingTopics) {
+      return this.getSettings().getItem("disableTopics");
+    }
+    return false;
   },
 
   /**

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -164,6 +164,21 @@ function loadOptions() {
       });
   }
 
+  // only show the Topics API override if browser supports it
+  if (document.browsingTopics) {
+    $("#disable-topics").show();
+    $("#disable-topics-checkbox")
+      .prop("checked", OPTIONS_DATA.settings.disableTopics)
+      .on("click", function () {
+        const disableTopics = $("#disable-topics-checkbox").prop("checked");
+
+        chrome.runtime.sendMessage({
+          type: "updateSettings",
+          data: { disableTopics }
+        });
+      });
+  }
+
   $('#local-learning-checkbox')
     .prop("checked", OPTIONS_DATA.settings.learnLocally)
     .on("click", (event) => {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -372,7 +372,18 @@ function onHeadersReceived(details) {
     return;
   }
 
+  // Google's Topics API: opt out all websites from topics generation
   if (details.type == 'main_frame') {
+    if (badger.isTopicsOverwriteEnabled()) {
+      let responseHeaders = details.responseHeaders || [];
+      responseHeaders.push({
+        name: 'permissions-policy',
+        // https://github.com/GoogleChrome/developer.chrome.com/issues/2296#issuecomment-1075478309
+        value: 'interest-cohort=()'
+      });
+      return { responseHeaders };
+    }
+
     return;
   }
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -202,6 +202,15 @@
           </span>
         </label>
       </div>
+      <div class="checkbox" id="disable-topics" style="display:none">
+        <label>
+          <input type="checkbox" id="disable-topics-checkbox">
+          <span>
+            <span class="i18n_options_disable_floc"></span>
+            <a href="https://brave.com/web-standards-at-brave/7-googles-topics-api/" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+          </span>
+        </label>
+      </div>
 
       <h4 class="i18n_options_advanced_settings"></h4>
 


### PR DESCRIPTION
By opting out the user from topics generation on all websites.

Related:
- https://github.com/w3ctag/design-reviews/issues/726#issuecomment-1379908459
- https://techcrunch.com/2023/01/17/privacy-sandbox-topics-api-criticism/

Testing: https://developer.chrome.com/docs/privacy-sandbox/topics/#view-topics-api-information

Follows up on #2762 and ac332574b43b401f7a3c6b7d56a0beb65927d51b.