### PR TITLE
Add widget replacement placeholder for Instagram

### DIFF
--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -277,6 +277,29 @@
             "type": 3
         }
     },
+    "Instagram": {
+        "domains": [
+            "www.instagram.com",
+            "platform.instagram.com"
+        ],
+        "buttonSelectors": [
+            "blockquote.instagram-media[data-instgrm-permalink]",
+            "blockquote.instagram-media-registered[data-instgrm-permalink]",
+            "amp-instagram"
+        ],
+        "scriptSelectors": [
+            "script[src^='//www.instagram.com/embed.js']",
+            "script[src^='https://www.instagram.com/embed.js']",
+            "script[src^='//platform.instagram.com/en_US/embeds.js']"
+        ],
+        "replacementButton": {
+            "unblockDomains": [
+                "www.instagram.com",
+                "platform.instagram.com"
+            ],
+            "type": 3
+        }
+    },
     "LinkedIn": {
         "domain": "platform.linkedin.com",
         "buttonSelectors": [

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -526,12 +526,23 @@ function createReplacementWidget(widget, elToReplace) {
       if (buri[0] && buri[0] == "at:" && buri[2] && buri[2].startsWith("did:") && buri[4]) {
         widget_url = "https://bsky.app/profile/" + buri[2] + "/post/" + buri[4];
       }
+    } else if (elToReplace.dataset && elToReplace.dataset.instgrmPermalink && elToReplace.dataset.instgrmPermalink.startsWith('https://www.instagram.com/')) {
+      // Instagram
+      widget_url = elToReplace.dataset.instgrmPermalink;
     }
   } else if (node_name == 'amp-twitter') {
     // AMP Twitter
-    let tweet_id = elToReplace.dataset.tweetid.replace(/[^0-9]/g, '');
+    let tweet_id = elToReplace.dataset && elToReplace.dataset.tweetid &&
+      elToReplace.dataset.tweetid.replace(/[^0-9]/g, '');
     if (tweet_id) {
       widget_url = "https://twitter.com/x/status/" + tweet_id;
+    }
+  } else if (node_name == 'amp-instagram') {
+    // AMP Instagram
+    let shortcode = elToReplace.dataset && elToReplace.dataset.shortcode &&
+      elToReplace.dataset.shortcode.replace(/^0-9A-Za-z/g, '');
+    if (shortcode) {
+      widget_url = "https://www.instagram.com/p/" + shortcode;
     }
   }
 


### PR DESCRIPTION
Seen on theverge.com and toothpastefordinner.com

>[!NOTE]
>`instagram.com` is [currently on the yellowlist](https://github.com/EFForg/privacybadger/blob/8dba49fdf26c31a58afd094422b175ccf06ed234/src/data/pbconfig.json#L396), which means we have to manually move the toggle to "block" first for the widget replacement to work.

More examples:

- https://time.com/7020451/taylor-swift-kamala-harris-donald-trump-ai/
- https://deadline.com/2024/09/taylor-swift-endorses-kamala-harris-1236084389/
- https://www.euronews.com/green/2024/01/03/sweden-portugal-luxembourg-which-eu-countries-use-the-most-and-least-renewable-energy
- https://stylebyemilyhenderson.com/blog/5-color-palettes-to-freshen-up-a-tired-honey-oak-kitchen
- https://montreal.eater.com/maps/best-brunch-restaurants-montreal
- https://www.vesti.bg/lyubopitno/imenie-v-dubaj-samolet-luksozni-koli-podarycite-za-svatbata-na-ambani-6204723
- https://www.seiska.fi/urheilu/josses-suomen-seksikkain-uimari-veera-kivirinta-revittelee-somessa/1484647
- https://wydarzenia.interia.pl/ciekawostki/news-choroba-po-zjedzeniu-borowika-ostrzegaja-przed-tymi-prawdziw,nId,6949241
- https://sport1.maariv.co.il/square/article/1182890/
- https://gong.bg/oshte-sport/drugi-sportove/multimedia/gallery/demi-pak-ostana-pochti-chisto-gola-737742
- https://www.theinertia.com/surf/ben-gravy-surfing-a-stupidly-long-mini-wave-in-the-florida-panhandle/
- https://www.narcity.com/32-popular-canadian-snacks-that-you-cant-buy-in-the-united-states (alt selector)
- https://www.comicsands.com/ohio-taylor-bruck-coming-out (alt selector)
- https://escapecollective.com/the-stories-we-didnt-get-around-to-writing-at-the-spring-classics/ (alt selector)
- https://thebuzz.iheart.com/alternate/amp/2024-06-27-lookin-at-girlzzz-katy-perry-miranda-tori-tiffani-thiessen-sophia/ (AMP)

Broken examples:
- https://timesofindia.indiatimes.com/technology/tech-news/taylor-swift-calls-out-donald-trumps-ai-photos-writes-why-i-am-telling-who-i-will-vote-for/articleshow/113257130.cms (service worker, frame ID of -1 doesn't match 0 in the content script upon receiving "replaceWidget", plus lazy loader (that we fail to replace because of timing issues))
- https://cavesocial.com/embed-instagram-photo-website-blog (missing data attribute)
- https://www.cosmopolitan.com/style-beauty/beauty/g38452978/3a-hairstyle-ideas/

Follows up on #3028 and #3006.