### PR TITLE
Add api.reddit.com

### DIFF
--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -19,6 +19,7 @@
         "aetnd.com",
         "acast.com",
         "actionnetwork.org",
+        "api.reddit.com",
         "imagesrv.adition.com",
         "acrobat.adobe.com",
         "animate.adobe.com",


### PR DESCRIPTION
Blocking api.reddit.com breaks websites that use the Reddit API, e.g. https://redditmetis.com/user/spez