### PR TITLE
Improve popup header display on small screens

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -613,7 +613,7 @@ function refreshPopup() {
     $("#activate_site_btn").show();
     $("#deactivate_site_btn").hide();
     $("#disabled-site-message").show();
-    $("#title").addClass("faded-bw-color-scheme");
+    $("#badger-title-div").addClass("faded-bw-color-scheme");
   }
 
   // if there is any saved error text, fill the error input with it

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -56,10 +56,7 @@ function setTextDirection() {
   // popup page
   if (ON_POPUP) {
     // fix floats
-    ['#badger-header-logo', '#header-image-stack', '#header-image-stack a', '#header-image-stack img'].forEach((selector) => {
-      toggle_css_value(selector, "float", "left", "right");
-    });
-    ['#fittslaw', '#options', '#help', '#share', '.overlay_close'].forEach((selector) => {
+    ['#fittslaw', '.overlay_close'].forEach((selector) => {
       toggle_css_value(selector, "float", "right", "left");
     });
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -148,34 +148,32 @@ a.removeOrigin:hover {
     display: inline-block;
 }
 
-#privacyBadgerHeader {
+#privacy-badger-header {
     display: flex;
-    flex-wrap: wrap;
     color: #505050;
     font-size: 16px;
     margin-bottom: 5px;
-}
-
-#privacyBadgerHeader h2 {
-    color: #000;
-    font-size: 24px;
-    font-weight: normal;
-    font-family: "Chunk-Five", serif;
-    margin: 0;
 }
 
 #badger-logo-div {
     width: 48px;
 }
 
-#badger-logo-div, #title {
+#badger-logo-div, #badger-title-div {
     padding-top: 4px;
 }
 
-#title {
+#badger-title-div {
     flex: 1;
     margin: 2px 10px 0 10px;
     line-height: 0.8;
+}
+#badger-title-div h2 {
+    color: #000;
+    font-size: 24px;
+    font-weight: normal;
+    font-family: "Chunk-Five", serif;
+    margin: 0;
 }
 
 #corner-buttons {
@@ -623,7 +621,7 @@ a.overlay_close:hover {
         filter: invert(0.85);
     }
 
-    #privacyBadgerHeader h2 {
+    #badger-title-div h2 {
         color: #f9f9f9;
     }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -149,33 +149,47 @@ a.removeOrigin:hover {
 }
 
 #privacyBadgerHeader {
+    display: flex;
+    flex-wrap: wrap;
     color: #505050;
     font-size: 16px;
     margin-bottom: 5px;
 }
 
-#title {
+#privacyBadgerHeader h2 {
+    color: #000;
+    font-size: 24px;
+    font-weight: normal;
+    font-family: "Chunk-Five", serif;
+    margin: 0;
+}
+
+#badger-logo-div {
+    width: 48px;
+}
+
+#badger-logo-div, #title {
     padding-top: 4px;
 }
 
-#header-image-stack {
-    display: table;
+#title {
+    flex: 1;
     margin: 2px 10px 0 10px;
-    line-height: 1.0;
+    line-height: 0.8;
 }
 
-#badger-header-logo, #header-image-stack, #header-image-stack a, #header-image-stack img {
-    float: left;
+#corner-buttons {
+    margin-top: 7px;
 }
-
-#privacyBadgerHeader h2{
-  display: table-row;
-  color: #000;
-  font-size: 24px;
-  font-weight: normal;
-  clear: initial;
-  font-family: "Chunk-Five", serif;
-  margin-top: 5px;
+#corner-buttons a {
+    display: inline-block;
+}
+#share {
+    margin-left: 10px;
+    margin-right: 12px;
+}
+#options {
+    margin-inline-end: 3px;
 }
 
 /* body#main to avoid applying this to options page */
@@ -284,17 +298,6 @@ button.cta-button:hover, a.cta-button:hover {
 }
 #fittslaw {
     float: right;
-}
-#options, #share, #help {
-    float: right;
-    margin-top: 7px;
-}
-#share {
-    margin-left: 10px;
-    margin-right: 12px;
-}
-#options {
-    margin-inline-end: 3px;
 }
 #pbInstructions, #special-browser-page, #disabled-site-message, .toggle-header-title {
     color: #505050;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -166,7 +166,10 @@ a.removeOrigin:hover {
 #badger-title-div {
     flex: 1;
     margin: 2px 10px 0 10px;
