### PR TITLE
Handle storage.local.read() returning undefined

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -84,8 +84,13 @@ function BadgerPen(callback) {
 
   // initialize from extension local storage
   chrome.storage.local.get(self.KEYS, function (store) {
+    let storage_err;
+    if (chrome.runtime.lastError) {
+      storage_err = chrome.runtime.lastError.message;
+    }
+
     self.KEYS.forEach(key => {
-      if (utils.hasOwn(store, key)) {
+      if (store && utils.hasOwn(store, key)) {
         self[key] = new BadgerStorage(key, store[key]);
       } else {
         let storageObj = new BadgerStorage(key, {});
@@ -93,6 +98,14 @@ function BadgerPen(callback) {
         _syncStorage(storageObj);
       }
     });
+
+    if (!store || storage_err) {
+      console.error("Error reading from extension storage:", storage_err);
+      if (!store) {
+        self.settings_map.setItem("showIntroPage", false);
+        self.settings_map.setItem("seenComic", true);
+      }
+    }
 
     badger.initSettings();
 


### PR DESCRIPTION
Fixes (potentially) #2966, fixes #2954.

Follows up on #2955.

Now when Privacy Badger fails to read from storage, it will still function but with all settings reset to defaults, with the exception of the new user welcome page (and its in-popup reminder), which we specifically disable. It will be just as if the user installed Privacy Badger for the first time, only without the welcome page.

This should be an improvement over Privacy Badger failing to initialize and not doing anything useful while annoying the user with a bright red exclamation badge over its icon.

Unfortunately, we still don't know what causes Privacy Badger to fail to read from storage.