### PR TITLE
Refactor mass tab lookups on startup

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -92,14 +92,6 @@ function Badger(from_qunit) {
       chrome.browserAction.setBadgeTextColor({ color: "#fff" });
     }
 
-    // Show icon as page action for all tabs that already exist
-    chrome.tabs.query({}, function (tabs) {
-      for (let tab of tabs) {
-        self.updateIcon(tab.id, tab.url);
-      }
-      log("Updated tab icons");
-    });
-
     // wait for async functions (seed data, yellowlist, ...) to resolve
     await widgetListPromise;
     await seedDataPromise;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -75,8 +75,9 @@ function Badger(from_qunit) {
     self.setPrivacyOverrides();
 
     // kick off async initialization steps
-    let pbconfigPromise = self.initPbconfig().catch(console.error),
-      tabDataPromise = self.tabData.initialize().catch(console.error);
+    let pbconfigPromise = self.initPbconfig().catch(console.error);
+
+    self.tabData.initialize().catch(console.error);
 
     // async load known CNAME domain aliases (but don't wait on them)
     self.initializeCnames().catch(console.error);
@@ -95,7 +96,6 @@ function Badger(from_qunit) {
     // wait for async functions (seed data, yellowlist, ...) to resolve
     await widgetListPromise;
     await seedDataPromise;
-    await tabDataPromise;
 
     if (self.isFirstRun || self.isUpdate || !self.getPrivateSettings().getItem('doneLoadingSeed')) {
       // block all widget domains

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -39,20 +39,18 @@ function HeuristicBlocker(pbStorage) {
   // impossible to attribute to a tab.
   self.tabBases = {};
   self.tabUrls = {};
-
-  // initialize tab bases and URLs for already-open tabs
-  chrome.tabs.query({}, function (res) {
-    for (let tab of res) {
-      if (utils.isRestrictedUrl(tab.url)) {
-        continue;
-      }
-      self.tabBases[tab.id] = getBaseDomain((new URI(tab.url)).host);
-      self.tabUrls[tab.id] = tab.url;
-    }
-  });
 }
 
 HeuristicBlocker.prototype = {
+
+  /**
+   * Initializes tab bases and URLs for already-open tabs
+   */
+  initTabData: function (tab_id, tab_url) {
+    let self = this;
+    self.tabBases[tab_id] = getBaseDomain((new URI(tab_url)).host);
+    self.tabUrls[tab_id] = tab_url;
+  },
 
   /**
    * Blocklists a domain:

--- a/src/js/incognito.js
+++ b/src/js/incognito.js
@@ -4,12 +4,9 @@ import utils from "./utils.js";
 
 let tabs = {};
 
-// Get all existing tabs
-chrome.tabs.query({}, function(results) {
-  results.forEach(function(tab) {
-    tabs[tab.id] = tab.incognito;
-  });
-});
+function updateTabStatus(tab_id, incognito) {
+  tabs[tab_id] = !!incognito;
+}
 
 // Create tab event listeners
 function onCreatedListener(tab) {
@@ -43,4 +40,5 @@ function learningEnabled(tab_id) {
 export default {
   learningEnabled,
   startListeners,
+  updateTabStatus,
 };

--- a/src/js/tabdata.js
+++ b/src/js/tabdata.js
@@ -20,6 +20,7 @@
 import { extractHostFromURL, getChromeInitiator } from "../lib/basedomain.js";
 
 import { log } from "./bootstrap.js";
+import incognito from "./incognito.js";
 import utils from "./utils.js";
 
 function TabData() {
@@ -124,6 +125,9 @@ TabData.prototype.initialize = function () {
       chrome.tabs.query({}, tabs => {
         for (let tab of tabs) {
           let { id, url } = tab;
+
+          // mark incognito status
+          incognito.updateTabStatus(id, tab.incognito);
 
           // don't record on special browser pages
           if (utils.isRestrictedUrl(url)) {

--- a/src/js/tabdata.js
+++ b/src/js/tabdata.js
@@ -134,6 +134,9 @@ TabData.prototype.initialize = function () {
             continue;
           }
 
+          // set HeuristicBlocker's [sic] tab URL and eTLD+1 domain data
+          badger.heuristicBlocking.initTabData(id, url);
+
           // update icon to active when not disabled for site
           badger.updateIcon(id, url);
 

--- a/src/js/tabdata.js
+++ b/src/js/tabdata.js
@@ -123,36 +123,40 @@ TabData.prototype.initialize = function () {
 
       chrome.tabs.query({}, tabs => {
         for (let tab of tabs) {
+          let { id, url } = tab;
+
           // don't record on special browser pages
-          if (utils.isRestrictedUrl(tab.url)) {
+          if (utils.isRestrictedUrl(url)) {
             continue;
           }
 
+          // update icon to active when not disabled for site
+          badger.updateIcon(id, url);
+
           // if there is data in session storage, restore
-          if (oldTabData && utils.hasOwn(oldTabData, tab.id) &&
-            oldTabData[tab.id].frames[0] && (tab.url == oldTabData[tab.id].frames[0].url)) {
+          if (oldTabData && utils.hasOwn(oldTabData, id) &&
+            oldTabData[id].frames[0] && (url == oldTabData[id].frames[0].url)) {
 
-            self.set(tab.id, oldTabData[tab.id]);
+            self.set(id, oldTabData[id]);
 
-            self.tabIdsByInitiator[getChromeInitiator(tab.url)] = tab.id;
+            self.tabIdsByInitiator[getChromeInitiator(url)] = id;
 
             if (savedData.tempAllowlist) {
-              if (utils.hasOwn(savedData.tempAllowlist, tab.id)) {
-                self.tempAllowlist[tab.id] = [...savedData.tempAllowlist[tab.id]];
+              if (utils.hasOwn(savedData.tempAllowlist, id)) {
+                self.tempAllowlist[id] = [...savedData.tempAllowlist[id]];
               }
             }
             if (savedData.tempAllowedWidgets) {
-              if (utils.hasOwn(savedData.tempAllowedWidgets, tab.id)) {
-                self.tempAllowedWidgets[tab.id] = [...savedData.tempAllowedWidgets[tab.id]];
+              if (utils.hasOwn(savedData.tempAllowedWidgets, id)) {
+                self.tempAllowedWidgets[id] = [...savedData.tempAllowedWidgets[id]];
               }
             }
 
-            continue;
+          } else {
+            // no data to restore, make a new tab data entry
+            // TODO indicate that we don't have complete info for this tab?
+            self.recordFrame(id, 0, url);
           }
-
-          // no data to restore, make a new tab data entry
-          // TODO indicate that we don't have complete info for this tab?
-          self.recordFrame(tab.id, 0, tab.url);
         }
 
         log("Initialized tab data");


### PR DESCRIPTION
Fixes #3036. Follows up on #3059.

It seems that `chrome.tabs.query()` can be really slow too.

The big idea behind these fixes is that if the mass tab query is slow for whatever reason, rather than fail completely, let's handle whatever specific issues arise from not having tab data.

It should be OK to not wait on:

- Tab incognito statuses because we play it safe and assume incognito when this data is missing. Potentially missing some local learning on browser startup when restoring tabs seems acceptable. Plus we already technically didn't wait on this, although this lookup ran basically before everything else.
- Updating tab icons because we already didn't wait on this.
- Tab URLs/base domains for learning from cookies because we already didn't wait on this.
- tabData's tab data because if we do wait on it and it's what's stalling initialization, all of PB is broken. If we don't wait on this, ~~some of PB works, we just won't block/etc. via webRequest in MV2~~ PB seems to work at least as well as before. If the browser proceeds to restore a tab on startup after PB is ready, great, we initialize everything we need on the fly. Otherwise, if a website starts loading before PB is done initializing, we will fail to learn trackers/block in MV2, but this is already the status quo, and this change (not waiting on tab data) speeds up PB's initialization.

For testing, going to want to restore the extension and tabs on Firefox startup, like we did in #2982. Something like:

0. Add an artificial delay to `chrome.tabs.query` on startup or whatever other testing tweaks you like
1. Make a new Firefox Nightly profile
2. Check "Open previous windows and tabs" in `about:settings`
3. Toggle `xpinstall.signatures.required` to `false` in `about:config`
4. Zip up PB's `src/` and rename to `.xpi`
5. Drag and drop XPI into `about:addons` to install
6. Open some websites
7. Quit Nightly and reopen into the same profile