### PR TITLE
Unblock arcade.software following DNT compliance

### DIFF
--- a/src/data/seed.json
+++ b/src/data/seed.json
@@ -2123,9 +2123,6 @@
     "arc.io": {
       "heuristicAction": "block"
     },
-    "arcade.software": {
-      "heuristicAction": "block"
-    },
     "arcamax.com": {
       "heuristicAction": "allow"
     },
@@ -24358,11 +24355,6 @@
       "apnetv.to",
       "manhwaindo.id",
       "mangaokutr.com"
-    ],
-    "arcade.software": [
-      "gitbook.com",
-      "copy.ai",
-      "seon.io"
     ],
     "arcamax.com": [
       "hollywoodlife.com"


### PR DESCRIPTION
Hi!

We noticed our website was being blocked by Privacy Badger because we indeed didn't have support for the DNT header.

Since December 18, shipped DNT support and I'm happy to announce that we no longer use cookies nor local storage when the DNT header is set.

You document that [sites get unblocked automatically](https://privacybadger.org/#-I-am-an-online-advertising-tracking-company.--How-do-I-stop-Privacy-Badger-from-blocking-me) but it looks like the seed was last updated 3 months ago and I'm not sure when you next plan to update it, which is why I'm resorting to this manual PR.

You can verify compliance by clicking "remove all tracking domains" in Privacy Badger options, and browsing https://up.codejam.info/test-privacy-badger.html (a page that embeds a demo from demo.arcade.software) - it will not re-learn to block demo.arcade.software because it now implements DNT.

Thanks!