### PR TITLE
Hide widget replacement toggle

### DIFF
--- a/src/data/schema.json
+++ b/src/data/schema.json
@@ -38,11 +38,6 @@
             "title": "Show intro page",
             "description": "If set to false then do not open the new user intro page upon install.",
             "type": "boolean"
-        },
-        "socialWidgetReplacementEnabled": {
-            "title": "Replace social widgets",
-            "description": "Toggles social widget replacement.",
-            "type": "boolean"
         }
     }
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -295,6 +295,12 @@ function loadOptions() {
   $widgetExceptions.on('select2:unselect', updateWidgetReplacementExceptions);
   $widgetExceptions.on('select2:clear', updateWidgetReplacementExceptions);
 
+  // hide the deprecated widget replacement toggle
+  // unless the user previously checked it
+  if (!OPTIONS_DATA.settings.socialWidgetReplacementEnabled) {
+    $('#widget-replacement-toggle').show();
+  }
+
   reloadDisabledSites();
   reloadTrackingDomainsTab();
   reloadWidgetSiteExceptions();

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -254,7 +254,7 @@
 
   <div id="tab-manage-widgets">
     <p><span class="i18n_options_widget_replacement_desc"></span></p>
-    <p>
+    <p id="widget-replacement-toggle" style="display:none">
     <label>
       <input type="checkbox" id="replace-widgets-checkbox">
       <span class="i18n_options_social_widgets_checkbox"></span>

--- a/tests/selenium/widgets_test.py
+++ b/tests/selenium/widgets_test.py
@@ -296,39 +296,6 @@ class WidgetsTest(pbtest.PBSeleniumTest):
         self.assert_no_replacement()
         self.assert_widget()
 
-    def test_disabling_all_replacement(self):
-        self.block_domain(self.THIRD_PARTY_DOMAIN)
-
-        # disable widget replacement
-        self.load_url(self.options_url)
-        self.wait_for_script("return window.OPTIONS_INITIALIZED")
-        self.find_el_by_css('a[href="#tab-manage-widgets"]').click()
-        self.driver.find_element(By.ID, 'replace-widgets-checkbox').click()
-
-        # verify basic widget is no longer replaced
-        self.load_url(self.BASIC_FIXTURE_URL)
-        self.assert_no_replacement()
-        self.assert_widget_blocked()
-        # type 4 replacement should also be missing
-        self.assert_no_replacement(self.TYPE4_WIDGET_NAME)
-        # type 4 widget should also have gotten blocked
-        try:
-            widget_div = self.driver.find_element(By.CSS_SELECTOR,
-                'div.pb-type4-test-widget')
-        except NoSuchElementException:
-            self.fail("Widget div should still be here")
-        # check the div's text a few times to make sure it stays empty
-        for _ in range(3):
-            assert not widget_div.text, (
-                "Widget output container should remain empty")
-            sleep(1)
-
-        # verify dynamic widget is no longer replaced
-        self.load_url(self.DYNAMIC_FIXTURE_URL)
-        self.find_el_by_css('#widget-trigger').click()
-        self.assert_no_replacement()
-        self.assert_widget_blocked()
-
     def test_disabling_replacement_for_one_widget(self):
         self.block_domain(self.THIRD_PARTY_DOMAIN)
 


### PR DESCRIPTION
The first part of #3007. We could make the deprecation more visible by doing something like #2783, but it doesn't feel like we need to in this case.