### PR TITLE
Unset "failed to initialize" error upon successful initialization

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -124,6 +124,15 @@ function Badger(from_qunit) {
     console.log("Privacy Badger is ready to rock!");
     self.INITIALIZED = true;
 
+    if (self.criticalError == "Privacy Badger failed to initialize") {
+      delete self.criticalError;
+      chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+        if (tabs[0]) {
+          self.updateBadge(tabs[0].id);
+        }
+      });
+    }
+
     if (!from_qunit) {
       self.initYellowlistUpdates();
       self.initDntPolicyUpdates();


### PR DESCRIPTION
Following up on #2967. Fixes another part of #2966. This PR is this bit:

>We are going to follow this up with a fix for (1) where we deactivate the "failed to initialize" error when PB does in fact finish initializing successfully.