### PR TITLE
Add widget replacement placeholder for Bluesky

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -53,6 +53,23 @@
             "type": 3
         }
     },
+    "Bluesky": {
+        "domain": "embed.bsky.app",
+        "buttonSelectors": [
+            "blockquote.bluesky-embed[data-bluesky-cid]"
+        ],
+        "scriptSelectors": [
+            "script[src^='https://embed.bsky.app/static/embed.js']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "public.api.bsky.app",
+                "cdn.bsky.app",
+                "embed.bsky.app"
+            ],
+            "type": 3
+        }
+    },
     "Captivate Player": {
         "domain": "player.captivate.fm",
         "buttonSelectors": [

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -56,7 +56,8 @@
     "Bluesky": {
         "domain": "embed.bsky.app",
         "buttonSelectors": [
-            "blockquote.bluesky-embed[data-bluesky-cid]"
+            "blockquote.bluesky-embed[data-bluesky-cid]",
+            "iframe[src^='https://embed.bsky.app/embed/']"
         ],
         "scriptSelectors": [
             "script[src^='https://embed.bsky.app/static/embed.js']"

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -513,6 +513,12 @@ function createReplacementWidget(widget, elToReplace) {
     } else if (elToReplace.dataset && elToReplace.dataset.textPostPermalink && elToReplace.dataset.textPostPermalink.startsWith('https://www.threads.net/')) {
       // Threads
       widget_url = elToReplace.dataset.textPostPermalink;
+    } else if (elToReplace.dataset && elToReplace.dataset.blueskyUri) {
+      // Bluesky
+      let buri = elToReplace.dataset.blueskyUri.split('/');
+      if (buri[0] && buri[0] == "at:" && buri[2] && buri[2].startsWith("did:") && buri[4]) {
+        widget_url = "https://bsky.app/profile/" + buri[2] + "/post/" + buri[4];
+      }
     }
   } else if (node_name == 'amp-twitter') {
     // AMP Twitter

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -492,6 +492,13 @@ function createReplacementWidget(widget, elToReplace) {
     // use the frame URL for framed widgets
     if (elToReplace.src) {
       widget_url = elToReplace.src;
+      if (widget_url.startsWith("https://embed.bsky.app/embed/")) {
+        // Bluesky
+        let buri = (new URL(widget_url)).pathname.split("/");
+        if (buri[2] && buri[2].startsWith("did:") && buri[4]) {
+          widget_url = "https://bsky.app/profile/" + buri[2] + "/post/" + buri[4];
+        }
+      }
     } else {
       for (let prop of lazyLoadDatasetSrcProps) {
         if (elToReplace.dataset[prop]) {


### PR DESCRIPTION
Seen on theverge.com, techdirt.com ([example](https://www.techdirt.com/2024/10/29/some-slightly-biased-thoughts-on-the-state-of-decentralized-social-media/)), beeradvocate.com

More examples:
- https://bsky.social/about/blog/post-embeds-guide
- toothpastefordinner.com
- bancodeseries.com.br