### PR TITLE
Add stonly.com to yellowlist

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -605,6 +605,10 @@ web.sundaysky.com
 www.surveygizmo.com
 surveymonkey.com
 swiftype.com
+stonly.com
+api.stonly.com
+s.stonly.com
+media.stonly.com
 t.me
 public.tableau.com
 cdn.tagcommander.com


### PR DESCRIPTION
Hi!

Stonly's domain (stonly.com) is currently blocked by Privacy Badger.

Stonly helps companies provide personalised guidance to their customers, in the form of guided tours, banners, knowledge bases.

A few example websites where the experience is broken with Privacy Badger:
- [French Post Office help center](https://aide.lidentitenumerique.laposte.fr/kb/fr/) (images are not loading)
- [Online Boat Store Jeanneau](https://www.jeanneau.com/) (the pill at the bottom right is not loading)
- [Canadian Telecom company Telus email setup guide](https://www.telus.com/en/support/article/set-up-email-on-devices) (the embedded guide is not loading)