### PR TITLE
Add tracking domains filter that hides (most recent) remotely learned domains

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -563,8 +563,12 @@
         "description": "Dropdown control setting on the Tracking Domains options page tab."
     },
     "options_show_not_yet_blocked": {
-        "message": "Show domains your Badger hasn't decided yet to block:",
-        "description": "Label for a checkbox on the Tracking Domains options page tab. Should match wording used in the 'not_yet_blocked_header' message."
+        "message": "Show domains your Badger hasn't decided yet to block",
+        "description": "Checkbox label on the Tracking Domains tab. Should match wording used in the 'not_yet_blocked_header' message. Only visible when 'learn to block new trackers' is enabled."
+    },
+    "options_hide_in_seed": {
+        "message": "Hide domains present in the latest pre-trained list",
+        "description": "Checkbox label on the Tracking Domains tab. Only visible when 'learn to block new trackers' is enabled."
     },
     "options_domain_list_sites": {
         "message": "$DOMAIN$ was seen tracking on the following sites:",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -442,15 +442,11 @@ Badger.prototype = {
   },
 
   /**
-   * Blocks all widget domains
-   * to ensure that all widgets that could get replaced
-   * do get replaced by default for all users.
+   * @returns {Set}
    */
-  blockWidgetDomains() {
-    let self = this;
-
-    // compile set of widget domains
-    let domains = new Set();
+  getAllWidgetDomains() {
+    let self = this,
+      domains = new Set();
     for (let widget of self.widgetList) {
       for (let domain of widget.domains) {
         if (domain[0] == "*") {
@@ -459,6 +455,17 @@ Badger.prototype = {
         domains.add(domain);
       }
     }
+    return domains;
+  },
+
+  /**
+   * Blocks all widget domains
+   * to ensure that all widgets that could get replaced
+   * do get replaced by default for all users.
+   */
+  blockWidgetDomains() {
+    let self = this,
+      domains = self.getAllWidgetDomains();
 
     // block the domains
     for (let domain of domains) {
@@ -473,7 +480,7 @@ Badger.prototype = {
    * https://github.com/EFForg/privacybadger/issues/2712
    */
   blockPanopticlickDomains() {
-    for (let domain of ["trackersimulator.org", "eviltracker.net"]) {
+    for (let domain of constants.PANOPTICLICK_DOMAINS) {
       this.heuristicBlocking.blocklistOrigin(domain, domain);
     }
   },

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -39,6 +39,8 @@ let exports = {
   MAX_COOKIE_ENTROPY: 12,
 
   DNT_POLICY_CHECK_INTERVAL: 1000, // one second
+
+  PANOPTICLICK_DOMAINS: ["trackersimulator.org", "eviltracker.net"],
 };
 
 exports.BLOCKED_ACTIONS = new Set([

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -779,7 +779,8 @@ function filterTrackingDomains() {
       statusFilter: $statusFilter.val(),
       showNotYetBlocked: show_not_yet_blocked,
       hideInSeed: hide_in_seed,
-      seedBases: OPTIONS_DATA.seedBases
+      seedBases: OPTIONS_DATA.seedBases,
+      seedNotYetBlocked: OPTIONS_DATA.seedNotYetBlocked
     }),
     callback);
 }
@@ -1067,6 +1068,7 @@ $(function () {
       type: "getOptionsData",
     }, (response) => {
       response.seedBases = new Set(response.seedBases);
+      response.seedNotYetBlocked = new Set(response.seedNotYetBlocked);
       OPTIONS_DATA = response;
       loadOptions();
     });

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1439,44 +1439,15 @@ function dispatcher(request, sender, sendResponse) {
       }
     }
 
-    utils.fetchResource(constants.SEED_DATA_LOCAL_URL, function (_, response) {
-      let seedActions,
-        seedBases = new Set(),
-        seedNotYetBlocked = new Set();
-
-      try {
-        seedActions = JSON.parse(response).action_map;
-      } catch (e) { /* ignore */ }
-      if (seedActions) {
-        for (let domain of Object.keys(seedActions)) {
-          let base = getBaseDomain(domain);
-          seedBases.add(base);
-          if (utils.hasOwn(seedActions, base) && seedActions[base] == constants.ALLOW) {
-            seedNotYetBlocked.add(base);
-          }
-        }
-      }
-
-      // also add widget and Panopticlick domains
-      for (let domain of badger.getAllWidgetDomains()) {
-        seedBases.add(getBaseDomain(domain));
-      }
-      for (let domain of constants.PANOPTICLICK_DOMAINS) {
-        seedBases.add(getBaseDomain(domain));
-      }
-
-      sendResponse({
-        cookieblocked,
-        origins: trackers,
-        seedBases: Array.from(seedBases),
-        seedNotYetBlocked: Array.from(seedNotYetBlocked),
-        settings: badger.getSettings().getItemClones(),
-        widgets: badger.widgetList.map(widget => widget.name),
-      });
+    sendResponse({
+      cookieblocked,
+      origins: trackers,
+      settings: badger.getSettings().getItemClones(),
+      widgets: badger.widgetList.map(widget => widget.name),
+      widgetDomains: Array.from(badger.getAllWidgetDomains()),
     });
 
-    // indicate this is an async response to chrome.runtime.onMessage
-    return true;
+    break;
   }
 
   case "getOptionsDomainTooltip": {

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -30,6 +30,7 @@ import { getBaseDomain } from "./basedomain.js";
  *     hasn't yet learned to block.
  *   {Boolean} [hideInSeed] Whether to hide domains found in seed list.
  *   {Set} [seedBases] Required by hideInSeed.
+ *   {Set} [seedNotYetBlocked] Required by hideInSeed.
  *
  * @return {Array} The array of domains.
  */
@@ -41,7 +42,8 @@ function filterDomains(domains, options) {
     status_filter = options.statusFilter,
     show_not_yet_blocked = options.showNotYetBlocked,
     hide_in_seed = options.hideInSeed,
-    seedBases = options.seedBases;
+    seedBases = options.seedBases,
+    seedNotYetBlocked = options.seedNotYetBlocked;
 
   // lower case for case-insensitive matching
   if (search_filter) {
@@ -64,9 +66,24 @@ function filterDomains(domains, options) {
       }
     }
 
-    if (hide_in_seed && seedBases) {
-      if (seedBases.has(domain) || seedBases.has(getBaseDomain(domain))) {
-        return false;
+    if (hide_in_seed && seedBases && seedNotYetBlocked) {
+      // if domain is not-yet-blocked, keep only if
+      // domain and its base are not in seed data
+      if (value == "allow") {
+        if (seedBases.has(domain) || seedBases.has(getBaseDomain(domain))) {
+          return false;
+        }
+      // otherwise, keep if domain and its base are either
+      // not in seed data, or they were not-yet-blocked in seed data
+      } else {
+        if (seedBases.has(domain) && !seedNotYetBlocked.has(domain)) {
+          return false;
+        } else {
+          let base = getBaseDomain(domain);
+          if (seedBases.has(base) && !seedNotYetBlocked.has(base)) {
+            return false;
+          }
+        }
       }
     }
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -28,6 +28,8 @@ import { getBaseDomain } from "./basedomain.js";
  *   {String} [statusFilter] Status: blocked/cookieblocked/allowed
  *   {Boolean} [showNotYetBlocked] Whether to show domains your Badger
  *     hasn't yet learned to block.
+ *   {Boolean} [hideInSeed] Whether to hide domains found in seed list.
+ *   {Set} [seedBases] Required by hideInSeed.
  *
  * @return {Array} The array of domains.
  */
@@ -37,7 +39,9 @@ function filterDomains(domains, options) {
   let search_filter = options.searchFilter,
     type_filter = options.typeFilter,
     status_filter = options.statusFilter,
-    show_not_yet_blocked = options.showNotYetBlocked;
+    show_not_yet_blocked = options.showNotYetBlocked,
+    hide_in_seed = options.hideInSeed,
+    seedBases = options.seedBases;
 
   // lower case for case-insensitive matching
   if (search_filter) {
@@ -56,6 +60,12 @@ function filterDomains(domains, options) {
     if (!show_not_yet_blocked) {
       // hide the not-yet-seen-on-enough-sites potential trackers
       if (value == "allow") {
+        return false;
+      }
+    }
+
+    if (hide_in_seed && seedBases) {
+      if (seedBases.has(domain) || seedBases.has(getBaseDomain(domain))) {
         return false;
       }
     }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -15,32 +15,43 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { getBaseDomain } from "./basedomain.js";
+
 /**
- * Gets array of encountered origins.
+ * Filters the list of tracking domains for display on the options page.
  *
- * @param {Object} origins The starting set of domains to be filtered.
- * @param {String} [filter_text] Text to filter origins with.
- * @param {String} [type_filter] Type: user-controlled/DNT-compliant
- * @param {String} [status_filter] Status: blocked/cookieblocked/allowed
- * @param {Boolean} [show_not_yet_blocked] Whether to show domains your Badger
- * hasn't yet learned to block.
+ * @param {Object} domains The starting set of domains to be filtered.
  *
- * @return {Array} The array of origins.
+ * @param {Object} [options] Could contain the following keys:
+ *   {String} [searchFilter] The text to filter domain names against.
+ *   {String} [typeFilter] Type: user-controlled/DNT-compliant
+ *   {String} [statusFilter] Status: blocked/cookieblocked/allowed
+ *   {Boolean} [showNotYetBlocked] Whether to show domains your Badger
+ *     hasn't yet learned to block.
+ *
+ * @return {Array} The array of domains.
  */
-function getOriginsArray(origins, filter_text, type_filter, status_filter, show_not_yet_blocked) {
-  // Make sure filter_text is lower case for case-insensitive matching.
-  if (filter_text) {
-    filter_text = filter_text.toLowerCase();
+function filterDomains(domains, options) {
+  options = options || {};
+
+  let search_filter = options.searchFilter,
+    type_filter = options.typeFilter,
+    status_filter = options.statusFilter,
+    show_not_yet_blocked = options.showNotYetBlocked;
+
+  // lower case for case-insensitive matching
+  if (search_filter) {
+    search_filter = search_filter.toLowerCase();
   } else {
-    filter_text = "";
+    search_filter = "";
   }
 
   /**
-   * @param {String} origin The origin to test.
-   * @return {Boolean} Does the origin pass filters?
+   * @param {String} domain The domain to test.
+   * @return {Boolean} Does the domain pass filters?
    */
-  function matchesFormFilters(origin) {
-    const value = origins[origin];
+  function matchesFormFilters(domain) {
+    const value = domains[domain];
 
     if (!show_not_yet_blocked) {
       // hide the not-yet-seen-on-enough-sites potential trackers
@@ -78,7 +89,7 @@ function getOriginsArray(origins, filter_text, type_filter, status_filter, show_
     // filter by search text
     // treat spaces as OR operators
     // treat "-" prefixes as NOT operators
-    let textFilters = filter_text.split(" ").filter(i=>i); // remove empties
+    let textFilters = search_filter.split(" ").filter(i=>i); // remove empties
 
     // no text filters, we have a match
     if (!textFilters.length) {
@@ -86,13 +97,13 @@ function getOriginsArray(origins, filter_text, type_filter, status_filter, show_
     }
 
     let positiveFilters = textFilters.filter(i => i[0] != "-"),
-      lorigin = origin.toLowerCase();
+      ldomain = domain.toLowerCase();
 
     // if we have any positive filters, and we don't match any,
     // don't bother checking negative filters
     if (positiveFilters.length) {
       let result = positiveFilters.some(text => {
-        return lorigin.indexOf(text) != -1;
+        return ldomain.indexOf(text) != -1;
       });
       if (!result) {
         return false;
@@ -107,14 +118,13 @@ function getOriginsArray(origins, filter_text, type_filter, status_filter, show_
       if (text[0] != "-" || text == "-") {
         return true;
       }
-      return lorigin.indexOf(text.slice(1)) == -1;
+      return ldomain.indexOf(text.slice(1)) == -1;
     });
   }
 
-  // Include only origins that match given filters.
-  return Object.keys(origins).filter(matchesFormFilters);
+  return Object.keys(domains).filter(matchesFormFilters);
 }
 
 export {
-  getOriginsArray,
+  filterDomains,
 };

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -113,6 +113,13 @@
                 </label>
                 <input type="checkbox" id="tracking-domains-show-not-yet-blocked">
               </li>
+              <li id="hide-in-seed-filter" style="display:none">
+                <label for="tracking-domains-hide-in-seed">
+                  <span class="i18n_options_hide_in_seed"></span>
+                  <a href="https://www.eff.org/badger-pretraining" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+                </label>
+                <input type="checkbox" id="tracking-domains-hide-in-seed">
+              </li>
           </ul>
           <div id="blockedResources">
             <div class="keyContainer">

--- a/src/tests/tests/options.js
+++ b/src/tests/tests/options.js
@@ -23,6 +23,12 @@ QUnit.test("filterDomains", (assert) => {
       ([, val]) => val != "dnt"
     )
   );
+  const seedBases = new Set([
+    "allowed.com",
+    "blocked.org",
+    "alsoblocked.org",
+    "cookieblocked.biz",
+  ]);
 
   const tests = [
     {
@@ -104,6 +110,20 @@ QUnit.test("filterDomains", (assert) => {
         showNotYetBlocked: true,
       }],
       expected: ["UserAllowed.net"]
+    },
+    {
+      msg: "Domains present in seed data can be hidden",
+      args: [domains, {
+        showNotYetBlocked: true,
+        hideInSeed: true,
+        seedBases,
+      }],
+      expected: [
+        "UserAllowed.net",
+        "uuuserblocked.nyc",
+        "dntDomain.co.uk",
+        "another.allowed.domain.example",
+      ]
     },
   ];
 

--- a/src/tests/tests/options.js
+++ b/src/tests/tests/options.js
@@ -1,9 +1,9 @@
-import { getOriginsArray } from "../../lib/options.js";
+import { filterDomains } from "../../lib/options.js";
 
 QUnit.module("Options page utils");
 
-QUnit.test("getOriginsArray", (assert) => {
-  const origins = {
+QUnit.test("filterDomains", (assert) => {
+  const domains = {
     "allowed.com": "allow",
     "blocked.org": "block",
     "alsoblocked.org": "block",
@@ -13,13 +13,13 @@ QUnit.test("getOriginsArray", (assert) => {
     "dntDomain.co.uk": "dnt",
     "another.allowed.domain.example": "allow",
   };
-  const originsSansAllowed = Object.fromEntries(
-    Object.entries(origins).filter(
+  const domainsSansAllowed = Object.fromEntries(
+    Object.entries(domains).filter(
       ([, val]) => val != "allow"
     )
   );
-  const originsSansAllowedSansDnt = Object.fromEntries(
-    Object.entries(originsSansAllowed).filter(
+  const domainsSansAllowedSansDnt = Object.fromEntries(
+    Object.entries(domainsSansAllowed).filter(
       ([, val]) => val != "dnt"
     )
   );
@@ -32,52 +32,52 @@ QUnit.test("getOriginsArray", (assert) => {
     },
     {
       msg: "No filters (allowed domains are filtered out)",
-      args: [origins,],
-      expected: Object.keys(originsSansAllowed)
+      args: [domains,],
+      expected: Object.keys(domainsSansAllowed)
     },
     {
       msg: "Not-yet-blocked domains are shown",
-      args: [origins, null, null, null, true],
-      expected: Object.keys(origins)
+      args: [domains, { showNotYetBlocked: true }],
+      expected: Object.keys(domains)
     },
     {
       msg: "Type filter (user-controlled)",
-      args: [origins, "", "user"],
+      args: [domains, { typeFilter: 'user' }],
       expected: ["UserAllowed.net", "uuuserblocked.nyc"]
     },
     {
       msg: "Type filter (DNT)",
-      args: [origins, "", "dnt"],
+      args: [domains, { typeFilter: 'dnt' }],
       expected: ["dntDomain.co.uk"]
     },
     {
       msg: "Type filter (non-DNT)",
-      args: [origins, "", "-dnt"],
-      expected: Object.keys(originsSansAllowedSansDnt)
+      args: [domains, { typeFilter: '-dnt' }],
+      expected: Object.keys(domainsSansAllowedSansDnt)
     },
     {
       msg: "Status filter",
-      args: [origins, "", "", "allow"],
+      args: [domains, { statusFilter: 'allow' }],
       expected: ["UserAllowed.net", "dntDomain.co.uk"]
     },
     {
       msg: "Text filter",
-      args: [origins, ".org"],
+      args: [domains, { searchFilter: ".org" }],
       expected: ["blocked.org", "alsoblocked.org"]
     },
     {
       msg: "Text filter and domain case insensitivity",
-      args: [origins, "uSER"],
+      args: [domains, { searchFilter: "uSER" }],
       expected: ["UserAllowed.net", "uuuserblocked.nyc"]
     },
     {
       msg: "Text filter with extra space",
-      args: [origins, " .org"],
+      args: [domains, { searchFilter: " .org" }],
       expected: ["blocked.org", "alsoblocked.org"]
     },
     {
       msg: "Negative text filter",
-      args: [origins, "-.org"],
+      args: [domains, { searchFilter: "-.org" }],
       expected: [
         "cookieblocked.biz",
         "UserAllowed.net",
@@ -87,24 +87,29 @@ QUnit.test("getOriginsArray", (assert) => {
     },
     {
       msg: "Multiple negative text filter",
-      args: [origins, "-.net -cookie -.co.uk"],
+      args: [domains, { searchFilter: "-.net -cookie -.co.uk" }],
       expected: ["blocked.org", "alsoblocked.org", "uuuserblocked.nyc"]
     },
     {
       msg: "Multiple text filters",
-      args: [origins, "  -also .biz     .org   "],
+      args: [domains, { searchFilter: "  -also .biz     .org   "}],
       expected: ["blocked.org", "cookieblocked.biz"]
     },
     {
       msg: "All filters together",
-      args: [origins, ".net", "user", "allow", true],
+      args: [domains, {
+        searchFilter: ".net",
+        typeFilter: 'user',
+        statusFilter: 'allow',
+        showNotYetBlocked: true,
+      }],
       expected: ["UserAllowed.net"]
     },
   ];
 
   tests.forEach((test) => {
     assert.deepEqual(
-      getOriginsArray.apply(window, test.args),
+      filterDomains.apply(window, test.args),
       test.expected,
       test.msg
     );

--- a/src/tests/tests/options.js
+++ b/src/tests/tests/options.js
@@ -2,7 +2,7 @@ import { filterDomains } from "../../lib/options.js";
 
 QUnit.module("Options page utils");
 
-QUnit.test("filterDomains", (assert) => {
+QUnit.test("filterDomains()", (assert) => {
   const domains = {
     "allowed.com": "allow",
     "blocked.org": "block",
@@ -112,13 +112,38 @@ QUnit.test("filterDomains", (assert) => {
       expected: ["UserAllowed.net"]
     },
     {
-      msg: "Domains present in seed data can be hidden",
+      msg: "Hiding pre-trained domains",
       args: [domains, {
         showNotYetBlocked: true,
         hideInSeed: true,
         seedBases,
+        seedNotYetBlocked: new Set()
       }],
       expected: [
+        "UserAllowed.net",
+        "uuuserblocked.nyc",
+        "dntDomain.co.uk",
+        "another.allowed.domain.example",
+      ]
+    },
+    {
+      msg: "Hiding pre-trained domains requires seed data",
+      args: [domains, {
+        showNotYetBlocked: true,
+        hideInSeed: true,
+      }],
+      expected: Object.keys(domains)
+    },
+    {
+      msg: "Hiding pre-trained domains should keep domains that went from allowed to blocked",
+      args: [domains, {
+        showNotYetBlocked: true,
+        hideInSeed: true,
+        seedBases,
+        seedNotYetBlocked: new Set(["alsoblocked.org"])
+      }],
+      expected: [
+        "alsoblocked.org",
         "UserAllowed.net",
         "uuuserblocked.nyc",
         "dntDomain.co.uk",


### PR DESCRIPTION
Fixes #2929.

Hiding domains found in the latest seed data is not the same as only showing locally learned domains, but it might be close enough.

The new filter becomes visible after enabling local learning.

![Screenshot from 2023-12-21 13-59-59](https://github.com/EFForg/privacybadger/assets/794578/d9f051a7-77fa-4e4c-9d81-4152379aeb9b)
