### PR TITLE
Add close icon to breakage note tooltip

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -569,7 +569,12 @@ function createBreakageNote(domain, i18n_message_key) {
   // return the tooltip we want (the breakage note, not Allow)
   $slider_allow.tooltipster('destroy').tooltipster({
     autoClose: false,
-    content: chrome.i18n.getMessage(i18n_message_key),
+    content: $(`<div>
+                    <a href="" id="dismiss-tooltip" role="button" aria-label="i18n_report_close">
+                      <img src="../icons/close.svg" alt="">
+                    </a>
+                  <div>${chrome.i18n.getMessage(i18n_message_key)}</div>
+                </div>`),
     functionReady: function (tooltip) {
       // close on tooltip click/tap
       $(tooltip.elementTooltip()).on('click', function (e) {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -59,6 +59,15 @@ function setTextDirection() {
     ['#fittslaw', '.overlay-close'].forEach((selector) => {
       toggle_css_value(selector, "float", "right", "left");
     });
+    // Workaround for tooltipster dynamically inserted after localization
+    let css = document.createElement("style");
+    css.textContent = `
+    #dismiss-tooltip {
+      float: left;
+      right: unset;
+      left: -5px;
+    }`;
+    document.body.appendChild(css);
 
   // options page
   } else if (document.location.pathname == "/skin/options.html") {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -533,6 +533,24 @@ a.overlay-close:hover {
     cursor: pointer;
 }
 
+#dismiss-tooltip {
+    float: right;
+    margin: 5px;
+    position: relative;
+    top: -5px;
+    right: -5px;
+}
+  
+#dismiss-tooltip img {
+    height: 18px;
+    filter: invert(100%) sepia(0%) saturate(7489%) hue-rotate(126deg) brightness(106%) contrast(100%);
+}
+  
+#dismiss-tooltip:hover img, #dismiss-tooltip:focus img {
+    /* Calculated with https://codepen.io/sosuke/pen/Pjoqqp to match #fff */
+    filter: invert(93%) sepia(8%) saturate(30%) hue-rotate(203deg) brightness(99%) contrast(94%);
+}
+
 #firstparty-protections-container, #youtube-message-container {
     border-bottom: 1px solid #d3d3d3;
     margin: 10px 0;


### PR DESCRIPTION
As we are making the breakage tooltip appear consistently (#3029), we should follow [tooltip best practices](https://userpilot.com/blog/tooltip-best-practices/#:~:text=Allow%20easy%20exit%20from%20tooltips&text=You%20could%20use%20an%20X,user%20knows%20how%20to%20exit.) and make it clear how users can close it

<img width="491" alt="Screenshot 2024-11-21 at 10 51 29 AM" src="https://github.com/user-attachments/assets/853bd15d-b314-40f4-824c-c9cd161d8580">


