### PR TITLE
Prefer sender.origin for determining message sender's frame host

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -543,19 +543,19 @@ Badger.prototype = {
   },
 
   /**
-   * Saves a user preference for an origin, overriding the default setting.
+   * Saves a user preference for a domain, overriding the default setting.
    *
    * @param {String} userAction enum of block, cookieblock, noaction
-   * @param {String} origin the third party origin to take action on
+   * @param {String} domain the third party domain to take action on
    */
-  saveAction: function(userAction, origin) {
-    var allUserActions = {
+  saveAction: function(userAction, domain) {
+    let allUserActions = {
       block: constants.USER_BLOCK,
       cookieblock: constants.USER_COOKIEBLOCK,
       allow: constants.USER_ALLOW
     };
-    this.storage.setupUserAction(origin, allUserActions[userAction]);
-    log("Finished saving action " + userAction + " for " + origin);
+    this.storage.setupUserAction(domain, allUserActions[userAction]);
+    log(`Finished saving action ${userAction} for ${domain}`);
   },
 
   initializeCnames: function () {
@@ -1127,7 +1127,7 @@ Badger.prototype = {
    * and if necessary updates the badge.
    *
    * @param {Integer} tab_id the tab we are on
-   * @param {String} fqdn the third party origin to add
+   * @param {String} fqdn the third party domain to add
    * @param {String} action the action we are taking
    */
   logThirdParty: function (tab_id, fqdn, action) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -527,8 +527,7 @@ Badger.prototype = {
 
     // block the domains
     for (let domain of domains) {
-      self.heuristicBlocking.blocklistOrigin(
-        getBaseDomain(domain), domain);
+      self.heuristicBlocking.blocklistDomain(getBaseDomain(domain), domain);
     }
   },
 
@@ -539,7 +538,7 @@ Badger.prototype = {
    */
   blockPanopticlickDomains() {
     for (let domain of constants.PANOPTICLICK_DOMAINS) {
-      this.heuristicBlocking.blocklistOrigin(domain, domain);
+      this.heuristicBlocking.blocklistDomain(domain, domain);
     }
   },
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1131,7 +1131,7 @@ Badger.prototype = {
    * @param {String} fqdn the third party origin to add
    * @param {String} action the action we are taking
    */
-  logThirdPartyOriginOnTab: function (tab_id, fqdn, action) {
+  logThirdParty: function (tab_id, fqdn, action) {
     let self = this,
       is_blocked = (
         action == constants.BLOCK ||

--- a/src/js/contentscripts/clobbercookie.js
+++ b/src/js/contentscripts/clobbercookie.js
@@ -33,7 +33,7 @@ if (window.top == window) {
 
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
-  type: "checkLocation",
+  type: "checkClobberingEnabled",
   frameUrl: window.FRAME_URL
 }, function (blocked) {
   if (blocked) {

--- a/src/js/contentscripts/clobberlocalstorage.js
+++ b/src/js/contentscripts/clobberlocalstorage.js
@@ -33,7 +33,7 @@ if (window.top == window) {
 
 // TODO race condition; fix waiting on https://crbug.com/478183
 chrome.runtime.sendMessage({
-  type: "checkLocation",
+  type: "checkClobberingEnabled",
   frameUrl: window.FRAME_URL
 }, function (blocked) {
   if (blocked) {

--- a/src/js/contentscripts/supercookie.js
+++ b/src/js/contentscripts/supercookie.js
@@ -113,7 +113,7 @@ function getPageScript(event_id) {
 // TODO sometimes contentscripts/utils.js isn't here?!
 // TODO window.FRAME_URL / window.injectScript are undefined ...
 chrome.runtime.sendMessage({
-  type: "inspectLocalStorage",
+  type: "detectSupercookies",
   frameUrl: window.FRAME_URL
 }, function (enabledAndThirdParty) {
   if (!enabledAndThirdParty) {

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -32,12 +32,12 @@ function HeuristicBlocker(pbStorage) {
   self.storage = pbStorage;
 
   // TODO roll into tabData? -- 6/10/2019 not for now, since tabData is populated
-  // by the synchronous listeners in webrequests.js and tabOrigins is used by the
+  // by the synchronous listeners in webrequests.js and tabBases is used by the
   // async listeners here; there's no way to enforce ordering of requests among
   // those two. Also, tabData is cleaned up every time a tab is closed, so
   // dangling requests that don't trigger listeners until after the tab closes are
   // impossible to attribute to a tab.
-  self.tabOrigins = {};
+  self.tabBases = {};
   self.tabUrls = {};
 
   // initialize tab bases and URLs for already-open tabs
@@ -46,7 +46,7 @@ function HeuristicBlocker(pbStorage) {
       if (utils.isRestrictedUrl(tab.url)) {
         continue;
       }
-      self.tabOrigins[tab.id] = getBaseDomain((new URI(tab.url)).host);
+      self.tabBases[tab.id] = getBaseDomain((new URI(tab.url)).host);
       self.tabUrls[tab.id] = tab.url;
     }
   });
@@ -132,12 +132,12 @@ HeuristicBlocker.prototype = {
     // if this is a main window request, update tab data and quit
     if (details.type == "main_frame") {
       let tab_host = (new URI(details.url)).host;
-      self.tabOrigins[tab_id] = getBaseDomain(tab_host);
+      self.tabBases[tab_id] = getBaseDomain(tab_host);
       self.tabUrls[tab_id] = details.url;
       return;
     }
 
-    let tab_base = self.tabOrigins[tab_id];
+    let tab_base = self.tabBases[tab_id];
     if (!tab_base) {
       return;
     }
@@ -209,7 +209,7 @@ HeuristicBlocker.prototype = {
     }
 
     let self = this,
-      tab_base = self.tabOrigins[details.tabId];
+      tab_base = self.tabBases[details.tabId];
     if (!tab_base) {
       return;
     }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -55,16 +55,17 @@ function HeuristicBlocker(pbStorage) {
 HeuristicBlocker.prototype = {
 
   /**
-   * Blocklists a domain.
+   * Blocklists a domain:
    *
-   * - Blocks or cookieblocks an FQDN.
-   * - Blocks or cookieblocks its base domain (eTLD+1).
-   * - Cookieblocks any yellowlisted subdomains that share the base domain with the FQDN.
+   * - Blocks or cookieblocks the given domain.
+   * - Blocks or cookieblocks its eTLD+1 ("base" domain).
+   * - Cookieblocks any yellowlisted subdomains that
+   *   share the base domain with the given domain.
    *
    * @param {String} base The base domain (eTLD+1) to blocklist
-   * @param {String} fqdn The FQDN
+   * @param {String} fqdn The domain to blocklist
    */
-  blocklistOrigin: function (base, fqdn) {
+  blocklistDomain: function (base, fqdn) {
     let self = this,
       ylistStorage = self.storage.getStore("cookieblock_list");
 
@@ -438,7 +439,7 @@ HeuristicBlocker.prototype = {
     // (cookie)block if domain was seen tracking on enough first party domains
     if (firstParties.length >=
         self.storage.getStore('private_storage').getItem('blockThreshold')) {
-      self.blocklistOrigin(tracker_base, tracker_fqdn);
+      self.blocklistDomain(tracker_base, tracker_fqdn);
     }
   }
 };

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -179,7 +179,7 @@ HeuristicBlocker.prototype = {
       badger.storage.recordTrackingDetails(request_base, tab_base, 'beacon');
       // log in popup
       if (from_current_tab) {
-        badger.logThirdPartyOriginOnTab(
+        badger.logThirdParty(
           tab_id, request_host, badger.storage.getBestAction(request_host));
       }
       // don't bother checking for tracking cookies

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -510,9 +510,9 @@ function updateCheckingDNTPolicy() {
       type: "getOptionsData",
     }, (response) => {
       // update DNT-compliant domains
-      updateSliders(response.origins);
+      updateSliders(response.trackers);
       // update cached domain data
-      OPTIONS_DATA.origins = response.origins;
+      OPTIONS_DATA.trackers = response.trackers;
       // update count of blocked domains
       updateSummary();
       // toggle the "dnt" filter
@@ -613,7 +613,7 @@ function removeWidgetSiteExceptions(event) {
  * @param {String} origin - Origin to get action for.
  */
 function getOriginAction(origin) {
-  return OPTIONS_DATA.origins[origin];
+  return OPTIONS_DATA.trackers[origin];
 }
 
 function revertDomainControl(event) {
@@ -626,9 +626,9 @@ function revertDomainControl(event) {
     origin
   }, (response) => {
     // update any sliders that changed as a result
-    updateSliders(response.origins);
+    updateSliders(response.trackers);
     // update cached domain data
-    OPTIONS_DATA.origins = response.origins;
+    OPTIONS_DATA.trackers = response.trackers;
   });
 }
 
@@ -637,7 +637,7 @@ function revertDomainControl(event) {
  */
 function updateSummary() {
   // if there are no tracking domains
-  let allTrackingDomains = Object.keys(OPTIONS_DATA.origins);
+  let allTrackingDomains = Object.keys(OPTIONS_DATA.trackers);
   if (!allTrackingDomains || !allTrackingDomains.length) {
     // hide the number of trackers message
     $("#options_domain_list_trackers").hide();
@@ -658,7 +658,7 @@ function updateSummary() {
 
   // count unique (cookie)blocked tracking base domains
   let blockedBases = new Set(
-    filterDomains(OPTIONS_DATA.origins, { typeFilter: '-dnt' })
+    filterDomains(OPTIONS_DATA.trackers, { typeFilter: '-dnt' })
       .map(d => getBaseDomain(d)));
   $("#options_domain_list_trackers").html(i18n.getMessage(
     "options_domain_list_trackers", [
@@ -780,7 +780,7 @@ let filterTrackingDomains = (function () {
 
     _maybeFetchSeed(!hide_in_seed, function () {
       renderTrackingDomains(
-        filterDomains(OPTIONS_DATA.origins, {
+        filterDomains(OPTIONS_DATA.trackers, {
           searchFilter: $searchFilter.val().toLowerCase(),
           typeFilter: $typeFilter.val(),
           statusFilter: $statusFilter.val(),
@@ -994,7 +994,7 @@ function updateSliders(updatedOriginData) {
   // update any sliders that changed
   for (let domain of updated_domains) {
     let action = updatedOriginData[domain];
-    if (action == OPTIONS_DATA.origins[domain]) {
+    if (action == OPTIONS_DATA.trackers[domain]) {
       continue;
     }
 
@@ -1016,7 +1016,7 @@ function updateSliders(updatedOriginData) {
   }
 
   // remove sliders that are no longer present
-  let removed = Object.keys(OPTIONS_DATA.origins).filter(
+  let removed = Object.keys(OPTIONS_DATA.trackers).filter(
     x => !updated_domains.includes(x));
   for (let domain of removed) {
     let $clicker = $('#blockedResourcesInner div.clicker[data-origin="' + domain + '"]');
@@ -1036,11 +1036,11 @@ function saveToggle(origin, action) {
     // first update the cache for the slider
     // that was just changed by the user
     // to avoid redundantly updating it below
-    OPTIONS_DATA.origins[origin] = response.origins[origin];
+    OPTIONS_DATA.trackers[origin] = response.trackers[origin];
     // update any sliders that changed as a result
-    updateSliders(response.origins);
+    updateSliders(response.trackers);
     // update cached domain data
-    OPTIONS_DATA.origins = response.origins;
+    OPTIONS_DATA.trackers = response.trackers;
   });
 }
 
@@ -1063,9 +1063,9 @@ function removeOrigin(event) {
     origin
   }, (response) => {
     // remove rows that are no longer here
-    updateSliders(response.origins);
+    updateSliders(response.trackers);
     // update cached domain data
-    OPTIONS_DATA.origins = response.origins;
+    OPTIONS_DATA.trackers = response.trackers;
     // if we removed domains, the summary text may have changed
     updateSummary();
     // and we probably now have new visible rows in the tracking domains list

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -988,12 +988,12 @@ function updateOrigin(domain, action, userset) {
  * For example, moving the slider for example.com should move the sliders
  * for www.example.com and cdn.example.com
  */
-function updateSliders(updatedOriginData) {
-  let updated_domains = Object.keys(updatedOriginData);
+function updateSliders(updatedTrackerData) {
+  let updated_domains = Object.keys(updatedTrackerData);
 
   // update any sliders that changed
   for (let domain of updated_domains) {
-    let action = updatedOriginData[domain];
+    let action = updatedTrackerData[domain];
     if (action == OPTIONS_DATA.trackers[domain]) {
       continue;
     }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -71,18 +71,18 @@ function loadOptions() {
   $("#tracking-domains-show-not-yet-blocked").on("change", filterTrackingDomains);
   $("#tracking-domains-hide-in-seed").on("change", filterTrackingDomains);
 
-  // Add event listeners for origins container.
+  // Add event listeners for domain toggles container.
   $('#blockedResourcesContainer').on('change', 'input:radio', function () {
     let $radio = $(this),
       $clicker = $radio.parents('.clicker').first(),
-      origin = $clicker.data('origin'),
+      domain = $clicker.data('origin'),
       action = $radio.val();
 
     // update domain slider row tooltip/status indicators
-    updateOrigin(origin, action, true);
+    updateOrigin(domain, action, true);
 
     // persist the change
-    saveToggle(origin, action);
+    saveToggle(domain, action);
   });
   $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
   $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
@@ -609,21 +609,21 @@ function removeWidgetSiteExceptions(event) {
 // Tracking Domains slider functions
 
 /**
- * Gets action for given origin.
- * @param {String} origin - Origin to get action for.
+ * Gets action for given domain.
+ * @param {String} domain - Domain to get action for.
  */
-function getOriginAction(origin) {
-  return OPTIONS_DATA.trackers[origin];
+function getOriginAction(domain) {
+  return OPTIONS_DATA.trackers[domain];
 }
 
 function revertDomainControl(event) {
   event.preventDefault();
 
-  let origin = $(event.target).parent().data('origin');
+  let domain = $(event.target).parent().data('origin');
 
   chrome.runtime.sendMessage({
     type: "revertDomainControl",
-    origin
+    origin: domain
   }, (response) => {
     // update any sliders that changed as a result
     updateSliders(response.trackers);
@@ -948,8 +948,8 @@ function updatePrivacyOverride(setting_name, setting_value) {
  * Updates domain tooltip, slider color.
  * Also toggles status indicators like breakage warnings.
  */
-function updateOrigin(origin, action, userset) {
-  let $clicker = $('#blockedResourcesInner div.clicker[data-origin="' + origin + '"]'),
+function updateOrigin(domain, action, userset) {
+  let $clicker = $('#blockedResourcesInner div.clicker[data-origin="' + domain + '"]'),
     $switchContainer = $clicker.find('.switch-container').first();
 
   // update slider color via CSS
@@ -976,7 +976,7 @@ function updateOrigin(origin, action, userset) {
 
   let show_breakage_warning = (
     action == constants.BLOCK &&
-    utils.hasOwn(OPTIONS_DATA.cookieblocked, origin)
+    utils.hasOwn(OPTIONS_DATA.cookieblocked, domain)
   );
 
   htmlUtils.toggleBlockedStatus($clicker, userset, show_breakage_warning);
@@ -1027,16 +1027,16 @@ function updateSliders(updatedOriginData) {
 /**
  * Save the user setting for a domain by messaging the background page.
  */
-function saveToggle(origin, action) {
+function saveToggle(domain, action) {
   chrome.runtime.sendMessage({
     type: "saveOptionsToggle",
-    origin,
+    origin: domain,
     action
   }, (response) => {
     // first update the cache for the slider
     // that was just changed by the user
     // to avoid redundantly updating it below
-    OPTIONS_DATA.trackers[origin] = response.trackers[origin];
+    OPTIONS_DATA.trackers[domain] = response.trackers[domain];
     // update any sliders that changed as a result
     updateSliders(response.trackers);
     // update cached domain data
@@ -1045,7 +1045,7 @@ function saveToggle(origin, action) {
 }
 
 /**
- * Remove origin from Privacy Badger.
+ * Remove domain from Privacy Badger.
  * @param {Event} event Click event triggered by user.
  */
 function removeOrigin(event) {
@@ -1056,11 +1056,11 @@ function removeOrigin(event) {
     return;
   }
 
-  let origin = $(event.target).parent().data('origin');
+  let domain = $(event.target).parent().data('origin');
 
   chrome.runtime.sendMessage({
     type: "removeOrigin",
-    origin
+    origin: domain
   }, (response) => {
     // remove rows that are no longer here
     updateSliders(response.trackers);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -85,7 +85,7 @@ function loadOptions() {
     saveToggle(domain, action);
   });
   $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
-  $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
+  $('#blockedResourcesContainer').on('click', '.removeOrigin', removeDomain);
   $('#blockedResourcesInner').on('scroll', function () {
     activateDomainListTooltips();
   });
@@ -623,7 +623,7 @@ function revertDomainControl(event) {
 
   chrome.runtime.sendMessage({
     type: "revertDomainControl",
-    origin: domain
+    domain
   }, (response) => {
     // update any sliders that changed as a result
     updateSliders(response.trackers);
@@ -1030,7 +1030,7 @@ function updateSliders(updatedOriginData) {
 function saveToggle(domain, action) {
   chrome.runtime.sendMessage({
     type: "saveOptionsToggle",
-    origin: domain,
+    domain,
     action
   }, (response) => {
     // first update the cache for the slider
@@ -1048,7 +1048,7 @@ function saveToggle(domain, action) {
  * Remove domain from Privacy Badger.
  * @param {Event} event Click event triggered by user.
  */
-function removeOrigin(event) {
+function removeDomain(event) {
   event.preventDefault();
 
   // confirm removal before proceeding
@@ -1059,8 +1059,8 @@ function removeOrigin(event) {
   let domain = $(event.target).parent().data('origin');
 
   chrome.runtime.sendMessage({
-    type: "removeOrigin",
-    origin: domain
+    type: "removeDomain",
+    domain
   }, (response) => {
     // remove rows that are no longer here
     updateSliders(response.trackers);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -315,7 +315,7 @@ function send_error(message) {
     tabId: POPUP_DATA.tabId,
     tabUrl: POPUP_DATA.tabUrl
   }, (response) => {
-    const origins = response.origins;
+    const origins = response.trackers;
 
     if (!origins) {
       return;
@@ -436,7 +436,7 @@ function share() {
     return;
   }
 
-  let origins = POPUP_DATA.origins;
+  let origins = POPUP_DATA.trackers;
   let originsArr = [];
   if (origins) {
     originsArr = Object.keys(origins);
@@ -634,11 +634,11 @@ function refreshPopup() {
   if (POPUP_DATA.settings.showExpandedTrackingSection || (
     (POPUP_DATA.settings.seenComic && !POPUP_DATA.showLearningPrompt && !POPUP_DATA.criticalError) &&
     Object.keys(BREAKAGE_NOTE_DOMAINS).some(d =>
-      POPUP_DATA.origins[d] == constants.BLOCK ||
-        POPUP_DATA.origins[d] == constants.COOKIEBLOCK)
+      POPUP_DATA.trackers[d] == constants.BLOCK ||
+        POPUP_DATA.trackers[d] == constants.COOKIEBLOCK)
   ) || (
     POPUP_DATA.cookieblocked && Object.keys(POPUP_DATA.cookieblocked).some(
-      d => POPUP_DATA.origins[d] == constants.USER_BLOCK)
+      d => POPUP_DATA.trackers[d] == constants.USER_BLOCK)
   )) {
     $('#expand-blocked-resources').hide();
     $('#collapse-blocked-resources').show();
@@ -650,7 +650,7 @@ function refreshPopup() {
     $('#blockedResources').hide();
   }
 
-  let origins = POPUP_DATA.origins;
+  let origins = POPUP_DATA.trackers;
   let originsArr = [];
   if (origins) {
     originsArr = Object.keys(origins);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -519,7 +519,7 @@ function revertDomainControl(event) {
 
   chrome.runtime.sendMessage({
     type: "revertDomainControl",
-    origin: domain
+    domain
   }, () => {
     chrome.tabs.reload(POPUP_DATA.tabId);
     window.close();
@@ -846,7 +846,7 @@ function updateOrigin() {
 function saveToggle(domain, action) {
   chrome.runtime.sendMessage({
     type: "savePopupToggle",
-    origin: domain,
+    domain,
     action,
     tabId: POPUP_DATA.tabId
   });

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -364,7 +364,7 @@ BadgerPen.prototype = {
       for (const subdomain of actionMap.keys()) {
         if (getBaseDomain(subdomain) == base) {
           if (self.getAction(subdomain) != constants.NO_TRACKING) {
-            badger.heuristicBlocking.blocklistOrigin(base, subdomain);
+            badger.heuristicBlocking.blocklistDomain(base, subdomain);
           }
         }
       }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -606,10 +606,10 @@ function onNavigate(details) {
   // when there is no "main_frame" webRequest callback
   // (such as on Service Worker pages)
   //
-  // see the tabOrigins TODO in heuristicblocking.js
+  // see the tabBases TODO in heuristicblocking.js
   // as to why we don't just use tabData
   let base = getBaseDomain(tab_host);
-  badger.heuristicBlocking.tabOrigins[tab_id] = base;
+  badger.heuristicBlocking.tabBases[tab_id] = base;
   badger.heuristicBlocking.tabUrls[tab_id] = url;
 }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1583,7 +1583,7 @@ function dispatcher(request, sender, sendResponse) {
   }
 
   case "revertDomainControl": {
-    badger.storage.revertUserAction(request.origin);
+    badger.storage.revertUserAction(request.domain);
     sendResponse({
       trackers: badger.storage.getTrackingDomains()
     });
@@ -1631,7 +1631,7 @@ function dispatcher(request, sender, sendResponse) {
   }
 
   case "savePopupToggle": {
-    let domain = request.origin,
+    let domain = request.domain,
       action = request.action;
 
     badger.saveAction(action, domain);
@@ -1644,7 +1644,7 @@ function dispatcher(request, sender, sendResponse) {
 
   // called when the user manually sets a slider on the options page
   case "saveOptionsToggle": {
-    badger.saveAction(request.action, request.origin);
+    badger.saveAction(request.action, request.domain);
     sendResponse({
       trackers: badger.storage.getTrackingDomains()
     });
@@ -1729,9 +1729,9 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
-  case "removeOrigin": {
+  case "removeDomain": {
     for (let name of ['snitch_map', 'action_map', 'tracking_map', 'fp_scripts']) {
-      badger.storage.getStore(name).deleteItem(request.origin);
+      badger.storage.getStore(name).deleteItem(request.domain);
     }
     sendResponse({
       trackers: badger.storage.getTrackingDomains()

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -128,7 +128,7 @@ function onBeforeRequest(details) {
   }
 
   if (from_current_tab) {
-    badger.logThirdPartyOriginOnTab(tab_id, request_host, action);
+    badger.logThirdParty(tab_id, request_host, action);
   }
 
   if (!badger.isPrivacyBadgerEnabled(tab_host)) {
@@ -427,7 +427,7 @@ function onBeforeSendHeaders(details) {
   let action = checkAction(tab_id, request_host, frame_id);
 
   if (action && from_current_tab) {
-    badger.logThirdPartyOriginOnTab(tab_id, request_host, action);
+    badger.logThirdParty(tab_id, request_host, action);
   }
 
   if (!badger.isPrivacyBadgerEnabled(tab_host)) {
@@ -524,7 +524,7 @@ function onHeadersReceived(details) {
   }
 
   if (from_current_tab) {
-    badger.logThirdPartyOriginOnTab(tab_id, response_host, action);
+    badger.logThirdParty(tab_id, response_host, action);
   }
 
   if (!badger.isPrivacyBadgerEnabled(tab_host)) {
@@ -686,7 +686,7 @@ function recordSupercookie(tab_id, frame_host) {
   // log for popup
   let action = checkAction(tab_id, frame_host);
   if (action) {
-    badger.logThirdPartyOriginOnTab(tab_id, frame_host, action);
+    badger.logThirdParty(tab_id, frame_host, action);
   }
 }
 
@@ -765,7 +765,7 @@ function recordFingerprinting(tab_id, msg) {
           // log for popup
           let action = checkAction(tab_id, script_host);
           if (action) {
-            badger.logThirdPartyOriginOnTab(tab_id, script_host, action);
+            badger.logThirdParty(tab_id, script_host, action);
           }
 
           // record canvas fingerprinting

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1402,7 +1402,7 @@ function dispatcher(request, sender, sendResponse) {
       errorText: badger.tabData._tabData[tab_id].errorText,
       isOnFirstParty: utils.firstPartyProtectionsEnabled(tab_host),
       noTabData: false,
-      origins: trackers,
+      trackers,
       settings: badger.getSettings().getItemClones(),
       showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),
       tabHost: tab_host,
@@ -1427,7 +1427,7 @@ function dispatcher(request, sender, sendResponse) {
 
     sendResponse({
       cookieblocked,
-      origins: trackers,
+      trackers,
       settings: badger.getSettings().getItemClones(),
       widgets: badger.widgetList.map(widget => widget.name),
       widgetDomains: Array.from(badger.getAllWidgetDomains()),
@@ -1585,7 +1585,7 @@ function dispatcher(request, sender, sendResponse) {
   case "revertDomainControl": {
     badger.storage.revertUserAction(request.origin);
     sendResponse({
-      origins: badger.storage.getTrackingDomains()
+      trackers: badger.storage.getTrackingDomains()
     });
     break;
   }
@@ -1646,7 +1646,7 @@ function dispatcher(request, sender, sendResponse) {
   case "saveOptionsToggle": {
     badger.saveAction(request.action, request.origin);
     sendResponse({
-      origins: badger.storage.getTrackingDomains()
+      trackers: badger.storage.getTrackingDomains()
     });
     break;
   }
@@ -1734,7 +1734,7 @@ function dispatcher(request, sender, sendResponse) {
       badger.storage.getStore(name).deleteItem(request.origin);
     }
     sendResponse({
-      origins: badger.storage.getTrackingDomains()
+      trackers: badger.storage.getTrackingDomains()
     });
     break;
   }

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1777,15 +1777,9 @@ function dispatcher(request, sender, sendResponse) {
     // implications of accepting pbSurrogateMessage events
     // from third-party scripts in nested frames
     if (sender.frameId > 0) {
-      let frame_origin = sender.origin;
-
-      if (!utils.hasOwn(sender, "origin")) {
-        if (request.frameUrl) {
-          let path = (new URL(request.frameUrl)).pathname,
-            path_idx = request.frameUrl.indexOf(path);
-          frame_origin = request.frameUrl.slice(0, path_idx);
-        }
-      }
+      let frame_origin = utils.hasOwn(sender, "origin") ?
+        sender.origin :
+        request.frameUrl && (new URL(request.frameUrl)).origin;
 
       if (!frame_origin) {
         break;

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1171,15 +1171,15 @@ function dispatcher(request, sender, sendResponse) {
     // reject unless it's a known content script message
     const KNOWN_CONTENT_SCRIPT_MESSAGES = [
       "allowWidgetOnSite",
+      "checkClobberingEnabled",
       "checkDNT",
       "checkEnabled",
-      "checkLocation",
       "checkWidgetReplacementEnabled",
       "detectFingerprinting",
+      "detectSupercookies",
       "fpReport",
       "getBlockedFrameUrls",
       "getReplacementButton",
-      "inspectLocalStorage",
       "supercookieReport",
       "unblockWidget",
       "widgetFromSurrogate",
@@ -1214,7 +1214,7 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
-  case "checkLocation": {
+  case "checkClobberingEnabled": {
     let tab_host = extractHostFromURL(sender.tab.url);
 
     if (!badger.isPrivacyBadgerEnabled(tab_host)) {
@@ -1319,7 +1319,7 @@ function dispatcher(request, sender, sendResponse) {
     break;
   }
 
-  case "inspectLocalStorage": {
+  case "detectSupercookies": {
     let tab_host = extractHostFromURL(sender.tab.url),
       frame_host = extractHostFromURL(
         utils.hasOwn(sender, "origin") ?

--- a/src/tests/tests/htmlutils.js
+++ b/src/tests/tests/htmlutils.js
@@ -63,7 +63,7 @@ QUnit.test("getActionDescription", (assert) => {
 
 QUnit.test("getToggleHtml", function (assert) {
   // Test parameters
-  const origin = "pbtest.org";
+  const domain = "pbtest.org";
   const tests = [
     {
       action: constants.BLOCK,
@@ -85,9 +85,9 @@ QUnit.test("getToggleHtml", function (assert) {
 
   // Run each test.
   for (let test of tests) {
-    let message = `Inputs: '${origin}' and '${test.action}'`;
-    let html = htmlUtils.getToggleHtml(origin, test.action);
-    let input_val = $('input[name="' + origin + '"]:checked', html).val();
+    let message = `Inputs: '${domain}' and '${test.action}'`;
+    let html = htmlUtils.getToggleHtml(domain, test.action);
+    let input_val = $('input[name="' + domain + '"]:checked', html).val();
     assert.equal(input_val, test.expectedResult, message);
   }
 });
@@ -97,36 +97,36 @@ QUnit.test("getOriginHtml", function (assert) {
   var tests = [
     {
       existingHtml: '<div id="existinghtml"></div>',
-      origin: "pbtest.org",
+      domain: "pbtest.org",
       action: constants.ALLOW,
     },
     {
       existingHtml: '<div id="existinghtml"></div>',
-      origin: "pbtest.org",
+      domain: "pbtest.org",
       action: constants.DNT,
     },
   ];
 
   // Run each test.
-  for (var i = 0; i < tests.length; i++) {
-    var existingHtml = tests[i].existingHtml;
-    var origin = tests[i].origin;
-    var action = tests[i].action;
+  for (let test of tests) {
+    let existing_html = test.existingHtml,
+      domain = test.domain,
+      action = test.action;
 
-    var htmlResult = existingHtml + htmlUtils.getOriginHtml(origin, action);
+    let result_html = existing_html + htmlUtils.getOriginHtml(domain, action);
 
     // Make sure existing HTML is present.
-    var existingHtmlExists = htmlResult.indexOf(existingHtml) > -1;
-    assert.ok(existingHtmlExists, "Existing HTML should be present");
+    let html_found = result_html.includes(existing_html);
+    assert.ok(html_found, "Existing HTML should be present");
 
-    // Make sure origin is set.
-    var originDataExists = htmlResult.indexOf('data-origin="' + origin + '"') > -1;
-    assert.ok(originDataExists, "Origin should be set");
+    // Make sure domain is set.
+    let dataset_prop_found = result_html.includes('data-origin="' + domain + '"');
+    assert.ok(dataset_prop_found, "Domain should be set");
 
     // Check for presence of DNT content.
-    var dntExists = htmlResult.indexOf('class="dnt-compliant"') > -1;
-    assert.equal(dntExists, action == constants.DNT,
-      "DNT div should " + (dntExists ? "" : "not ") + "be present");
+    let dnt_found = result_html.includes('class="dnt-compliant"');
+    assert.equal(dnt_found, action == constants.DNT,
+      "DNT div should " + (dnt_found ? "" : "not ") + "be present");
   }
 });
 

--- a/src/tests/tests/storage.js
+++ b/src/tests/tests/storage.js
@@ -782,7 +782,7 @@ function checkCookieblocking(assert) {
   );
 
   // block the subdomain
-  badger.heuristicBlocking.blocklistOrigin(DOMAIN, SUBDOMAIN);
+  badger.heuristicBlocking.blocklistDomain(DOMAIN, SUBDOMAIN);
 
   assert.equal(
     storage.getBestAction(SUBDOMAIN),

--- a/src/tests/tests/tabData.js
+++ b/src/tests/tests/tabData.js
@@ -26,7 +26,7 @@ QUnit.module("tabData", {
   }
 },
 function() {
-  QUnit.module("logThirdPartyOriginOnTab", {
+  QUnit.module("logThirdParty", {
     beforeEach: function () {
       this.clock = sinon.useFakeTimers();
       sinon.stub(chrome.browserAction, "setBadgeText");
@@ -48,7 +48,7 @@ function() {
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log blocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 1, "count gets incremented"
@@ -64,7 +64,7 @@ function() {
   });
 
   QUnit.test("logging unblocked domain", function (assert) {
-    badger.logThirdPartyOriginOnTab(this.tabId, "example.com", constants.ALLOW);
+    badger.logThirdParty(this.tabId, "example.com", constants.ALLOW);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 0, "count stays at zero"
@@ -76,7 +76,7 @@ function() {
   });
 
   QUnit.test("logging DNT-compliant domain", function (assert) {
-    badger.logThirdPartyOriginOnTab(this.tabId, "example.com", constants.DNT);
+    badger.logThirdParty(this.tabId, "example.com", constants.DNT);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 0, "count stays at zero"
@@ -91,14 +91,14 @@ function() {
     const DOMAIN = "example.com";
 
     // log unblocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.ALLOW);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.ALLOW);
     this.clock.tick(1);
 
     // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log the same domain, this time as blocked
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 1, "count gets incremented"
@@ -121,7 +121,7 @@ function() {
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log blocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 1, "count gets incremented"
@@ -136,7 +136,7 @@ function() {
     }), "setBadgeText was called with expected args");
 
     // log the same blocked domain again
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId),
@@ -153,16 +153,16 @@ function() {
     const DOMAIN = "example.com";
 
     // log unblocked domain twice
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.ALLOW);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.ALLOW);
     this.clock.tick(1);
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.ALLOW);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.ALLOW);
     this.clock.tick(1);
 
     // set up domain blocking (used by getTrackerCount)
     badger.storage.setupHeuristicAction(DOMAIN, constants.BLOCK);
 
     // log blocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 1, "count gets incremented"
@@ -177,7 +177,7 @@ function() {
     }, "setBadgeText was called with expected args");
 
     // log the same blocked domain again
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId),
@@ -197,7 +197,7 @@ function() {
     badger.storage.setupHeuristicAction(DOMAIN, constants.COOKIEBLOCK);
 
     // log cookieblocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN, constants.COOKIEBLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN, constants.COOKIEBLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 1, "count gets incremented"
@@ -221,7 +221,7 @@ function() {
     badger.storage.setupHeuristicAction(DOMAIN2, constants.COOKIEBLOCK);
 
     // log blocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN1, constants.BLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN1, constants.BLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 1, "count gets incremented"
@@ -236,7 +236,7 @@ function() {
     }), "setBadgeText was called with expected args");
 
     // log cookieblocked domain
-    badger.logThirdPartyOriginOnTab(this.tabId, DOMAIN2, constants.COOKIEBLOCK);
+    badger.logThirdParty(this.tabId, DOMAIN2, constants.COOKIEBLOCK);
     this.clock.tick(1);
     assert.equal(
       badger.getTrackerCount(this.tabId), 2, "count gets incremented again"

--- a/src/tests/tests/utils.js
+++ b/src/tests/tests/utils.js
@@ -194,7 +194,7 @@ QUnit.module("Utils", function (/*hooks*/) {
       "PSL TLDs work with wildcards as expected.");
   });
 
-  QUnit.test("disable/enable privacy badger for origin", function (assert) {
+  QUnit.test("disable/enable privacy badger for domain", function (assert) {
     function parsed() {
       return badger.storage.getStore('settings_map').getItem('disabledSites');
     }

--- a/tests/selenium/content_filtering_test.py
+++ b/tests/selenium/content_filtering_test.py
@@ -286,8 +286,8 @@ class ContentFilteringTest(pbtest.PBSeleniumTest):
         # now remove it
         self.js(
             "chrome.runtime.sendMessage({"
-            "  type: 'removeOrigin',"
-            "  origin: arguments[0]"
+            "  type: 'removeDomain',"
+            "  domain: arguments[0]"
             "});", self.THIRD_PARTY_DOMAIN)
 
         # the domain should now load

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -616,7 +616,7 @@ class PBSeleniumTest(unittest.TestCase):
         self.wait_for_script("return window.DONE_REFRESHING && window.SLIDERS_DONE")
 
     def get_tracker_state(self):
-        """Parse the UI to group all third party origins into their respective action states."""
+        """Parse the UI to group all third party domains into their respective action states."""
 
         notYetBlocked = {}
         cookieBlocked = {}

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -496,7 +496,7 @@ class PBSeleniumTest(unittest.TestCase):
             "let done = arguments[arguments.length - 1];"
             "chrome.runtime.sendMessage({"
             "  type: 'saveOptionsToggle',"
-            "  origin: arguments[0],"
+            "  domain: arguments[0],"
             "  action: arguments[1]"
             "}, done);", domain, action)
 


### PR DESCRIPTION
Follows up on #2467 and 94adce8862cb5a3a3b0dc462c16d22e8431a3ed7 / 1518d01a66deb04b5dc27323fc8d73e78bc8b8a5.

There should be no functional difference in browsers that haven't implemented [`MessageSender.origin`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender#origin).

Up-to-date browsers get an improved version of #2467. Also, we may learn to block more trackers as we will no longer sometimes fail to determine the originating frame URL of content script messages (1518d01a66deb04b5dc27323fc8d73e78bc8b8a5).

Regarding the mass renaming commits:

- https://web.dev/articles/same-site-same-origin
- not fully done, leaving more for later