### PR TITLE
Simplify intro text on the Disabled Sites tab

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -464,16 +464,16 @@
         "description": "Placeholder for a text input under the Disabled Sites tab on the options page"
     },
     "add_domain_button": {
-        "message": "Add domain",
-        "description": "Button found under the Disabled Sites tab on the options page"
+        "message": "Add site",
+        "description": "Button on the Disabled Sites options page tab"
     },
     "remove_button": {
         "message": "Remove selected",
-        "description": "Button found under the Disabled Sites tab on the options page"
+        "description": "Button on the Disabled Sites options page tab"
     },
     "invalid_domain": {
         "message": "Please add a valid domain or URL",
-        "description": "Error shown when attempting to add an invalid domain to the list of disabled sites"
+        "description": "Error text for the form on the Disabled Sites options page tab"
     },
     "options_widget_replacement_tab": {
         "message": "Widget Replacement",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -456,8 +456,8 @@
         "description": "Options page tab heading"
     },
     "disabled_for_these_domains": {
-        "message": "<p>Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here, and it will not send the Do Not Track or Global Privacy Control signals.</p><p>If you think Privacy Badger is breaking a page, or you would like to allow a particular site to share or sell your data, you can type that page's domain in the box below and click the \"Add domain\" button.</p>",
-        "description": "Shown on the options page under the Disabled Sites tab. 'Add domain' should match the 'add_domain_button' message."
+        "message": "Privacy Badger is disabled on the following sites. This means that Privacy Badger will not block anything when you visit the sites listed here, and it will not send the Do Not Track or Global Privacy Control signals.",
+        "description": "Intro text on the Disabled Sites options page tab"
     },
     "allowlist_domain_input_placeholder": {
         "message": "e.g. www.example.com, *.example.net, example.org",

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -134,7 +134,7 @@
   </div>
 
   <div id="tab-allowlist">
-    <div class="i18n_disabled_for_these_domains"></div>
+    <p class="i18n_disabled_for_these_domains"></p>
 
     <form id="allowlist-form" action="#">
       <div>


### PR DESCRIPTION
Too much text means users tend not to read any of it, and we don't need to explain how basic forms work.

Also, "Add domain" is now "Add site".

The new, single-paragraph intro:

![Screenshot from 2024-08-26 10-02-29](https://github.com/user-attachments/assets/7eefde8f-b3f3-425c-b978-ff4d60cb0bae)