### PR TITLE
Add site-specific domain overrides to pbconfig

### DIFF
--- a/doc/fixing-broken-sites.md
+++ b/doc/fixing-broken-sites.md
@@ -27,6 +27,7 @@ Once the issue is confirmed (and the responsible domains have been identified), 
 | [Widget replacement](https://www.eff.org/deeplinks/2024/01/privacy-badger-puts-you-control-widgets) | [widgets](https://github.com/EFForg/privacybadger/labels/widgets) | [#196](https://github.com/EFForg/privacybadger/issues/196), [#1467](https://github.com/EFForg/privacybadger/issues/1467) | Medium | Still needs review/improvements, although some progress being made ([#2262](https://github.com/EFForg/privacybadger/pull/2262)) |
 | EFF's Do Not Track policy | [DNT Policy](https://github.com/EFForg/privacybadger/labels/DNT%20policy)| - | n/a | Narrowly applicable |
 | Yellowlisting | [yellowlist](https://github.com/EFForg/privacybadger/labels/yellowlist)| - | Easy | Only protects against some types of tracking |
+| Site-specific domain overrides | - | - | Easy | Last resort for when other approaches don't apply. |
 
 The question to ask is, which way addresses the issue most specifically, resolving the breakage while increasing privacy exposure by the smallest amount? If you are not sure, that's OK! Opening a new issue (or chiming in on an existing issue) to ask for help is fine.
 
@@ -61,3 +62,5 @@ If nothing else seems to fit, adding the affected domain to the "[yellowlist](/d
 Resources from yellowlisted domains are requested without referrer headers, and are restricted from reading or writing cookies or localStorage.
 
 [Here is an example yellowlist pull request](https://github.com/EFForg/privacybadger/pull/1543) that shows what's good to know when deciding how to fix a breakage, and how to get that information.
+
+Site-specific domain overrides are like the yellowlist, but specific to the site. Look for them under the `"sitefixes"` key in [pbconfig.json](/src/data/pbconfig.json). In addition to site-specific yellowlisting, when blocking cookies also breaks the website, we can tell PB to ignore specified domains entirely on a particular website instead. To do this, we use the `"ignore"` subkey under the website domain key inside `"sitefixes"`.

--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -8,6 +8,27 @@
         "DNT Policy v1.0 dos-line-endings": "c09f71363bb29d0250a1f5524eef36f9ab07669b",
         "DNT Policy v1.0 no-eof-newline": "7861462d500fbb6ccb74c614782f4937377bec76"
     },
+    "sitefixes": {
+        "www.crunchyroll.com": {
+            "yellowlist": [
+                "2mdn.net",
+                "doubleclick.net",
+                "getpublica.com",
+                "googleadservices.com",
+                "googlesyndication.com",
+                "litix.io",
+                "playwire.com",
+                "rubiconproject.com",
+                "segment.com"
+            ]
+        },
+        "www.youtube.com": {
+            "ignore": [
+                "doubleclick.net",
+                "googlesyndication.com"
+            ]
+        }
+    },
     "yellowlist": [
         "cstaticdun.126.net",
         "music.126.net",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -539,7 +539,69 @@ Badger.prototype = {
   },
 
   /**
-   * Initializes PB's remotely configurable settings from local copy on disk.
+   * Fetches, parses and validates the settings file.
+   * Then, updates the fetched settings in memory and storage.
+   *
+   * @param {String} url The URL to fetch settings from.
+   *
+   * @returns {Promise}
+   */
+  ingestPbconfig: async function (url) {
+    let self = this;
+
+    let response, data;
+
+    try {
+      response = await fetch(url, { cache: "no-store" });
+    } catch (err) {
+      console.error("Problem fetching pbconfig:", err);
+      throw new Error("Failed to fetch pbconfig");
+    }
+    if (!response.ok) {
+      console.error("Problem fetching pbconfig: %s response", response.status);
+      throw new Error("Failed to fetch pbconfig");
+    }
+
+    try {
+      data = await response.json();
+    } catch (err) {
+      console.error(err);
+      throw new Error("Failed to parse pbconfig JSON");
+    }
+
+    // validate the response
+    if (!data.yellowlist || !data.yellowlist.length || !data.yellowlist.every || !data.yellowlist.every(domain => {
+      // all domains must contain at least one dot
+      if (domain.indexOf('.') == -1) {
+        return false;
+      }
+
+      // validate character set
+      //
+      // regex says:
+      // - domain starts with lowercase English letter or Arabic numeral
+      // - following that, it contains one or more
+      // letter/numeral/dot/dash characters
+      // - following the previous two requirements, domain ends with a letter
+      //
+      // TODO both overly restrictive and inaccurate
+      // but that's OK for now, we manage the list
+      if (!/^[a-z0-9][a-z0-9.-]+[a-z]$/.test(domain)) {
+        return false;
+      }
+
+      return true;
+    })) {
+      throw new Error("Invalid yellowlist response");
+    }
+
+    self.storage.updateYellowlist(data.yellowlist);
+
+    self.storage.updateDntHashes(data.dnt_policy_hashes);
+  },
+
+  /**
+   * Initializes remotely configurable settings from local copy on disk.
    *
    * @returns {Promise}
    */
@@ -552,24 +614,7 @@ Badger.prototype = {
       return;
     }
 
-    let response, data;
-
-    try {
-      response = await fetch(constants.PBCONFIG_LOCAL_URL);
-    } catch (err) {
-      console.error(err);
-      throw new Error("Failed to fetch local pbconfig");
-    }
-
-    try {
-      data = await response.json();
-    } catch (err) {
-      console.error(err);
-      throw new Error("Failed to parse local pbconfig JSON");
-    }
-
-    self.storage.updateYellowlist(data.yellowlist);
-    self.storage.updateDntHashes(data.dnt_policy_hashes);
+    await self.ingestPbconfig(constants.PBCONFIG_LOCAL_URL);
 
     if (!self.getPrivateSettings().getItem('doneLoadingYellowlist')) {
       self.storage.forceSync('action_map', function () {
@@ -610,8 +655,7 @@ Badger.prototype = {
   },
 
   /**
-   * Fetches the latest pbconfig from eff.org, and updates
-   * the yellowlist and DNT policy hashes.
+   * Updates remotely configurable settings from eff.org.
    *
    * @returns {Promise}
    */
@@ -621,59 +665,7 @@ Badger.prototype = {
     // schedule the next update for long-running extension environments
     setTimeout(self.updatePbconfig.bind(self), utils.oneDay());
 
-    let response, data;
-
-    try {
-      response = await fetch(constants.PBCONFIG_REMOTE_URL, { cache: "no-store" });
-    } catch (err) {
-      console.error("Problem fetching pbconfig:", err);
-      throw new Error("Failed to fetch remote pbconfig");
-    }
-    if (!response.ok) {
-      console.error("Problem fetching pbconfig: %s response", response.status);
-      throw new Error("Failed to fetch remote pbconfig");
-    }
-
-    try {
-      data = await response.json();
-    } catch (err) {
-      console.error(err);
-      throw new Error("Failed to parse pbconfig JSON");
-    }
-
-    // validate the response
-    if (!data.yellowlist || !data.yellowlist.length || !data.yellowlist.every || !data.yellowlist.every(domain => {
-      // all domains must contain at least one dot
-      if (domain.indexOf('.') == -1) {
-        return false;
-      }
-
-      // validate character set
-      //
-      // regex says:
-      // - domain starts with lowercase English letter or Arabic numeral
-      // - following that, it contains one or more
-      // letter/numeral/dot/dash characters
-      // - following the previous two requirements, domain ends with a letter
-      //
-      // TODO both overly restrictive and inaccurate
-      // but that's OK for now, we manage the list
-      if (!/^[a-z0-9][a-z0-9.-]+[a-z]$/.test(domain)) {
-        return false;
-      }
-
-      return true;
-    })) {
-      throw new Error("Invalid yellowlist response");
-    }
-
-    self.storage.updateYellowlist(data.yellowlist);
-    log("Updated yellowlist from remote");
-
-    if (self.isCheckingDNTPolicyEnabled()) {
-      self.storage.updateDntHashes(data.dnt_policy_hashes);
-      log("Updated DNT policy hashes from remote");
-    }
+    await self.ingestPbconfig(constants.PBCONFIG_REMOTE_URL);
 
     // refresh next update time to help avoid updating on every restart
     self.getPrivateSettings().setItem('nextPbconfigUpdateTime',

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -539,7 +539,7 @@ Badger.prototype = {
   },
 
   /**
-   * Fetches, parses and validates the settings file.
+   * Fetches, parses and validates remotely configurable settings.
    * Then, updates the fetched settings in memory and storage.
    *
    * @param {String} url The URL to fetch settings from.
@@ -598,6 +598,11 @@ Badger.prototype = {
     self.storage.updateYellowlist(data.yellowlist);
 
     self.storage.updateDntHashes(data.dnt_policy_hashes);
+
+    if (utils.hasOwn(data, 'sitefixes')) {
+      self.getPrivateSettings().setItem('sitefixes',
+        JSON.parse(JSON.stringify(data.sitefixes)));
+    }
   },
 
   /**
@@ -812,6 +817,7 @@ Badger.prototype = {
       ignoredSiteBases: [],
       nextPbconfigUpdateTime: 0,
       showLearningPrompt: false,
+      sitefixes: {}
     };
     for (let key of Object.keys(privateDefaultSettings)) {
       if (!privateStore.hasItem(key)) {
@@ -1003,6 +1009,7 @@ Badger.prototype = {
     // temp. exception list for sites
     // where sending DNT/GPC signals causes major breakages
     // TODO indicate when this happens in the UI somehow
+    // TODO move to pbconfig.json
     const gpcDisabledWebsites = {
       'www.costco.com': true,
       'fivethirtyeight.com': true,

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -71,4 +71,10 @@ exports.BLOCKED_ACTIONS = new Set([
   exports.USER_COOKIEBLOCK,
 ]);
 
+exports.USER_ACTIONS = new Set([
+  exports.USER_BLOCK,
+  exports.USER_COOKIEBLOCK,
+  exports.USER_ALLOW
+]);
+
 export default exports;

--- a/src/tests/tests/yellowlist.js
+++ b/src/tests/tests/yellowlist.js
@@ -113,7 +113,7 @@ QUnit.module("Yellowlist", (hooks) => {
       await badger.updatePbconfig();
     } catch (ex) {
       assert.ok(ex, "exception was thrown, as expected");
-      assert.equal(ex, "Error: Failed to fetch remote pbconfig",
+      assert.equal(ex, "Error: Failed to fetch pbconfig",
         "exception matches expectation");
       done();
     }


### PR DESCRIPTION
Fixes #3109

Related to #2395

This needs a followup MV3 PR where we regenerate site-specific domain override rules in response to `sitefixes` storage changes.