### PR TITLE
add Creative Commons (CC) licensebuttons.net to the yellow list

### DIFF
--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -424,6 +424,7 @@ kustomerapp.com
 kxcdn.com
 ddragon.leagueoflegends.com
 libsyn.com
+licensebuttons.net
 addon.lidl.de
 lightboxcdn.com
 graphql-cdn-slplatform.liquidus.net


### PR DESCRIPTION
## Description

Add `licensebuttons.net` ([Creative Commons license buttons](https://licensebuttons.net/) site) to the yellow list
- `i.creativecommons.org` and `mirrors.creativecommons.org` were added in 92ef1904dc23b4aea53b439c4b43cea322e223d4
- `i.creativecommons.org` redirects to `licensebuttons.net`

The [Creative Commons license buttons](https://licensebuttons.net/) site is minimal and does not include any analytics (there are only the time limited logs from Cloudflare and from NGINX on the server itself).

## Related
- [Creative Commons Privacy Policy - Creative Commons](https://creativecommons.org/privacy/)
- [creativecommons/licensebuttons](https://github.com/creativecommons/licensebuttons/): _Creative Commons badges, license Buttons, etc._
- [creativecommons/sre-salt-prime](https://github.com/creativecommons/sre-salt-prime/): _Site Reliability Engineering / DevOps SaltStack configuration files_
