### PR TITLE
Fix navigation-related request attribution

### DIFF
--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -781,10 +781,12 @@ function startListeners() {
 
     // check for cookie tracking if there are any set-cookie headers
     let has_setcookie_header = false;
-    for (let i = 0; i < details.responseHeaders.length; i++) {
-      if (details.responseHeaders[i].name.toLowerCase() == "set-cookie") {
-        has_setcookie_header = true;
-        break;
+    if (details.responseHeaders) {
+      for (let i = 0; i < details.responseHeaders.length; i++) {
+        if (details.responseHeaders[i].name.toLowerCase() == "set-cookie") {
+          has_setcookie_header = true;
+          break;
+        }
       }
     }
     if (has_setcookie_header) {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -552,11 +552,13 @@ function onHeadersReceived(details) {
 /**
  * Event handler when a tab gets removed
  *
- * @param {Integer} tabId Id of the tab
+ * @param {Integer} tab_id Id of the tab
  */
-function onTabRemoved(tabId) {
+function onTabRemoved(tab_id) {
   if (badger.INITIALIZED) {
-    forgetTab(tabId);
+    setTimeout(function () {
+      forgetTab(tab_id);
+    }, 20000);
   }
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -129,6 +129,7 @@ function onBeforeRequest(details) {
     return;
   }
 
+  // TODO !from_current_tab requests shouldn't go through allowedOnTab()
   let action = checkAction(tab_id, request_host, frame_id);
   if (!action) {
     return;
@@ -164,6 +165,10 @@ function onBeforeRequest(details) {
             script_path = script_path.slice(0, qs_start);
           }
           if (utils.hasOwn(fpScripts, script_path)) {
+            if (!from_current_tab) {
+              return { cancel: true };
+            }
+
             badger.tabData.logFpScript(tab_id, request_host, url);
 
             let surrogate = surrogates.getSurrogateUri(url, request_host);
@@ -185,7 +190,7 @@ function onBeforeRequest(details) {
     return;
   }
 
-  if (type == 'script' || sw_request) {
+  if ((type == 'script' || sw_request) && from_current_tab) {
     let surrogate;
 
     if (utils.hasOwn(surrogates.WIDGET_SURROGATES, request_host)) {

--- a/src/lib/webrequestUtils.js
+++ b/src/lib/webrequestUtils.js
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Privacy Badger <https://privacybadger.org/>
+ * Copyright (C) 2023 Electronic Frontier Foundation
+ *
+ * Privacy Badger is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * Privacy Badger is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* globals badger:false */
+
+import utils from "../js/utils.js";
+
+/**
+ * Tries to work around tab ID of -1 for requests
+ * originated by a Service Worker in Chrome.
+ *
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=766433#c13
+ *
+ * @param {Object} details webRequest request/response details object
+ *
+ * @returns {Integer} the tab ID or -1
+ */
+function guessTabIdFromInitiator(details) {
+  if (!details.initiator || details.initiator == "null") {
+    return -1;
+  }
+
+  if (details.tabId != -1 || details.frameId != -1 || details.parentFrameId != -1 || details.type != "xmlhttprequest") {
+    return -1;
+  }
+
+  // ignore trivially first party requests
+  if (details.url.startsWith(details.initiator)) {
+    return -1;
+  }
+
+  if (utils.hasOwn(badger.tabData.tabIdsByInitiator, details.initiator)) {
+    return badger.tabData.tabIdsByInitiator[details.initiator];
+  }
+
+  return -1;
+}
+
+export {
+  guessTabIdFromInitiator,
+};

--- a/tests/selenium/navigation_test.py
+++ b/tests/selenium/navigation_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import unittest
+
+import pbtest
+
+
+class NavigationTest(pbtest.PBSeleniumTest):
+    """Verifies navigation-related fixes and workarounds."""
+
+    def get_trackers(self, url):
+        trackers = self.driver.execute_async_script(
+            "let done = arguments[arguments.length - 1];"
+            "chrome.tabs.query({ url: arguments[0] }, function (tabs) {"
+            "  if (!tabs[0]) {"
+            "    done(null);"
+            "  }"
+            "  chrome.runtime.sendMessage({ type: 'getTabData' }, tabData => {"
+            "    done(tabData[tabs[0].id].trackers);"
+            "  });"
+            "});", url)
+        return trackers
+
+    def test_beacon_attribution(self):
+        FIXTURE_URL = (
+            "https://efforg.github.io/privacybadger-test-fixtures/html/"
+            "beacon.html"
+        )
+        OTHER_SITE_URL = "https://dnt-test.trackersimulator.org/"
+        THIRD_PARTY_HOST = "privacybadger-tests.eff.org"
+
+        self.clear_tracker_data()
+        # enable local learning
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('#local-learning-checkbox').click()
+
+        self.load_url(FIXTURE_URL)
+        # open new window (to avoid clearing badger.tabData) and verify results
+        self.open_window()
+        self.load_url(self.options_url)
+        assert self.get_trackers(FIXTURE_URL) == {}, "beacon should not have fired yet"
+
+        # verify beacon domain is listed after page refresh
+        self.driver.switch_to.window(self.driver.window_handles[-2])
+        self.driver.refresh()
+        self.driver.switch_to.window(self.driver.window_handles[-1]) 
+        assert self.get_trackers(FIXTURE_URL) == {THIRD_PARTY_HOST: "noaction"}, "beacon should have fired"
+
+        # visit a different site (doesn't matter what it is,
+        # just needs to be an http site with a different domain)
+        self.driver.switch_to.window(self.driver.window_handles[-2])
+        self.load_url(OTHER_SITE_URL)
+        # verify no domains are listed
+        self.driver.switch_to.window(self.driver.window_handles[-1])
+        assert self.get_trackers(OTHER_SITE_URL) == {}, "beacon got wrongly attributed to an unrelated site"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/selenium/navigation_test.py
+++ b/tests/selenium/navigation_test.py
@@ -5,6 +5,10 @@ import unittest
 
 import pbtest
 
+from functools import partial
+
+from pbtest import retry_until
+
 
 class NavigationTest(pbtest.PBSeleniumTest):
     """Verifies navigation-related fixes and workarounds."""
@@ -45,7 +49,8 @@ class NavigationTest(pbtest.PBSeleniumTest):
         self.driver.switch_to.window(self.driver.window_handles[-2])
         self.driver.refresh()
         self.driver.switch_to.window(self.driver.window_handles[-1]) 
-        assert self.get_trackers(FIXTURE_URL) == {THIRD_PARTY_HOST: "noaction"}, "beacon should have fired"
+        domains = pbtest.retry_until(partial(self.get_trackers, FIXTURE_URL), times=2)
+        assert domains == {THIRD_PARTY_HOST: "noaction"}, "beacon should have fired"
 
         # visit a different site (doesn't matter what it is,
         # just needs to be an http site with a different domain)


### PR DESCRIPTION
Fixes #1997 (partial fix in Chrome where we're unable to correct out-of-order [requests from nested frames](https://crbug.com/838242#c17)).

Fixes #2692.

Fixes #2198.

Related to https://github.com/EFForg/privacybadger/compare/master...fix-sw-monitoring-chrome. ~~We don't yet handle requests from just-closed tabs (2be5ed12e80a02540fdd9a3329f368dc6191b8e2~~, nor have we consolidated webRequest listeners (1059d34f7894db301acf146b58e3ce11c36ed07f).

Should help with #2234.

Follows up on #2860.

To be followed by #2024.