### PR TITLE
Add Discord CDNs to the yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -166,6 +166,8 @@ ehc.com
 elfsight.com
 api-cdn.embed.ly
 cdn.embedly.com
+cdn.discordapp.com
+media.discordapp.net
 i-cdn.embed.ly
 pp.ephapay.net
 epoq.de


### PR DESCRIPTION
Discord users often (ab)use the CDN for free image hosting on various websites, and both Discord CDNs are currently detected by my Privacy Badger and blocked due to the number of cookies used by Discord, so I'm adding this here to fix the breakage of various images.