-    line-height: 0.8;
+    line-height: 0.9;
+    @supports (-moz-appearance:none) { /* Firefox */
+        line-height: 0.8;
+    }
 }
 #badger-title-div h2 {
     color: #000;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -98,16 +98,22 @@
   </div>
 
 <div id='privacyBadgerHeader'>
-  <a id="options" title="i18n_popup_options_button" href='/skin/options.html' class="tooltip" target="_blank"><img width="25" src="/icons/options.svg" alt="i18n_popup_options_button"></a>
-  <a id="share" href="" title="i18n_popup_share_button" class="tooltip" target="_blank"><img width="23" height="auto" src="/icons/share.svg" alt="i18n_popup_share_button"></a>
-  <a id="help" title="i18n_popup_help_button" href='https://privacybadger.org/#faq' class="tooltip" target="_blank"><img width="25" src="/icons/help.svg" alt="i18n_popup_help_button"></a>
-  <div id='title'>
+
+  <div id="badger-logo-div">
     <img src="../icons/badger-bw-noborder.svg" width="48" alt="" id="badger-header-logo">
-    <div id='header-image-stack'>
+  </div>
+
+  <div id="title">
+    <div id="header-image-stack">
       <a href="https://www.eff.org/" target="_blank"><img id='header-red-eff-logo' src="./images/EFF-red.svg" width="48" alt="" title="i18n_intro_by_eff" class="tooltip" data-tooltipster='{"distance":20,"maxWidth":180}'></a>
       <h2 id="title-name"><span class="i18n_name"></span></h2>
     </div>
   </div>
+
+  <div id="corner-buttons">
+    <a id="help" title="i18n_popup_help_button" href='https://privacybadger.org/#faq' class="tooltip" target="_blank"><img width="25" src="/icons/help.svg" alt="i18n_popup_help_button"></a><a id="share" href="" title="i18n_popup_share_button" class="tooltip" target="_blank"><img width="23" height="auto" src="/icons/share.svg" alt="i18n_popup_share_button"></a><a id="options" title="i18n_popup_options_button" href='/skin/options.html' class="tooltip" target="_blank"><img width="25" src="/icons/options.svg" alt="i18n_popup_options_button"></a>
+  </div>
+
 </div>
 
 <div id="firstparty-protections-container" style="display:none">

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -97,17 +97,15 @@
     <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
   </div>
 
-<div id='privacyBadgerHeader'>
+<div id="privacy-badger-header">
 
   <div id="badger-logo-div">
     <img src="../icons/badger-bw-noborder.svg" width="48" alt="" id="badger-header-logo">
   </div>
 
-  <div id="title">
-    <div id="header-image-stack">
-      <a href="https://www.eff.org/" target="_blank"><img id='header-red-eff-logo' src="./images/EFF-red.svg" width="48" alt="" title="i18n_intro_by_eff" class="tooltip" data-tooltipster='{"distance":20,"maxWidth":180}'></a>
-      <h2 id="title-name"><span class="i18n_name"></span></h2>
-    </div>
+  <div id="badger-title-div">
+    <a href="https://www.eff.org/" target="_blank"><img id='header-red-eff-logo' src="./images/EFF-red.svg" width="48" alt="" title="i18n_intro_by_eff" class="tooltip" data-tooltipster='{"distance":20,"maxWidth":180}'></a>
+    <h2><span class="i18n_name"></span></h2>
   </div>
 
   <div id="corner-buttons">


### PR DESCRIPTION
The "Privacy Badger" title text now supports splitting to two lines.

This also improves keyboard tabbing order, removes a few i18n hacks, and makes room for us to widen the spacing between the Help/Share/Options corner buttons if we wish to do so later.

Before:

![](https://github.com/EFForg/privacybadger/assets/794578/4828af70-089b-4cde-8b94-e3a886ae88a5)

After:

![](https://github.com/EFForg/privacybadger/assets/794578/0498f238-6da9-4fb3-b12c-e31ecba8b8d4)