### PR TITLE
Remove "Show not-yet-blocked domains" filter from UI

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -213,13 +213,17 @@ function loadOptions() {
           }
         }
 
-        $("#not-yet-blocked-filter").toggle(enabled);
+        if (!enabled || (new URLSearchParams(document.location.search)).has('all')) {
+          $("#not-yet-blocked-filter").toggle(enabled);
+        }
         $("#hide-in-seed-filter").toggle(enabled);
       });
     });
   if (OPTIONS_DATA.settings.learnLocally) {
     $("#learning-setting-divs").show();
-    $("#not-yet-blocked-filter").show();
+    if ((new URLSearchParams(document.location.search)).has('all')) {
+      $("#not-yet-blocked-filter").show();
+    }
     $("#hide-in-seed-filter").show();
   }
 

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -43,7 +43,7 @@ class OptionsTest(pbtest.PBSeleniumTest):
         self.find_el_by_css('a[href="#tab-manage-data"]').click()
 
     def load_options_page(self):
-        self.load_url(self.options_url)
+        self.load_url(self.options_url + '?all')
         self.wait_for_script("return window.OPTIONS_INITIALIZED")
 
     def test_reloading_should_reapply_filters(self):


### PR DESCRIPTION
Can be restored for now by adding "all" to the options page query string.

Previously: #2768, #1603

Follows up on #2679.