### PR TITLE
Ignore "unexpected error" storage errors

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -283,16 +283,6 @@
         "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
         "description": "Shown in the popup when there is an extension error we want to encourage the user to tell us about."
     },
-    "popup_error_text_low_disk_space_issue": {
-      "message": "Failed to write to extension storage: $ERROR_TEXT$.<br><br>Is your disk low on space?",
-      "description": "Special error message for the 'An unexpected error occurred' text that sometimes occurs on Firefox browsers with low disk space",
-      "placeholders": {
-        "error_text": {
-          "content": "$1",
-          "example": "An unexpected error occurred"
-        }
-      }
-    },
     "firstRun_title": {
         "message": "Thank you for installing Privacy Badger!",
         "description": "Title and header of the intro page."

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -98,27 +98,17 @@ function showNagMaybe() {
   function _showError(error_text) {
     $('#instruction-text').hide();
 
-    // if error is the 'unexpected error occurred' Firefox issue commonly associated with low disk space, show special message
-    if (error_text == "An unexpected error occurred") {
-      // replace current error text with this special message
-      $('#error-text').show().html([
-        chrome.i18n.getMessage("popup_error_text_low_disk_space_issue", [error_text]),
-        chrome.i18n.getMessage("learn_more_link", ["<a href='https://privacybadger.org/#I-found-a-bug%21-What-do-I-do-now'>privacybadger.org</a>"]),
-      ].join(" "));
+    $('#error-message').text(error_text);
 
-    } else {
-      $('#error-message').text(error_text);
-
-      $('#error-text').show().find('a')
-        .addClass('cta-button')
-        .css({
-          borderRadius: '3px',
-          display: 'inline-block',
-          padding: '5px',
-          textDecoration: 'none',
-          width: 'auto',
-        });
-    }
+    $('#error-text').show().find('a')
+      .addClass('cta-button')
+      .css({
+        borderRadius: '3px',
+        display: 'inline-block',
+        padding: '5px',
+        textDecoration: 'none',
+        width: 'auto',
+      });
 
     $('#fittslaw').on("click", function (e) {
       e.preventDefault();

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -817,7 +817,8 @@ let _syncStorage = (function () {
         return;
       }
       let err = chrome.runtime.lastError.message;
-      if (!err.startsWith("IO error:") && !err.startsWith("Corruption:") &&
+      if (err != "An unexpected error occurred" &&
+        !err.startsWith("IO error:") && !err.startsWith("Corruption:") &&
         !err.startsWith("InvalidStateError:") && !err.startsWith("AbortError:") &&
         !err.startsWith("QuotaExceededError:")) {
         badger.criticalError = err;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -576,6 +576,9 @@ a.overlay_close:hover {
     a:hover {
         color: #f06a0a;
     }
+    a.cta-button:hover {
+        color: #fff;
+    }
 
     body, #instruction, .key {
         background-color: #333;


### PR DESCRIPTION
"An unexpected error occurred" storage errors in Firefox [may or may not have to do with low disk space](https://bugzilla.mozilla.org/show_bug.cgi?id=1555491#c18), but surfacing them to the user seems to do more harm than good at this point.

This removes the special message added in #2835, and ignores "An unexpected error occurred" storage writing errors (no action other than logging the error to the background page developer console).

Should be followed up by updating [the FAQ](https://github.com/EFForg/privacybadger-website/blob/master/content/en/faqs/I-found-a-bug!-What-do-I-do-now.md).