### PR TITLE
Switch to the "<all_urls>" permission in the manifest

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -21,8 +21,8 @@ The blocking version of the WebRequest API allows extensions to modify or block 
 ## WebNavigation
 This API allows extensions to detect when the user navigates from one web page to another. Privacy Badger needs this in order to correctly determine whether each request is a first-party request (to the same domain as the web page) or a third-party request (to somewhere else). This permission allows it to avoid misattributing trackers on special pages such as Service Worker pages.
 
-## http://\*/\* and https://\*/\*
-These permissions allow Privacy Badger to use the WebRequest and WebRequestBlocking permissions on requests to all websites. As described above, Privacy Badger uses these APIs to analyze requests and detect tracking, then modify or block requests to known trackers. No information is ever shared outside of the browser.
+## \<all\_urls\>
+This permission allows Privacy Badger to use the WebRequest and WebRequestBlocking permissions on requests to all websites. As described above, Privacy Badger uses these APIs to analyze requests and detect tracking, then modify or block requests to known trackers. No information is ever shared outside of the browser.
 
 ## Tabs
 Privacy Badger needs access to the tabs API so that the extension can detect which tab is active and which tabs are simply present in the background. The extension icon, badge and popup update to reflect the state of Privacy Badger. This often requires knowing the tab's URL. For example, updating the icon requires the URL in order to determine whether Privacy Badger should be shown as disabled on that tab. Privacy Badger also uses the tabs API for miscellaneous tasks such as opening or switching to the already open new user welcome page.

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -794,7 +794,7 @@ function startListeners() {
     if (badger.INITIALIZED) {
       badger.heuristicBlocking.checkForTrackingCookies(details);
     }
-  }, {urls: ["<all_urls>"]}, extraInfoSpec);
+  }, {urls: ["http://*/*", "https://*/*"]}, extraInfoSpec);
 
   // inspect cookies in incoming headers
   extraInfoSpec = ['responseHeaders'];
@@ -823,7 +823,7 @@ function startListeners() {
     // check for pixel cookie sharing if the response appears to be for an image pixel
     badger.heuristicBlocking.checkForPixelCookieSharing(details);
 
-  }, {urls: ["<all_urls>"]}, extraInfoSpec);
+  }, {urls: ["http://*/*", "https://*/*"]}, extraInfoSpec);
 }
 
 export default {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1877,7 +1877,7 @@ function startListeners() {
   if (utils.hasOwn(chrome.webRequest.OnBeforeRequestOptions, 'REQUESTBODY')) {
     chrome.webRequest.onBeforeRequest.addListener(blockMozCspReports, {
       types: ['csp_report'],
-      urls: ['<all_urls>']
+      urls: ["http://*/*", "https://*/*"]
     }, ['blocking', 'requestBody']);
   }
 
@@ -1921,7 +1921,7 @@ function startListeners() {
   if (utils.hasOwn(chrome.webRequest.OnHeadersReceivedOptions, 'EXTRA_HEADERS')) {
     extraInfoSpec.push('extraHeaders');
   }
-  chrome.webRequest.onHeadersReceived.addListener(onHeadersReceived, {urls: ["<all_urls>"]}, extraInfoSpec);
+  chrome.webRequest.onHeadersReceived.addListener(onHeadersReceived, {urls: ["http://*/*", "https://*/*"]}, extraInfoSpec);
 
   chrome.tabs.onRemoved.addListener(onTabRemoved);
   chrome.tabs.onReplaced.addListener(onTabReplaced);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,10 +14,9 @@
   },
   "incognito": "spanning",
   "permissions": [
+    "<all_urls>",
     "alarms",
     "tabs",
-    "http://*/*",
-    "https://*/*",
     "webNavigation",
     "webRequest",
     "webRequestBlocking",


### PR DESCRIPTION
This updates the manifest to use `"<all_urls>"` instead of wildcard http(s).

This should be a no-op for now, as this updates all `"<all_urls>"` listeners to use wildcard http(s) instead.

To be followed by updating appropriate listeners to also process wildcard ws(s) requests, or perhaps to use `"<all_urls>"` instead. We may also want to add WebSockets request tests. This will resolve PR #2415 and issue #1010.