### PR TITLE
Hide "Disable" tip box on Options page on Firefox for Android

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -52,6 +52,19 @@ function loadOptions() {
   // Set page title to i18n version of "Privacy Badger Options"
   document.title = i18n.getMessage("options_title");
 
+  // Render tip box on Disabled Sites tab on non-Android platforms
+  if (chrome.runtime.getPlatformInfo) {
+    chrome.runtime.getPlatformInfo((info) => {
+      if (info.os == "android") {
+        $("#tip-container").hide();
+      } else {
+        $("#tip-container").show();
+      }
+    });
+  } else { // Default to showing tip box if chrome.runtime.getPlatformInfo is not supported
+    $("#tip-container").show();
+  }
+
   // Add event listeners
   $("#allowlist-form").on("submit", addDisabledSite);
   $("#remove-disabled-site").on("click", removeDisabledSite);

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -324,6 +324,7 @@ header {
 }
 
 #disable-instructions-image {
+    max-width: 100%;
     width: 400px;
     border: 1px solid #ccc;
     border-radius: 2px;

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -134,7 +134,7 @@
   </div>
 
   <div id="tab-allowlist">
-    <div id="tip-container">
+    <div id="tip-container" style="display:none;">
       <button id="tip-header" aria-expanded="true">
         <span id="tip-icon" class="ui-icon ui-icon-info"></span>
         <span id="tip-title" class="i18n_options_disable_tip_title"></span>


### PR DESCRIPTION
- Fixes #3086
- Hide the "how to disable" tip on the Options page for Android because the image doesn't show the correct steps for Firefox for Android. 
- The tip box is unnecessary because the extensions UI on Firefox for Android makes it harder to find the options page than the popup.
- I also fixed a visual bug with the tip box image being too wide on extremely narrow screens
- Confirmed the change on an Android Emulator:
<img width="527" alt="Screenshot 2025-04-16 at 2 35 13 PM" src="https://github.com/user-attachments/assets/237f4a60-e612-455d-8cc9-ba2070b0b83e" />
