### PR TITLE
Fix icon overlap on RTL widget placeholders

### DIFF
--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -700,6 +700,7 @@ html, body {
 #${close_icon_id} {
   ${TRANSLATIONS.rtl ? "right" : "left"}: 4px;
   width: 20px;
+  ${TRANSLATIONS.rtl ? "left" : "right"}: unset;
 }
 #${info_icon_id}:before, #${close_icon_id}:before {
   border: 2px solid;


### PR DESCRIPTION
Fixes #3023

<img width="705" alt="צילום מסך 2024-10-08 ב-3 42 10 אח׳" src="https://github.com/user-attachments/assets/4bc83e40-16d6-481e-b00b-289e216eb0e9">
