### PR TITLE
Upgrade Tweet replacement with surrogate JS API

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -457,7 +457,8 @@
         "domain": "platform.twitter.com",
         "buttonSelectors": [
             "blockquote[class*='twitter-tweet']",
-            "blockquote[class*='twitter-video']"
+            "blockquote[class*='twitter-video']",
+            "iframe[src^='https://platform.twitter.com/embed/Tweet.html']"
         ],
         "scriptSelectors": [
             "script[src='https://platform.twitter.com/widgets.js']",

--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -131,6 +131,13 @@ const hostnames = {
     ],
     widgetName: "Google reCAPTCHA"
   },
+  'platform.twitter.com': {
+    match: MATCH_PREFIX,
+    tokens: [
+      '/widgets.js',
+    ],
+    widgetName: "X (Twitter)"
+  },
   'www.youtube.com': {
     match: MATCH_PREFIX,
     tokens: [
@@ -195,6 +202,8 @@ const surrogates = {
   '/npm/@fingerprintjs/fingerprintjs@3/dist/fp.js': 'fingerprintjs3.js',
   '/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js': 'fingerprintjs3.js',
   '/npm/@fingerprintjs/fingerprintjs@3.3.2/dist/fp.js': 'fingerprintjs3.js',
+
+  '/widgets.js': 'twitter.js',
 
   '/omweb-v1.js': 'noop.js',
 

--- a/src/data/web_accessible_resources/twitter.js
+++ b/src/data/web_accessible_resources/twitter.js
@@ -11,7 +11,10 @@
     window.twttr = {};
     window.twttr.widgets = {};
 
-    window.twttr.ready = function () {
+    window.twttr.ready = function (cb) {
+        if (cb) {
+            return cb(window.twttr);
+        }
         return new Promise(function (resolve) {
             setTimeout(function () {
                 resolve(window.twttr);

--- a/src/data/web_accessible_resources/twitter.js
+++ b/src/data/web_accessible_resources/twitter.js
@@ -1,0 +1,39 @@
+(function () {
+    function requestReplacement() {
+        document.dispatchEvent(new CustomEvent("pbSurrogateMessage", {
+            detail: {
+                type: "widgetFromSurrogate",
+                name: "X (Twitter)"
+            }
+        }));
+    }
+
+    window.twttr = {};
+    window.twttr.widgets = {};
+
+    window.twttr.ready = function () {
+        return new Promise(function (resolve) {
+            setTimeout(function () {
+                resolve(window.twttr);
+            }, 0);
+        });
+    };
+
+    window.twttr.widgets.load = function () {
+        requestReplacement();
+    };
+
+    window.twttr.widgets.createTweet = function (tweet_id, targetEl) { // TODO handle `options` (3rd param)
+        return new Promise(function (resolve) {
+            setTimeout(function () {
+                targetEl.innerHTML = `<blockquote class="twitter-tweet"><a href="https://twitter.com/x/status/${tweet_id}">Loading Tweet ID ${tweet_id} ...</a></blockquote><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>`; // TODO i18n "loading" message
+                requestReplacement();
+                resolve(targetEl.children[0]);
+            }, 0);
+        });
+    };
+    // alias
+    window.twttr.widgets.createTweetEmbed = window.twttr.widgets.createTweet;
+
+    window.twttr.widgets.load();
+}());

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1796,6 +1796,17 @@ function dispatcher(request, sender, sendResponse) {
       break;
     }
 
+    if (request.name == "X (Twitter)") {
+      // no need to build a custom widget,
+      // merely rescan the page for Twitter embeds
+      chrome.tabs.sendMessage(sender.tab.id, {
+        type: "replaceWidget",
+        trackerDomain: "platform.twitter.com",
+        frameId: sender.frameId
+      });
+      return;
+    }
+
     // NOTE: request.name and request.data are not to be trusted
     // https://github.com/w3c/webextensions/issues/57#issuecomment-914491167
     // https://github.com/w3c/webextensions/issues/78#issuecomment-921058071


### PR DESCRIPTION
Following up on #2805 and 4cf05333257536ae0fb93ba7cd1799cc23b02b0c.

https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/overview

## Examples

### Already working and should continue to work

- https://www.theverge.com/2020/9/11/21433228/microsoft-xbox-series-x-hidden-video-phil-spencer-july-2020

### Newly working (alternate embed HTML)

- https://en.defence-ua.com/news/become_known_that_ukrainian_military_has_to_master_american_patriot_ads_in_a_record_time-5471.html

### Newly working (using JS API)

- https://www.srf.ch/news/international/krieg-in-der-ukraine-stoltenberg-fordert-bei-nato-treffen-standhaftigkeit
- https://www.thedrive.com/the-war-zone/ukraine-situation-report-new-ground-based-air-defense-coalition-announced
- https://www.comicsands.com/semicircle-corners-divides-irish-parents-2666363460.html
- https://www.dw.com/en/brazil-bolsonaro-supporters-storm-national-congress/a-64320440?protocol-flip=0

### Still broken

Forums that use a nested frame from https://github.com/s9e/s9e.github.io/blob/master/iframe/2/twitter.min.html:

- https://www.resetera.com/threads/pyoro-leaks-switch-game-announcements-part-3.784745/
- https://buckeyeplanet.com/forum/threads/tosu-recruiting-discussion.648320/page-103#post-3627490

Forum that uses https://api.twitter.com/1/statuses/oembed.json?id=XXX&omit_script=true&callback=jQueryYYY_ZZZ&_=QQQ:

- https://forums.somethingawful.com/showthread.php?threadid=3842990&userid=0&perpage=40&pagenumber=1799

### Broken display

- https://ge.globo.com/blogs/brasil-mundial-fc/post/2023/03/05/jogador-do-psv-faz-gol-com-chute-de-170kmh-assista-se-conseguir.ghtml (Chrome: replacement squished to the point most controls are inaccessible; Firefox: same styling issue when replacement happens but also replacement doesn't seem to happen most of the time, the surrogate API creates tweet markup but it doesn't get replaced)
- https://www.komputerswiat.pl/aktualnosci/nauka-i-technika/starship-zdemolowal-okolice-dantejskie-sceny-po-starcie-statku-wideo/rb0qntz (even if `pulsembed.eu` is unblocked, our replacement is almost completely hidden)