### PR TITLE
Add images-ext-1.discordapp.net and images-ext-2.discordapp.net

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -175,6 +175,8 @@ digitalriver.com
 digitalrivercontent.net
 cdn.discordapp.com
 media.discordapp.net
+images-ext-1.discordapp.net
+images-ext-2.discordapp.net
 discoverevvnt.com
 pics.dmm.co.jp
 api.docodoco.jp


### PR DESCRIPTION
This is a Discord CDN that some websites will embed for free file storage

Example: https://images-ext-1.discordapp.net/external/2pFyjiHFbEIogQ1qJYy1F2vuIHIlDdZsbzFCn7xGQHU/https/share.redd.it/preview/comment/h0ix4xs, https://images-ext-2.discordapp.net/external/2pFyjiHFbEIogQ1qJYy1F2vuIHIlDdZsbzFCn7xGQHU/https/share.redd.it/preview/comment/h0ix4xs

It's gotten blocked my Privacy Badger, probably because of cookies:
![image](https://github.com/EFForg/privacybadger/assets/147954091/9ab84b34-4f81-4d2a-82ed-afc240e003af)
