### PR TITLE
Disable 'Privacy Sandbox' ad tracking by default

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -8,7 +8,7 @@ The Privacy API lets extensions modify browser-wide privacy settings. Privacy Ba
 - [hyperlink auditing](https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/), an [HTML feature](https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing) meant to optimize and normalize click tracking on the Web
 - [prefetching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) (network predictions), as it presents a poor tradeoff between privacy and perceived browsing performance
 - suggestions for similar pages when a page can't be found, as this Chrome feature sends visited web addresses to Google
-- Google's Topics API
+- Google's [Privacy Sandbox ad tracking](https://www.eff.org/deeplinks/2023/09/how-turn-googles-privacy-sandbox-ad-tracking-and-why-you-should) (ad topics, site-suggested ads, and ad measurement), as these features enable Google’s behavioral advertising by tracking your internet use
 
 ## Storage
 The storage API lets extensions store information that persists after the browser is closed. Privacy Badger uses it to save user settings and information it has learned about trackers.

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -432,8 +432,8 @@
         "description": "(Chrome only) Checkbox label in general settings."
     },
     "options_disable_floc": {
-        "message": "Disable Google's Topics API",
-        "description": "Checkbox label in general settings. For what this disables, see https://brave.com/web-standards-at-brave/7-googles-topics-api/"
+        "message": "Disable Google's \"Privacy Sandbox\" Ad Tracking",
+        "description": "Checkbox label in general settings. For what this disables, see https://www.eff.org/deeplinks/2023/09/how-turn-googles-privacy-sandbox-ad-tracking-and-why-you-should"
     },
     "options_advanced_settings": {
         "message": "Advanced",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -432,7 +432,7 @@
         "description": "(Chrome only) Checkbox label in general settings."
     },
     "options_disable_floc": {
-        "message": "Disable Google's \"Privacy Sandbox\" Ad Tracking",
+        "message": "Disable Google's \"Privacy Sandbox\" ad tracking",
         "description": "Checkbox label in general settings. For what this disables, see https://www.eff.org/deeplinks/2023/09/how-turn-googles-privacy-sandbox-ad-tracking-and-why-you-should"
     },
     "options_advanced_settings": {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -245,6 +245,18 @@ Badger.prototype = {
         chrome.privacy.websites.topicsEnabled,
         (self.getSettings().getItem("disableTopics") ? false : null)
       );
+
+      _set_override(
+        "adMeasurementEnabled",
+        chrome.privacy.websites.adMeasurementEnabled,
+        (self.getSettings().getItem("disableTopics") ? false : null)
+      );
+
+      _set_override(
+        "fledgeEnabled",
+        chrome.privacy.websites.fledgeEnabled,
+        (self.getSettings().getItem("disableTopics") ? false : null)
+      );
     }
   },
 

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -214,7 +214,7 @@
           <input type="checkbox" id="disable-topics-checkbox">
           <span>
             <span class="i18n_options_disable_floc"></span>
-            <a href="https://brave.com/web-standards-at-brave/7-googles-topics-api/" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
+            <a href="https://www.eff.org/deeplinks/2023/09/how-turn-googles-privacy-sandbox-ad-tracking-and-why-you-should" target="_blank"><span class="ui-icon ui-icon-circle-b-help"></span></a>
           </span>
         </label>
       </div>


### PR DESCRIPTION
- Switched the "Disable Google's Topics API" toggle on the options page to "Disable Google's 'Privacy Sandbox' Ad Tracking"
- To test, run `make runch`, visit chrome://settings/adPrivacy, and confirm that you the extension icon on the pages of all three features
<img width="760" alt="Screenshot 2024-07-03 at 5 33 13 PM" src="https://github.com/EFForg/privacybadger/assets/40436018/19389cbb-e436-44f6-9df9-57fb4369a472">

- Visit the Options page and confirm that this toggle's link and text are correct

Follows up on d6e93e2c5787501041cc0b51cdb164de936a277a and #2888.