### PR TITLE
Record third-party beacons as tracking

### DIFF
--- a/doc/DESIGN-AND-ROADMAP.md
+++ b/doc/DESIGN-AND-ROADMAP.md
@@ -39,10 +39,13 @@ Privacy Badger:
    certain parts of first party cookies back to itself using image query
    strings (pixel cookie sharing).
 
+   2d. Observes on which first party origins a given third party
+   uses the [Beacon API].
+
 3. If a third party origin receives a cookie, a supercookie, an image pixel
-   containing first party cookie data, or makes JavaScript fingerprinting API
-   calls on 3 or more first party origins, this is deemed to be "cross site
-   tracking".
+   containing first party cookie data, uses the Beacon API, or makes
+   JavaScript fingerprinting API calls on three or more first party origins,
+   this is deemed to be "cross site tracking".
 4. Typically, cross site trackers are blocked completely; Privacy Badger
    prevents the browser from communicating with them. The exception is if the
    site is on Privacy Badger's "yellow list" (aka the "cookie block list"), in
@@ -74,7 +77,7 @@ Privacy Badger:
 
 #### Further Details
 
-Learning from cookies happens in [`heuristicblocking.js`](../src/js/heuristicblocking.js) [*sic*].
+Learning from cookies and the Beacon API happens in [`heuristicblocking.js`](../src/js/heuristicblocking.js) [*sic*].
 
 Privacy Badger also learns from [fingerprinting](../src/js/contentscripts/fingerprinting.js) and [HTML5 local storage "supercookies"](../src/js/contentscripts/supercookie.js).
 
@@ -230,8 +233,15 @@ in the `navigator` object in the future.
 
 Detection of first to third party cookie sharing via image pixels was added in [#2088](https://github.com/EFForg/privacybadger/issues/2088).
 
+#### Beacon API detection
+
+Added in https://github.com/EFForg/privacybadger/pull/2898.
+
 ### ROADMAP
 
 #### High priority issues
 
 Please see our ["high priority"-labeled issues](https://github.com/EFForg/privacybadger/issues?q=is%3Aissue+is%3Aopen+label%3A%22high+priority%22).
+
+
+[Beacon API]: https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -147,7 +147,7 @@ BadgerPen.prototype = {
     // {
     //   <tracker_base>: {
     //     <site_base>: [
-    //       <tracking_type>, // "canvas" or "pixelcookieshare"
+    //       <tracking_type>, // "beacon", "canvas", or "pixelcookieshare"
     //       ...
     //     ],
     //     ...

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -78,7 +78,7 @@ function onBeforeRequest(details) {
 
   if (tab_id < 0) {
     // TODO may also want to apply this workaround in onBeforeSendHeaders(),
-    // TODO onHeadersReceived() and heuristicBlockingAccounting()
+    // TODO onHeadersReceived() and heuristicBlocking.checkForTrackingCookies()
     tab_id = guessTabIdFromInitiator(details);
     if (tab_id < 0) {
       // TODO we still miss SW requests that show up after on-tab close cleanup
@@ -611,7 +611,7 @@ function onNavigate(details) {
 
   initAllowedWidgets(tab_id, tab_host);
 
-  // initialize tab data bookkeeping used by heuristicBlockingAccounting()
+  // initialize tab data bookkeeping used by heuristicBlocking.checkForTrackingCookies()
   // to avoid missing or misattributing learning
   // when there is no "main_frame" webRequest callback
   // (such as on Service Worker pages)

--- a/tests/selenium/navigation_test.py
+++ b/tests/selenium/navigation_test.py
@@ -49,8 +49,10 @@ class NavigationTest(pbtest.PBSeleniumTest):
         self.driver.switch_to.window(self.driver.window_handles[-2])
         self.driver.refresh()
         self.driver.switch_to.window(self.driver.window_handles[-1]) 
-        domains = pbtest.retry_until(partial(self.get_trackers, FIXTURE_URL), times=2)
-        assert domains == {THIRD_PARTY_HOST: "noaction"}, "beacon should have fired"
+        domains = pbtest.retry_until(partial(self.get_trackers, FIXTURE_URL),
+                                     tester=lambda x: x == "allow",
+                                     times=3)
+        assert domains == {THIRD_PARTY_HOST: "allow"}, "beacon should have fired"
 
         # visit a different site (doesn't matter what it is,
         # just needs to be an http site with a different domain)


### PR DESCRIPTION
New heuristic: all third-party uses of the [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API) are counted as tracking.

Fixes #2024.

This may let us entirely drop pixel cookie sharing detection.