### PR TITLE
Block moz-extension CSP reports

### DIFF
--- a/src/tests/tests/background.js
+++ b/src/tests/tests/background.js
@@ -589,3 +589,18 @@ QUnit.test("mergeUserData() clears snitch_map when all items are MDFP", (assert)
   });
 
 }());
+
+QUnit.module("Early-warning checks");
+
+QUnit.test("REQUESTBODY key is Firefox only", (assert) => {
+  let obro = chrome.webRequest.OnBeforeRequestOptions;
+  if (typeof browser == "object" && typeof browser.runtime.getBrowserInfo == "function") {
+    let done = assert.async();
+    browser.runtime.getBrowserInfo().then(function (info) {
+      assert.ok(utils.hasOwn(obro, info.name == "Firefox" ? 'REQUESTBODY' : 'REQUEST_BODY'));
+      done();
+    });
+  } else {
+    assert.ok(utils.hasOwn(obro, 'REQUEST_BODY'));
+  }
+});


### PR DESCRIPTION
Fixes a part of #1793.

Although this blocks all `source-file: "moz-extension"` CSP reports, we still have the issue of some of our scripts being blocked by page CSPs in Firefox.

Note that script surrogates are no longer subject to page CSPs (#2801).

DDG's test page: https://privacy-test-pages.glitch.me/security/csp-report/index.html

#### What does still get broken by page CSPs in Firefox?

Anything [injected into page-level contexts](https://github.com/EFForg/privacybadger/blob/463894198affe6d136a1c14c1e16429442efeaa8/src/js/contentscripts/utils.js#L29-L44) ("main world"). So, `navigator.doNotTrack`, canvas fp. detection, `document.cookie`/localStorage blocking, ...

>if your extension injects a (dynamically generated or static) inline script

&mdash; https://bugzilla.mozilla.org/show_bug.cgi?id=1588957#c13

#### Are there any MV2 workarounds?

Yes, inject page scripts from `web_accessible_resources` or via ["Xray vision"](https://github.com/EFForg/privacybadger/issues/1793#issuecomment-754810244) instead.

https://bugzilla.mozilla.org/show_bug.cgi?id=1591983#c1

#### How will this change with MV3?

TBD