### PR TITLE
khanacademy.org and kastatic.org in multi domain first parties

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -6032,6 +6032,7 @@ let multiDomainFirstPartiesArray = [
   ],
   ["zonealarm.com", "zonelabs.com"],
   ["zoom.us", "zoom.com", "zoomgov.com"],
+  ["khanacademy.org", "kastatic.org"]
 ];
 
 /**


### PR DESCRIPTION
kastatic.org is the CDN for khanacademy.org

![image](https://github.com/EFForg/privacybadger/assets/147954091/f9e34c88-d3c7-47ca-b444-f57a72fed78e)
![image](https://github.com/EFForg/privacybadger/assets/147954091/6d9b257e-e853-4395-9bbb-13f7b1964706)
