### PR TITLE
Add widget replacement placeholder for Threads

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -396,6 +396,21 @@
             "type": 3
         }
     },
+    "Threads": {
+        "domain": "www.threads.net",
+        "buttonSelectors": [
+            "blockquote.text-post-media[data-text-post-permalink^='https://www.threads.net/']"
+        ],
+        "scriptSelectors": [
+            "script[src^='https://www.threads.net/embed.js']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "www.threads.net"
+            ],
+            "type": 3
+        }
+    },
     "TikTok": {
         "domains": [
             "www.tiktok.com"

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -501,14 +501,17 @@ function createReplacementWidget(widget, elToReplace) {
     }
   } else if (elToReplace.nodeName.toLowerCase() == 'blockquote') {
     if (elToReplace.cite && elToReplace.cite.startsWith('https://')) {
-      // special case for TikTok
+      // TikTok
       widget_url = elToReplace.cite;
     } else if (elToReplace.className.includes("twitter-tweet") || elToReplace.className.includes("twitter-video")) {
-      // special case for Twitter
+      // Twitter
       let lastLink = Array.from(elToReplace.querySelectorAll("a[href^='https://twitter.com/']")).slice(-1)[0];
       if (lastLink) {
         widget_url = lastLink.href;
       }
+    } else if (elToReplace.dataset && elToReplace.dataset.textPostPermalink && elToReplace.dataset.textPostPermalink.startsWith('https://www.threads.net/')) {
+      // Threads
+      widget_url = elToReplace.dataset.textPostPermalink;
     }
   }
 


### PR DESCRIPTION
Examples:

- https://www.theverge.com/2024/7/31/24210511/bluecruisn-over-the-atlantic
- https://www.macrumors.com/2024/07/25/threads-app-gets-tweetdeck-dedicated-feeds/
- https://boingboing.net/2024/01/16/the-perfect-answer-to-god-made-trump-video-is-god-made-a-dictator.html
- https://fandomwire.com/i-was-paid-for-the-script-and-finished-it-unlike-zack-snyder-james-gunn-doesnt-regret-being-kicked-out-as-director-from-his-own-passion-project-14-years-ago/ (inline activation doesn't seem to work but maybe not PB's fault?)