### PR TITLE
Add timing info to log() output

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -38,6 +38,7 @@ import utils from "./utils.js";
  * @param {Boolean} from_qunit don't intercept requests when run by unit tests
  */
 function Badger(from_qunit) {
+  log("Initializing Privacy Badger ...");
   let self = this;
 
   self.isFirstRun = false;
@@ -121,6 +122,7 @@ function Badger(from_qunit) {
       self.runMigrations();
     }
 
+    log("Privacy Badger initialization complete");
     console.log("Privacy Badger is ready to rock!");
     console.log("Set DEBUG=1 to view console messages.");
     self.INITIALIZED = true;

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -17,13 +17,51 @@
 
 window.DEBUG = false;
 
+let time_prev = null,
+  time_total = 0,
+  // make local ref. to avoid problems caused by fake timers on the unit tests page
+  DATE = Date;
+
+function float_fmt(num) {
+  return num.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2
+  });
+}
+
 /**
-* Log a message to the console if debugging is enabled
-*/
+ * Log a message to the console if debugging is enabled
+ */
 function log(/*...*/) {
-  if (window.DEBUG) {
-    console.log.apply(console, arguments);
+  if (!window.DEBUG) {
+    return;
   }
+
+  let time_now = +new DATE,
+    time_diff = "";
+
+  if (time_prev) {
+    time_diff = time_now - time_prev;
+    time_total += time_diff;
+  }
+  time_prev = time_now;
+
+  let args = Array.from(arguments),
+    time_total_fmt = float_fmt(time_total / 1000) + "s",
+    time_diff_fmt = (time_diff ? (time_diff > 999 ? float_fmt(time_diff / 1000) + "s" : time_diff + "ms") : ""),
+    num_spaces = 16 - time_total_fmt.length - 1 - time_diff_fmt.length,
+    spaces_fmt = (num_spaces > 0 ? " ".repeat(num_spaces) : " ");
+
+  if (time_diff > 99) {
+    time_diff_fmt = '%c' + time_diff_fmt + '%c';
+    // insert styles as second and third args
+    args.splice(1, 0, 'color:yellow', 'color:auto');
+  }
+
+  // prepend first arg with timing info
+  args[0] = time_total_fmt + " " + time_diff_fmt + spaces_fmt + args[0];
+
+  console.log.apply(console, args);
 }
 
 export {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -266,7 +266,6 @@ HeuristicBlocker.prototype = {
     // (cookie)block if domain was seen tracking on enough first party domains
     if (firstParties.length >=
         self.storage.getStore('private_storage').getItem('blockThreshold')) {
-      log("blocklisting", tracker_fqdn);
       self.blocklistOrigin(tracker_base, tracker_fqdn);
     }
   }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -408,7 +408,9 @@ BadgerPen.prototype = {
     }
     actionObj[actionType] = action;
 
-    if (window.DEBUG) { // to avoid needless JSON.stringify calls
+    if (window.DEBUG && badger.INITIALIZED) {
+      // to avoid (A) needless JSON.stringify calls
+      // and (B) thousands of messages from loading seed data
       log(msg, domain, actionType, JSON.stringify(action));
     }
     action_map.setItem(domain, actionObj);


### PR DESCRIPTION
This prepends `log()` output with total time elapsed since the first `log()` call as well as with time elapsed since the previous `log()` call, to help with debugging and general development.

Unfortunately, it seems that we can have correct caller line numbers[*], or we can decorate output with arbitrary logic at run time, but we can't have both.

[*] using [`.bind()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind); something like:
```javascript
let log = (function () {
  return Function.prototype.bind.call(console.log, console);
}());
```
