### PR TITLE
Retry reading from extension storage on startup

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -74,6 +74,8 @@ function Badger(from_qunit) {
    * once Badger storage is ready.
    */
   async function onStorageReady() {
+    log("Storage is ready");
+
     self.heuristicBlocking = new HeuristicBlocking.HeuristicBlocker(self.storage);
 
     self.setPrivacyOverrides();
@@ -120,7 +122,7 @@ function Badger(from_qunit) {
       window.DATA_LOAD_IN_PROGRESS = false;
     }
 
-    log("Privacy Badger initialization complete");
+    log("Initialization complete");
     console.log("Privacy Badger is ready to rock!");
     self.INITIALIZED = true;
 


### PR DESCRIPTION
When `chrome.storage.local.get()` fails to return an object [^1], and also when `chrome.storage.local` is `undefined` [^2].

Follows up on #2967 and https://github.com/EFForg/privacybadger/issues/2966#issuecomment-2153316523

Might fix issues like #2979.

[^1]: Fails to return something [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), to be exact
[^2]: When calling `chrome.storage.local.get()` throws an exception, to be exact