### PR TITLE
Add widget replacement for more Twitch embeds

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -407,14 +407,23 @@
         }
     },
     "Twitch Player": {
-        "domain": "player.twitch.tv",
+        "domains": [
+            "embed.twitch.tv",
+            "player.twitch.tv",
+            "www.twitch.tv",
+            "twitch.tv"
+        ],
         "buttonSelectors": [
+            "iframe[src^='https://embed.twitch.tv?']",
             "iframe[src^='https://player.twitch.tv/']",
-            "iframe[src^='//player.twitch.tv/']"
+            "iframe[src^='//player.twitch.tv/']",
+            "iframe[src^='https://www.twitch.tv/embed/']",
+            "iframe[src^='https://twitch.tv/embed/']"
         ],
         "replacementButton": {
             "unblockDomains": [
-                "player.twitch.tv"
+                "twitch.tv",
+                "*.twitch.tv"
             ],
             "type": 3
         }


### PR DESCRIPTION
Fixes #2540, closes #2785.

If this works, we'll be able to remove the following text and image from https://livestream.eff.org/:

>Using EFF's Privacy Badger? If you'd like to log in to Twitch chat, give it your permission by shifting the "embed.twitch.tv" slider and reload the page.

<img src="https://livestream.eff.org/images/privacy_badger_embedstream.png" height="200">

In order for replacement to happen, we need to remove `twitch.tv` from the yellowlist, so that we can block `embed.twitch.tv`. This means we release this patch, wait for most clients to update, remove `twitch.tv`, and then see if we need to restore some subdomains of Twitch, or, if our replacements don't work well enough, restore all of `twitch.tv`.