### PR TITLE
Fix replacing some lazy-loaded widgets

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -342,8 +342,13 @@
     },
     "SoundCloud": {
         "domain": "w.soundcloud.com",
-        "buttonSelectors": [
-            "iframe[src^='https://w.soundcloud.com/player']"
+        "selectors": [
+            {
+                "elm": "iframe",
+                "urls": [
+                    "https://w.soundcloud.com/player"
+                ]
+            }
         ],
         "replacementButton": {
             "unblockDomains": [
@@ -358,10 +363,15 @@
             "open.spotify.com",
             "podcasters.spotify.com"
         ],
-        "buttonSelectors": [
-            "iframe[src^='https://embed.spotify.com/']",
-            "iframe[src^='https://open.spotify.com/embed']",
-            "iframe[src^='https://podcasters.spotify.com/pod/']"
+        "selectors": [
+            {
+                "elm": "iframe",
+                "urls": [
+                    "https://embed.spotify.com/",
+                    "https://open.spotify.com/embed",
+                    "https://podcasters.spotify.com/pod/"
+                ]
+            }
         ],
         "replacementButton": {
             "unblockDomains": [
@@ -463,15 +473,20 @@
             "www.youtube.com",
             "www.youtube-nocookie.com"
         ],
-        "buttonSelectors": [
-            "iframe[src^='//youtube.com/embed']",
-            "iframe[src^='//www.youtube.com/embed']",
-            "iframe[src^='http://www.youtube.com/embed']",
-            "iframe[src^='https://www.youtube.com/embed']",
-            "iframe[src^='https://youtube.com/embed']",
-            "iframe[src^='https://www.youtube.com/v/']",
-            "iframe[src^='//www.youtube-nocookie.com/embed']",
-            "iframe[src^='https://www.youtube-nocookie.com/embed']"
+        "selectors": [
+            {
+                "elm": "iframe",
+                "urls": [
+                    "//youtube.com/embed",
+                    "//www.youtube.com/embed",
+                    "http://www.youtube.com/embed",
+                    "https://www.youtube.com/embed",
+                    "https://youtube.com/embed",
+                    "https://www.youtube.com/v/",
+                    "//www.youtube-nocookie.com/embed",
+                    "https://www.youtube-nocookie.com/embed"
+                ]
+            }
         ],
         "replacementButton": {
             "unblockDomains": [

--- a/src/js/contentscripts/utils.js
+++ b/src/js/contentscripts/utils.js
@@ -66,7 +66,9 @@ window.FRAME_URL = getFrameUrl();
 // investigate implications of third-party scripts in nested frames
 // generating pbSurrogateMessage events
 if (window.top != window) {
-  return;
+  if (!window.FRAME_URL.startsWith('https://cdn.embedly.com/')) {
+    return;
+  }
 }
 
 document.addEventListener("pbSurrogateMessage", function (e) {

--- a/src/js/contentscripts/utils.js
+++ b/src/js/contentscripts/utils.js
@@ -61,16 +61,6 @@ window.FRAME_URL = getFrameUrl();
 
 // END FUNCTION DEFINITIONS ///////////////////////////////////////////////////
 
-// register listener in top-level frames only for now
-// NOTE: before removing this restriction,
-// investigate implications of third-party scripts in nested frames
-// generating pbSurrogateMessage events
-if (window.top != window) {
-  if (!window.FRAME_URL.startsWith('https://cdn.embedly.com/')) {
-    return;
-  }
-}
-
 document.addEventListener("pbSurrogateMessage", function (e) {
   if (e.detail && e.detail.type == "widgetFromSurrogate") {
     chrome.runtime.sendMessage({

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1780,10 +1780,6 @@ function dispatcher(request, sender, sendResponse) {
         let tab_scheme = tab_url.slice(0, tab_url.indexOf(tab_host));
         if (!request.frameUrl.startsWith(tab_scheme + tab_host)) {
           let frame_host = extractHostFromURL(request.frameUrl);
-          // CNAME uncloaking
-          if (utils.hasOwn(badger.cnameDomains, frame_host)) {
-            frame_host = badger.cnameDomains[frame_host];
-          }
           if (!frame_host || utils.isThirdPartyDomain(frame_host, tab_host)) {
             break;
           }


### PR DESCRIPTION
Fixes #2989. Follows up on #2852.

Also fixes replacing Embedly frame loaded (nested) surrogate JS API-powered widgets:
- https://www.mediapart.fr/journal/france/290321/affaire-myriam-sakhri-la-famille-espere-une-reouverture-de-l-enquete (YouTube)
- https://medium.com/@samuelwestwood/time-saving-things-that-actually-work-trust-me-28461a6f4a41

Lazy loaded example that still doesn't work:

- https://kotaku.com/peach-is-a-monster-in-smash-ultimate-pros-say-1831613178

Surrogate JS API-powered example that no longer works (unrelated to this PR; a "loading" overlay hides our placeholder):

- https://www.aljazeera.com/program/talk-to-al-jazeera/2022/9/16/iran-raisi-no-benefit-in-direct-nuclear-negotiations-with-us