### PR TITLE
Fix suffix surrogate lookups for script URLs that contain a hash component

### DIFF
--- a/src/js/surrogates.js
+++ b/src/js/surrogates.js
@@ -69,17 +69,26 @@ function getSurrogateUri(script_url, script_hostname) {
   }
 
   // one or more suffix tokens:
-  // does the script URL (querystring excluded) end with one of these tokens?
+  // does the script URL (querystring and hash excluded) end with one of these tokens?
   case db.MATCH_SUFFIX: {
-    const qs_start = script_url.indexOf('?');
+    const hash_start = script_url.indexOf('#'),
+      qs_start = (hash_start == -1 ?
+        script_url.indexOf('?') :
+        script_url.slice(0, hash_start).indexOf('?'));
 
     for (const token of conf.tokens) {
       // do any of the suffix tokens match the script URL?
       let match = false;
 
       if (qs_start == -1) {
-        if (script_url.endsWith(token)) {
-          match = true;
+        if (hash_start == -1) {
+          if (script_url.endsWith(token)) {
+            match = true;
+          }
+        } else {
+          if (script_url.endsWith(token, hash_start)) {
+            match = true;
+          }
         }
       } else {
         if (script_url.endsWith(token, qs_start)) {

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -243,6 +243,21 @@ QUnit.module("Utils", function (/*hooks*/) {
         expected: false,
         msg: "should not match (token in querystring)"
       },
+      {
+        url: `https://${TEST_FQDN}${TEST_TOKEN}#foo`,
+        expected: true,
+        msg: "ga.js URL should still match regardless of trailing hash"
+      },
+      {
+        url: `https://${TEST_FQDN}${TEST_TOKEN}#?foo=bar`,
+        expected: true,
+        msg: "ga.js URL should still match if the trailing hash contains ?"
+      },
+      {
+        url: `https://${TEST_FQDN}${TEST_TOKEN}?foo=bar#?foo=bar`,
+        expected: true,
+        msg: "ga.js URL with querystring and hash should still match"
+      },
     ];
 
     for (let test of TESTS) {


### PR DESCRIPTION
For example, `https://securepubads.g.doubleclick.net/tag/js/gpt.js#?v=...` on https://www.cbsnews.com/philadelphia/live/.