### PR TITLE
Retry loading local assets when their "successfully loaded" flag isn't set

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -274,14 +274,6 @@ BadgerPen.prototype = {
         }
       }
     });
-
-    if (!badger.getPrivateSettings().getItem('doneLoadingYellowlist')) {
-      badger.storage.forceSync('action_map', function () {
-        badger.storage.forceSync('cookieblock_list', function () {
-          badger.getPrivateSettings().setItem('doneLoadingYellowlist', true);
-        });
-      });
-    }
   },
 
   /**
@@ -293,12 +285,6 @@ BadgerPen.prototype = {
 
     for (let policy_name in hashes) {
       dntPolicyStore.setItem(hashes[policy_name], policy_name);
-    }
-
-    if (!badger.getPrivateSettings().getItem('doneLoadingDntHashes')) {
-      badger.storage.forceSync('dnt_hashes', function () {
-        badger.getPrivateSettings().setItem('doneLoadingDntHashes', true);
-      });
     }
   },
 

--- a/src/tests/lib/qunit_config.js
+++ b/src/tests/lib/qunit_config.js
@@ -7,7 +7,13 @@
 
   // disable storage persistence
   // unit tests shouldn't be able to affect your Badger's storage
-  chrome.storage.local.set = () => {};
+  chrome.storage.local.set = (_, callback) => {
+    if (callback) {
+      setTimeout(function () {
+        callback(null);
+      }, 0);
+    }
+  };
 
   // make it seem like there is nothing in storage
   // unit tests shouldn't read from your Badger's storage either
@@ -18,6 +24,7 @@
         // don't open the new user intro page or load seed data
         private_storage: {
           badgerVersion: chrome.runtime.getManifest().version,
+          doneLoadingSeed: true,
         }
       });
     }, 0);


### PR DESCRIPTION
We currently load seed data from disk only on extension installation and updates. (Yellowlist and EFF's DNT policy hash list only get loaded from disk when they are empty in memory.)

This fixes #2930 by loading seed (and yellowlist and EFF's DNT policy hash list) data from disk on startup whenever its "successfully loaded" flag isn't set. If seed loading gets interrupted by an extension reload (or crash), the flag won't get set, and Privacy Badger will reattempt to load the seed on startup.

Existing installations will reload seed / yellowlist / EFF's DNT policy hash list assets from disk upon first updating to the new version that contains this patch. This will fix any broken installations.