### PR TITLE
Adds Bing Speech Platform domain to Yellow List to resolve issue with Edge Read aloud feature

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -99,7 +99,7 @@ www.beyondmenu.com
 bigcommerce.com
 api.bilibili.com
 www.bilibili.com
-platform.bing.com
+speech.platform.bing.com
 r.bing.com
 www.bing.com
 bit.ly

--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -2999,7 +2999,6 @@ let multiDomainFirstPartiesArray = [
     "azurerms.com",
     "azuresynapse.net",
     "bing.com",
-    "platform.bing.com",
     "bing.net",
     "cloudappsecurity.com",
     "dynamics.com",


### PR DESCRIPTION
Fixes #2976

Used Wireshark to identify `speech.platform.bing.com` as the requested resource.
Was able to verify that yellow listing bing.com resolved the issue with Edge's _Read along_ feature.

Reviewed https://github.com/EFForg/privacybadger/blob/master/doc/yellowlist-criteria.md before submitting.