### PR TITLE
Update old-style FAQ links

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -288,8 +288,17 @@
         "description": "Message in the popup when users visit YouTube.com"
     },
     "extension_error_text": {
-        "message": "Please <a href='https://www.eff.org/privacybadger#faq-I-found-a-bug!-What-do-I-do-now?' target='_blank'>tell us</a> about the following error:",
-        "description": "Shown in the popup when there is an extension error we want to encourage the user to tell us about."
+        "message": "Please $LINK_START$ tell us$LINK_END$ about the following error:",
+        "description": "Shown in the popup when there is an extension error we want to encourage the user to tell us about",
+        "placeholders": {
+            "link_start": {
+                "content": "$1",
+                "example": "<a href='http://example.com'>"
+            },
+            "link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "firstRun_title": {
         "message": "Thank you for installing Privacy Badger!",
@@ -543,8 +552,17 @@
         }
     },
     "options_domain_list_no_trackers": {
-        "message": "Privacy Badger hasn't detected any <a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://www.eff.org/privacybadger#faq-What-is-a-third-party-tracker?'>tracking domains</a> yet. Keep browsing!",
-        "description": "Shown on the Tracking Domains tab on the options page if all tracking domains have been removed."
+        "message": "Privacy Badger hasn't detected any $LINK_START$ tracking domains$LINK_END$ yet. Keep browsing!",
+        "description": "Shown on the Tracking Domains tab on the options page if all tracking domains have been removed",
+        "placeholders": {
+            "link_start": {
+                "content": "$1",
+                "example": "<a href='http://example.com'>"
+            },
+            "link_end": {
+                "content": "</a>"
+            }
+        }
     },
     "what_is_a_tracker": {
         "message": "What is a tracker?",

--- a/src/skin/options.html
+++ b/src/skin/options.html
@@ -71,7 +71,7 @@
     <div id="blockedResourcesContainer">
       <p>
         <span id="options_domain_list_trackers"></span>
-        <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" style="display:none"></span>
+        <span id="options_domain_list_no_trackers" class="i18n_options_domain_list_no_trackers" data-i18n_contents_placeholders="<a target='_blank' tabindex=-1 title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>" style="display:none"></span>
       </p>
       <div id="tracking-domains-loader" style="display:none">
         <div class="spinner"></div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -54,7 +54,7 @@
     <div id="error-text" style="display:none">
       <div class="flex-wrapper">
         <img class="instruction-logo" src="/icons/badger-48.png" srcset="/icons/badger-128.png 2x" width="48" alt="">
-        <div class="i18n_extension_error_text"></div>
+        <div class="i18n_extension_error_text" data-i18n_contents_placeholders="<a href='https://privacybadger.org/#I-found-a-bug%21-What-do-I-do-now' target='_blank'>"></div>
       </div>
       <div style="color:#cc0000" id="error-message"></div>
     </div>


### PR DESCRIPTION
The space between the first placeholder and the text is for Safari.