### PR TITLE
Remove infinite loop

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -41,6 +41,7 @@ function Badger(from_qunit) {
   log("Initializing Privacy Badger ...");
   let self = this;
 
+  self.startTime = new Date();
   self.isFirstRun = false;
   self.isUpdate = false;
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1192,6 +1192,21 @@ function dispatcher(request, sender, sendResponse) {
     if ((Date.now() - badger.startTime) > 10000) {
       // too much time elapsed for this to be a normal initialization,
       // give up to avoid an infinite loop
+      badger.criticalError = "Privacy Badger failed to initialize";
+      // update badge
+      chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+        if (tabs[0]) {
+          badger.updateBadge(tabs[0].id);
+        }
+      });
+      // show error in popup
+      if (request.type == "getPopupData") {
+        return sendResponse({
+          criticalError: badger.criticalError,
+          noTabData: true,
+          settings: { seenComic: true },
+        });
+      }
       return sendResponse();
     } else {
       setTimeout(function () {

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1189,11 +1189,17 @@ function dispatcher(request, sender, sendResponse) {
   // process is not running; the getPopupData message from the popup causes
   // the background to start but the background is not yet ready to respond
   if (!badger.INITIALIZED) {
-    setTimeout(function () {
-      dispatcher(request, sender, sendResponse);
-    }, 50);
-    // indicate this is an async response to chrome.runtime.onMessage
-    return true;
+    if ((Date.now() - badger.startTime) > 10000) {
+      // too much time elapsed for this to be a normal initialization,
+      // give up to avoid an infinite loop
+      return sendResponse();
+    } else {
+      setTimeout(function () {
+        dispatcher(request, sender, sendResponse);
+      }, 50);
+      // indicate this is an async response to chrome.runtime.onMessage
+      return true;
+    }
   }
 
   // messages from content scripts are to be treated with greater caution:


### PR DESCRIPTION
The infinite loop happens when initialization gets interrupted such as by unhandled JavaScript errors. While Privacy Badger will still be broken when this happens, it should not max out the CPU.

Follows up on #2909.

Fixes part of #2954.