### PR TITLE
Add Twitch JS API widget replacement placeholder

### DIFF
--- a/src/data/surrogates.js
+++ b/src/data/surrogates.js
@@ -131,6 +131,13 @@ const hostnames = {
     ],
     widgetName: "Google reCAPTCHA"
   },
+  'embed.twitch.tv': {
+    match: MATCH_PREFIX,
+    tokens: [
+      '/embed/v1.js'
+    ],
+    widgetName: "Twitch Player"
+  },
   'platform.twitter.com': {
     match: MATCH_PREFIX,
     tokens: [
@@ -206,6 +213,8 @@ const surrogates = {
   '/widgets.js': 'twitter.js',
 
   '/omweb-v1.js': 'noop.js',
+
+  '/embed/v1.js': 'twitch.js',
 
   'noopjs': 'noop.js'
 };

--- a/src/data/web_accessible_resources/twitch.js
+++ b/src/data/web_accessible_resources/twitch.js
@@ -1,0 +1,20 @@
+(function () {
+    // https://dev.twitch.tv/docs/embed/everything/
+    class Embed {
+        constructor(id, conf) {
+            let detail = {
+                type: "widgetFromSurrogate",
+                name: "Twitch Player",
+                widgetData: {
+                    domId: id,
+                    videoId: conf.channel
+                }
+            };
+            document.dispatchEvent(new CustomEvent("pbSurrogateMessage", { detail }));
+        }
+    }
+
+    window.Twitch = {
+        Embed
+    };
+}());

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1116,6 +1116,35 @@ function getSurrogateWidget(name, data, frame_url) {
     return widget;
   }
 
+  if (name == "Twitch Player") {
+    if (!data || !data.domId || !data.videoId) {
+      return false;
+    }
+
+    let video_id = data.videoId,
+      dom_id = data.domId;
+
+    if (!OK.test(video_id) || !OK.test(dom_id)) {
+      return false;
+    }
+
+    let widget = {
+      name,
+      buttonSelectors: ["#" + dom_id],
+      scriptSelectors: [
+        `script[src^='${CSS.escape("https://embed.twitch.tv/embed/v1.js")}']`
+      ],
+      replacementButton: {
+        "unblockDomains": ["twitch.tv", "*.twitch.tv"],
+        "type": 4
+      },
+      directLinkUrl: `https://www.twitch.tv/${video_id}`,
+      reloadOnActivation: true
+    };
+
+    return widget;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Example: https://gronkh.tv/live/GronkhTV

TODOs:
- More examples, potentially more Twitch JS API functionality
- Factor out webrequest.js widget message proxying into own file
- MV3 implications? Maybe none?