### PR TITLE
Update popup.html to correctly underline the "Donate to EFF" link

### DIFF
--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -168,7 +168,7 @@
 
 <footer>
   <div id="donate">
-    <a href="https://supporters.eff.org/donate/support-privacy-badger" target="_blank"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff"></span></a>
+    <a href="https://supporters.eff.org/donate/support-privacy-badger" target="_blank" style="text-decoration: none;"><span class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span class="i18n_donate_to_eff" style="text-decoration: underline;"></span></a>
   </div>
   <div id="version" class="i18n_version"></div>
 </footer>


### PR DESCRIPTION
Stops space before "Donate to EFF" from being underlined. Fixes #2960 

Before:
<img width="134" alt="Screenshot 2024-04-06 at 10 04 12 PM" src="https://github.com/EFForg/privacybadger/assets/49506603/2ff8a8d0-c272-4241-98ab-2d952c147546">

After:
<img width="127" alt="Screenshot 2024-04-06 at 10 11 32 PM" src="https://github.com/EFForg/privacybadger/assets/49506603/d4e3db8f-24aa-4b99-9426-d394d7cf4258">
