### PR TITLE
Add Shopify's missing domain

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -587,6 +587,7 @@ securiti.ai
 shopify.com
 shopifycdn.com
 shopifycloud.com
+shopifysvc.com
 shop-pro.jp
 shoprunner.com
 sibforms.com

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -4638,6 +4638,7 @@ let multiDomainFirstPartiesArray = [
     "shopify.in",
     "shopify.nl",
 
+    "shopifysvc.com",
     "shopifycdn.com",
     "shopifyapps.com",
     "shopifycloud.com",


### PR DESCRIPTION
This is the domain used by some Shopify to host services to provide features like address autocomplete, validation, etc.

After reading https://github.com/EFForg/privacybadger/blob/master/doc/yellowlist-criteria.md, I think that we should also add to https://github.com/EFForg/privacybadger/blob/master/src/data/yellowlist.txt#L587-L589 together with the other domains, given that this domain is crucial for the features.

<img width="1492" alt="Screenshot 2023-11-08 at 2 11 39 PM" src="https://github.com/EFForg/privacybadger/assets/4867/08d62835-29ad-4bcf-9df6-f4374ede6b4a">

Related https://github.com/EFForg/privacybadger/pull/2533