### PR TITLE
Avoid unnecessarily reopening the welcome page because of idle background process termination

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -26,3 +26,6 @@ These permissions allow Privacy Badger to use the WebRequest and WebRequestBlock
 
 ## Tabs
 Privacy Badger needs access to the tabs API so that the extension can detect which tab is active and which tabs are simply present in the background. The extension icon, badge and popup update to reflect the state of Privacy Badger. This often requires knowing the tab's URL. For example, updating the icon requires the URL in order to determine whether Privacy Badger should be shown as disabled on that tab. Privacy Badger also uses the tabs API for miscellaneous tasks such as opening or switching to the already open new user welcome page.
+
+## Alarms
+Privacy Badger uses the Alarms API to temporarily ensure the background process does not get terminated as idle when Privacy Badger needs it to perform some longer running asynchronous task. This workaround is used to help reopen the welcome page when it appears that the extension has been restarted because of interaction with the Private/Incognito browsing permision prompt, but not because of idle background process termination.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,6 +11,7 @@
   },
   "incognito": "spanning",
   "permissions": [
+    "alarms",
     "tabs",
     "http://*/*",
     "https://*/*",

--- a/src/skin/js/firstRun.js
+++ b/src/skin/js/firstRun.js
@@ -4,14 +4,15 @@ $(function () {
   $(".scroll-it").smoothScroll();
 
   $(window).scroll(function () {
-    if (!already_set) {
-      if ($(window).scrollTop() > 400) {
-        already_set = true;
-        chrome.runtime.sendMessage({
-          type: "updateSettings",
-          data: { seenComic: true }
-        });
-      }
+    if (already_set) {
+      return;
+    }
+    if ($(window).scrollTop() > 400) {
+      already_set = true;
+      chrome.runtime.sendMessage({
+        type: "updateSettings",
+        data: { seenComic: true }
+      });
     }
   });
 });


### PR DESCRIPTION
Part of #2579.

Follows up on #2798.

Confirmed that adding the `"alarms"` permission does not disable the extension on update pending new permission approval in Chrome using https://github.com/GoogleChromeLabs/extension-update-testing-tool.