### PR TITLE
Add Miraheze/Wikitide to MDFP

### DIFF
--- a/src/js/multiDomainFirstParties.js
+++ b/src/js/multiDomainFirstParties.js
@@ -3131,6 +3131,7 @@ let multiDomainFirstPartiesArray = [
     "cloud.githubusercontent.com",
     "raw.githubusercontent.com",
   ],
+  ["miraheze.org", "wikitide.net"],
   ["mobilism.org.in", "mobilism.org"],
   ["morganstanley.com", "morganstanleyclientserv.com", "stockplanconnect.com", "ms.com"],
   [


### PR DESCRIPTION
There's a long complicated story here - WikiTide forked from Miraheze following a hairy internal dispute and then they later merged together again. Anyway, right now the domains `wikitide.net` and `miraheze.org` are controlled by the same entity.

Privacy Badger says: 
```
wikitide.net was seen tracking on the following sites:

    miraheze.org
    orain.org
    sekaipedia.org
```

All of these domains are also technically first-parties controlled by Miraheze/Wikitide but since they let users add their own custom domains there's no point in listing every single one. I'm listing these two because my badger learned to block wikitide.net (I have local learning enabled) and it caused https://issue-tracker.miraheze.org/ to fail to load properly.