### PR TITLE
Add YouTube-specific message to the error report page

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -45,7 +45,7 @@
     },
     "report_broken_site": {
         "message": "Report broken site",
-        "description": "Button in the popup."
+        "description": "Button in the popup and title of the error reporting form overlay."
     },
     "version": {
         "message": "version $VERSION_STRING$",
@@ -193,20 +193,12 @@
         "message": "Currently Privacy Badger only checks if third parties are using cookies, HTML5 local storage, or canvas fingerprinting to track your browsing. Some of these domains may be using tracking methods that Privacy Badger can't detect.",
         "description": "Tooltip for the 'non_tracker' message."
     },
-    "report_title": {
-        "message": "Report an Error",
-        "description": "Title of the 'Report broken site' popup overlay."
-    },
-    "report_text": {
-        "message": "Briefly describe the error below.",
-        "description": "The 'below' refers to a text input located below this text. This asks the user to describe what problem the user experienced."
-    },
     "report_input_label": {
-        "message": "Description",
+        "message": "Briefly describe the problem",
         "description": "Label for the text input in the 'Report broken site' overlay."
     },
     "error_input": {
-        "message": "What's Wrong?",
+        "message": "What's wrong?",
         "description": "Placeholder text in the text input in the 'Report broken site' overlay."
     },
     "report_terms": {
@@ -214,7 +206,7 @@
         "description": ""
     },
     "report_button": {
-        "message": "Submit Error",
+        "message": "Send report",
         "description": "Button text."
     },
     "report_cancel": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -280,7 +280,7 @@
         }
     },
     "popup_info_youtube": {
-        "message": "YouTube not working? It's probably not because of Privacy Badger.",
+        "message": "YouTube not working? Ads playing? It's probably not because of Privacy Badger.",
         "description": "Message in the popup when users visit YouTube.com"
     },
     "extension_error_text": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -280,7 +280,7 @@
         }
     },
     "popup_info_youtube": {
-        "message": "YouTube not working? Ads playing? It's probably not because of Privacy Badger.",
+        "message": "Ads not blocked? YouTube not working?",
         "description": "Message in the popup when users visit YouTube.com"
     },
     "extension_error_text": {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -180,6 +180,11 @@ function init() {
 
   $("#error").on("click", function() {
     $('#overlay').toggleClass('active');
+    // Show YouTube message on error reporting form
+    if (POPUP_DATA.tabHost === "www.youtube.com") {
+      $('#report-youtube-message').html(chrome.i18n.getMessage("popup_info_youtube") + " " + chrome.i18n.getMessage('learn_more_link', ['<a target=_blank href="https://privacybadger.org/#Is-Privacy-Badger-breaking-YouTube">privacybadger.org</a>']));
+      $("#report-youtube-message-container").show();
+    }
   });
   $("#report-cancel").on("click", function() {
     clearSavedErrorText();

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -325,6 +325,19 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #d
     font-size: 14px;
 }
 
+#report-youtube-message-container {
+    font-size: 14px;
+    padding-bottom: 10px;
+}
+
+#report-youtube-message a, #report-youtube-message {
+    color: #F06A0A;
+}
+
+#report-youtube-message a:hover {
+    color: #ec9329
+}
+
 #no-third-parties {
     display: block;
     font-size: 12px;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -77,12 +77,11 @@
   </div><!-- end of div#instruction -->
 
   <div id="overlay" class="overlay">
-    <h1 id="report_title" class="i18n_report_title overlay_title"></h1>
+    <h1 id="report_title" class="i18n_report_broken_site overlay_title"></h1>
     <a href="" id="report_close" class="i18n_report_close overlay_close" role="button"></a>
     <div id="report-youtube-message-container" style="display:none">
       <div id="report-youtube-message"></div>
     </div>
-    <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
     <div id="report-controls">

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -79,6 +79,9 @@
   <div id="overlay" class="overlay">
     <h1 id="report_title" class="i18n_report_title overlay_title"></h1>
     <a href="" id="report_close" class="i18n_report_close overlay_close" role="button"></a>
+    <div id="report-youtube-message-container" style="display:none">
+      <div id="report-youtube-message"></div>
+    </div>
     <p id="report_text" class="i18n_report_text"></p>
     <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
     <textarea id="error_input" name="error_input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>


### PR DESCRIPTION
Following up on #2974, and in response to continuing error reports for non-Privacy related issues on YouTube, I copied the YouTube-specific message on the popup onto the error reporting form. I also edited to the message to explicit reference ads, since many of the continued error reports have to do with ads playing on YouTube.

Once the new text is approved, I'll re-run `make tx` to update the locale files