### PR TITLE
Add ability to specify tracking domain actions in managed storage

### DIFF
--- a/doc/sample-admin-policies/jid1-MnnxcxisBPnSXQ@jetpack.json
+++ b/doc/sample-admin-policies/jid1-MnnxcxisBPnSXQ@jetpack.json
@@ -6,6 +6,9 @@
     "showIntroPage": false,
     "disabledSites": [
         "example.com"
+    ],
+    "trackingDomains": [
+        { "action": "block", "domain": "youtube.com" }
     ]
   }
 }

--- a/doc/sample-admin-policies/sample-managed-storage-manifest-chrome.json
+++ b/doc/sample-admin-policies/sample-managed-storage-manifest-chrome.json
@@ -5,6 +5,9 @@
                 "showIntroPage": false,
                 "disabledSites": [
                     "example.com"
+                ],
+                "trackingDomains": [
+                    { "action": "block", "domain": "youtube.com" }
                 ]
             }
         }

--- a/src/data/schema.json
+++ b/src/data/schema.json
@@ -8,7 +8,7 @@
         },
         "disabledSites": {
             "title": "Websites to disable Privacy Badger on",
-            "description": "This is a list of website domains where Privacy Badger will be disabled. This means that Privacy Badger will not block anything or send DNT/GPC signals to anything when you visit a website on this list. This is NOT a list of tracker domains for Privacy Badger to always allow to load.",
+            "description": "This is a list of website domains where Privacy Badger will be disabled. This means that Privacy Badger will not block anything or send DNT/GPC signals to anything when you visit a website on this list. If you want to customize tracking domain settings, use trackingDomains, not disabledSites.",
             "type": "array",
             "items": {
                 "type": "string"
@@ -38,6 +38,23 @@
             "title": "Show intro page",
             "description": "If set to false then do not open the new user intro page upon install.",
             "type": "boolean"
+        },
+        "trackingDomains": {
+            "title": "Tracking Domains",
+            "description": "This list lets you specify actions for tracking domains.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                     "domain": {
+                         "type": "string"
+                     },
+                     "action": {
+                         "type": "string",
+                         "enum": ["block", "cookieblock", "allow"]
+                     }
+                }
+            }
         }
     }
 }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -87,6 +87,29 @@ function ingestManagedStorage(managedStore) {
     }
   }
   badger.getSettings().merge(settings);
+
+  if (managedStore.trackingDomains) {
+    let knownActions = new Set([
+      constants.BLOCK,
+      constants.COOKIEBLOCK,
+      constants.ALLOW]);
+    for (let item of managedStore.trackingDomains) {
+      // validate action
+      if (!knownActions.has(item.action)) {
+        continue;
+      }
+      // validate domain
+      try {
+        let { hostname } = new URL("https://" + item.domain);
+        if (hostname != item.domain) {
+          continue;
+        }
+      } catch (err) {
+        continue;
+      }
+      badger.saveAction(item.action, item.domain);
+    }
+  }
 }
 
 let pollForManagedStorage = (function () {


### PR DESCRIPTION
Fixes #3051. Should "just work" in MV3, but I need to test it.

Also fixes #2259, just not in the UI.