### PR TITLE
Wait for tabData initialization when opening popup

### DIFF
--- a/src/js/tabdata.js
+++ b/src/js/tabdata.js
@@ -26,6 +26,8 @@ import utils from "./utils.js";
 function TabData() {
   let self = this;
 
+  self.INITIALIZED = false;
+
   /**
    * {
    *   <tab_id>: {
@@ -167,6 +169,7 @@ TabData.prototype.initialize = function () {
         }
 
         log("Initialized tab data");
+        self.INITIALIZED = true;
         resolve();
       });
     });

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1411,6 +1411,14 @@ function dispatcher(request, sender, sendResponse) {
   case "getPopupData": {
     let tab_id = request.tabId;
 
+    // if tab data isn't yet ready, retry up to a point
+    if (!badger.tabData.INITIALIZED && (Date.now() - badger.startTime) < 5000) {
+      setTimeout(function () {
+        dispatcher(request, sender, sendResponse);
+      }, 50);
+      return true; // async chrome.runtime.onMessage response
+    }
+
     if (!badger.tabData.has(tab_id)) {
       sendResponse({
         criticalError: badger.criticalError,


### PR DESCRIPTION
Fixes #3116.

With MV2 the background process should only start once, on browser startup. If tab data fails to initialize in MV2 under X (5?) seconds for whatever reason, do we want to show a "failed to initialize" error in response to opening the popup, or do we want to ignore it? We may want to ignore it. To be clear, 15 secs of `!badger.INITIALIZED` should produce "failed to initialize" but X secs of `!badger.tabData.INITIALIZED` probably shouldn't.