### PR TITLE
Handle messages received before (event page or service worker) background is ready

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1035,14 +1035,6 @@ $(function () {
     chrome.runtime.sendMessage({
       type: "getOptionsData",
     }, (response) => {
-      if (!response) {
-        // event page/extension service worker is still starting up, retry
-        // async w/ non-zero delay to avoid locking up the messaging channel
-        setTimeout(function () {
-          getOptionsData();
-        }, 10);
-        return;
-      }
       OPTIONS_DATA = response;
       loadOptions();
     });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -881,14 +881,6 @@ $(function () {
       tabId: tab.id,
       tabUrl: tab.url
     }, (response) => {
-      if (!response) {
-        // event page/extension service worker is still starting up, retry
-        // async w/ non-zero delay to avoid locking up the messaging channel
-        setTimeout(function () {
-          getPopupData(tab);
-        }, 10);
-        return;
-      }
       setPopupData(response);
       refreshPopup();
       init();

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1186,8 +1186,16 @@ function getSurrogateWidget(name, data, frame_url) {
 
 // NOTE: sender.tab is available for content script (not popup) messages only
 function dispatcher(request, sender, sendResponse) {
+  // messages may arrive before Privacy Badger is ready
+  // for example, user clicks to open the popup when the ephemeral background
+  // process is not running; the getPopupData message from the popup causes
+  // the background to start but the background is not yet ready to respond
   if (!badger.INITIALIZED) {
-    return sendResponse();
+    setTimeout(function () {
+      dispatcher(request, sender, sendResponse);
+    }, 50);
+    // indicate this is an async response to chrome.runtime.onMessage
+    return true;
   }
 
   // messages from content scripts are to be treated with greater caution:
@@ -1210,7 +1218,12 @@ function dispatcher(request, sender, sendResponse) {
       "widgetFromSurrogate",
       "widgetReplacementReady",
     ];
-    if (!KNOWN_CONTENT_SCRIPT_MESSAGES.includes(request.type)) {
+    if (KNOWN_CONTENT_SCRIPT_MESSAGES.includes(request.type)) {
+      if (!sender.tab) {
+        console.error("Dropping malformed content script message %o from %s", request, sender.url);
+        return sendResponse();
+      }
+    } else {
       console.error("Rejected unknown message %o from %s", request, sender.url);
       return sendResponse();
     }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -606,14 +606,12 @@ function onHeadersReceived(details) {
 /**
  * Event handler when a tab gets removed
  *
- * @param {Integer} tab_id Id of the tab
+ * @param {Integer} tab_id ID of the tab
  */
 function onTabRemoved(tab_id) {
-  if (badger.INITIALIZED) {
-    setTimeout(function () {
-      forgetTab(tab_id);
-    }, 20000);
-  }
+  setTimeout(function () {
+    forgetTab(tab_id);
+  }, utils.oneSecond() * 20);
 }
 
 /**


### PR DESCRIPTION
Part of #2579.

Follows up on #2883 by expanding the fix to all messages handled by `dispatcher()` (rather than only `"getPopupData"` and `"getOptionsData"`).