### PR TITLE
Persist important state in session storage

### DIFF
--- a/src/js/tabdata.js
+++ b/src/js/tabdata.js
@@ -223,7 +223,7 @@ TabData.prototype.saveSession = (function () {
  * @param {Object} data the tab data
  */
 TabData.prototype.set = function (tab_id, data) {
-  this._tabData[tab_id] = data;
+  this._tabData[tab_id] = JSON.parse(JSON.stringify(data));
   this.saveSession();
 };
 

--- a/src/lib/basedomain.js
+++ b/src/lib/basedomain.js
@@ -327,9 +327,22 @@ URI.prototype = {
   }
 };
 
+/**
+ * Given a URL, returns a substring matching
+ * webRequest's details.initiator in Chrome.
+ *
+ * @param {String} url
+ *
+ * @returns {String}
+ */
+function getChromeInitiator(url) {
+  return (new URL('/', url)).toString().slice(0, -1);
+}
+
 export {
   extractHostFromURL,
   getBaseDomain,
+  getChromeInitiator,
   ipAddressToNumber,
   isIPv4,
   isIPv6,


### PR DESCRIPTION
Important state consists of tab and activated widget data.

No-op for now; meant for event pages (Firefox with background.persistent set to `false` in the manifest), or Manifest V3.

Part of https://github.com/EFForg/privacybadger/pull/2579.