### PR TITLE
Fix close button misalignment in error report overlay

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -166,12 +166,12 @@ function init() {
   $("#activate_site_btn").on("click", activateOnSite);
   $("#deactivate_site_btn").on("click", deactivateOnSite);
 
-  $('#error_input').on('input propertychange', function() {
+  $('#error-input').on('input propertychange', function() {
     // No easy way of sending message on popup close, send message for every change
     chrome.runtime.sendMessage({
       type: 'saveErrorText',
       tabId: POPUP_DATA.tabId,
-      errorText: $("#error_input").val()
+      errorText: $("#error-input").val()
     });
   });
 
@@ -190,9 +190,9 @@ function init() {
   $("#report-button").on("click", function() {
     $(this).prop("disabled", true);
     $("#report-cancel").prop("disabled", true);
-    send_error($("#error_input").val());
+    send_error($("#error-input").val());
   });
-  $("#report_close").on("click", function (e) {
+  $("#report-close").on("click", function (e) {
     e.preventDefault();
     clearSavedErrorText();
     closeOverlay();
@@ -243,12 +243,12 @@ function init() {
     e.preventDefault();
     share();
   });
-  $("#share_close").on("click", function (e) {
+  $("#share-close").on("click", function (e) {
     e.preventDefault();
-    $("#share_overlay").toggleClass('active', false);
+    $("#share-overlay").toggleClass('active', false);
   });
   $("#copy-button").on("click", function() {
-    $("#share_output").select();
+    $("#share-output").select();
     document.execCommand('copy');
     $(this).text(chrome.i18n.getMessage("copy_button_copied"));
   });
@@ -300,7 +300,7 @@ function closeOverlay() {
   $('#overlay').toggleClass('active', false);
   $("#report-success").hide();
   $("#report-fail").hide();
-  $("#error_input").val("");
+  $("#error-input").val("");
 }
 
 /**
@@ -362,7 +362,7 @@ function send_error(message) {
     });
 
     sendReport.done(function() {
-      $("#error_input").val("");
+      $("#error-input").val("");
       $("#report-success").slideDown();
 
       clearSavedErrorText();
@@ -426,13 +426,13 @@ function deactivateOnSite() {
  * Open the share overlay
  */
 function share() {
-  $("#share_overlay").toggleClass('active');
+  $("#share-overlay").toggleClass('active');
   let share_msg = chrome.i18n.getMessage("share_base_message");
 
   // only add language about found trackers if we actually found trackers
   // (but regardless of whether we are actually blocking them)
   if (POPUP_DATA.noTabData) {
-    $("#share_output").val(share_msg);
+    $("#share-output").val(share_msg);
     return;
   }
 
@@ -443,7 +443,7 @@ function share() {
   }
 
   if (!originsArr.length) {
-    $("#share_output").val(share_msg);
+    $("#share-output").val(share_msg);
     return;
   }
 
@@ -465,7 +465,7 @@ function share() {
     share_msg += "\n\n";
     share_msg += tracking.join("\n");
   }
-  $("#share_output").val(share_msg);
+  $("#share-output").val(share_msg);
 }
 
 /**
@@ -616,7 +616,7 @@ function refreshPopup() {
 
   // if there is any saved error text, fill the error input with it
   if (utils.hasOwn(POPUP_DATA, 'errorText')) {
-    $("#error_input").val(POPUP_DATA.errorText);
+    $("#error-input").val(POPUP_DATA.errorText);
   }
   // show error layout if the user was writing an error report
   if (utils.hasOwn(POPUP_DATA, 'errorText') && POPUP_DATA.errorText) {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -56,7 +56,7 @@ function setTextDirection() {
   // popup page
   if (ON_POPUP) {
     // fix floats
-    ['#fittslaw', '.overlay_close'].forEach((selector) => {
+    ['#fittslaw', '.overlay-close'].forEach((selector) => {
       toggle_css_value(selector, "float", "right", "left");
     });
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -410,15 +410,15 @@ div.overlay.active {
   z-index: 31;
   opacity: 1;
 }
-#error_input {
+#error-input {
     display: block;
     width: 98%;
 }
-.overlay_title {
+.overlay-title {
   padding: 0;
   margin: 0 0 10px;
 }
-#report_label {
+#report-label {
   display: block;
   margin: 1% 0;
   font-weight: bold;
@@ -437,7 +437,7 @@ div.overlay.active {
 #report-terms {
     margin: 10px 0 !important;
 }
-a.overlay_close {
+a.overlay-close {
   float: right;
   background: none;
   border: 0;
@@ -446,14 +446,14 @@ a.overlay_close {
   text-decoration: none;
   margin-inline-start: 10px;
 }
-a.overlay_close:before {
+a.overlay-close:before {
   content: '\2716';
   margin: 4px;
 }
-a.overlay_close:hover {
+a.overlay-close:hover {
     color: #f06a0a;
 }
-#share_output {
+#share-output {
   display: block;
   width: 98%;
   height: 60%;
@@ -647,7 +647,7 @@ a.overlay_close:hover {
         color: #f9f9f9;
     }
 
-    textarea, #share_output {
+    textarea, #share-output {
         background-color: #333;
         border: solid 1px #555;
         color: #ddd;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -415,7 +415,6 @@ div.overlay.active {
     width: 98%;
 }
 .overlay_title {
-  display: inline-block;
   padding: 0;
   margin: 0 0 10px;
 }
@@ -439,13 +438,13 @@ div.overlay.active {
     margin: 10px 0 !important;
 }
 a.overlay_close {
-  display: inline-block;
   float: right;
   background: none;
   border: 0;
   font-size: 1.4em;
   color: #ccc;
   text-decoration: none;
+  margin-left: 10px;
 }
 a.overlay_close:before {
   content: '\2716';

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -444,7 +444,7 @@ a.overlay_close {
   font-size: 1.4em;
   color: #ccc;
   text-decoration: none;
-  margin-left: 10px;
+  margin-inline-start: 10px;
 }
 a.overlay_close:before {
   content: '\2716';

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -73,8 +73,10 @@
   </div><!-- end of div#instruction -->
 
   <div id="overlay" class="overlay">
-    <h1 id="report_title" class="i18n_report_broken_site overlay_title"></h1>
-    <a href="" id="report_close" class="i18n_report_close overlay_close" role="button"></a>
+    <div>
+      <a href="" id="report_close" class="i18n_report_close overlay_close" role="button"></a>
+      <h1 id="report_title" class="i18n_report_broken_site overlay_title"></h1>
+    </div>
     <div id="report-youtube-message-container" style="display:none">
       <div id="report-youtube-message"></div>
     </div>
@@ -89,8 +91,10 @@
     <p id="report-terms" class="i18n_report_terms"></p>
   </div>
   <div id="share_overlay" class="overlay">
-    <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
-    <a href="" id="share_close" class="i18n_report_close overlay_close" role="button"></a>
+    <div>
+      <a href="" id="share_close" class="i18n_report_close overlay_close" role="button"></a>
+      <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
+    </div>
     <textarea id="share_output" name="share_output" spellcheck="false"></textarea>
     <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
   </div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -74,14 +74,14 @@
 
   <div id="overlay" class="overlay">
     <div>
-      <a href="" id="report_close" class="i18n_report_close overlay_close" role="button"></a>
-      <h1 id="report_title" class="i18n_report_broken_site overlay_title"></h1>
+      <a href="" id="report-close" class="i18n_report_close overlay-close" role="button"></a>
+      <h1 class="i18n_report_broken_site overlay-title"></h1>
     </div>
     <div id="report-youtube-message-container" style="display:none">
       <div id="report-youtube-message"></div>
     </div>
-    <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
-    <textarea id="error_input" name="error_input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
+    <label id="report-label" for="error-input" class="i18n_report_input_label"></label>
+    <textarea id="error-input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
     <div id="report-controls">
       <button id="report-button" class="i18n_report_button pbButton"></button>
       <button id="report-cancel" class="i18n_report_cancel pbButton"></button>
@@ -90,12 +90,12 @@
     <div id="report-fail" class="i18n_report_fail" style="display:none"></div>
     <p id="report-terms" class="i18n_report_terms"></p>
   </div>
-  <div id="share_overlay" class="overlay">
+  <div id="share-overlay" class="overlay">
     <div>
-      <a href="" id="share_close" class="i18n_report_close overlay_close" role="button"></a>
-      <h1 id="share_title" class="i18n_share_title overlay_title"></h1>
+      <a href="" id="share-close" class="i18n_report_close overlay-close" role="button"></a>
+      <h1 class="i18n_share_title overlay-title"></h1>
     </div>
-    <textarea id="share_output" name="share_output" spellcheck="false"></textarea>
+    <textarea id="share-output" spellcheck="false"></textarea>
     <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
   </div>
 

--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -260,7 +260,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.load_url(DUMMY_PAGE_URL)
         self.open_popup(DUMMY_PAGE_URL)
 
-        report_input = self.driver.find_element(By.ID, "error_input")
+        report_input = self.driver.find_element(By.ID, "error-input")
         assert not report_input.is_displayed(), (
             "Error reporting should be closed by default")
 
@@ -270,7 +270,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         assert report_input.is_displayed(), (
             "Error reporting should be open")
 
-        self.driver.find_element(By.ID, "report_close").click()
+        self.driver.find_element(By.ID, "report-close").click()
         time.sleep(1)
         assert not report_input.is_displayed(), (
             "Error reporting should have gotten closed")
@@ -284,7 +284,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         self.driver.switch_to.window(self.driver.window_handles[0])
         self.open_popup(DUMMY_PAGE_URL)
         time.sleep(1)
-        report_input = self.driver.find_element(By.ID, "error_input")
+        report_input = self.driver.find_element(By.ID, "error-input")
         assert report_input.is_displayed(), "Error reporting should be open"
         assert report_input.get_attribute('value') == ERROR_REPORT_TEXT, (
             "Previously entered text should be displayed")


### PR DESCRIPTION
For testing, check the share overlay and the error report overlay. Add more text to the title until text wraps onto two lines.