### PR TITLE
Replace hardcoded wait with polling in popup tests

### DIFF
--- a/tests/selenium/popup_test.py
+++ b/tests/selenium/popup_test.py
@@ -9,20 +9,37 @@ import pbtest
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
 class PopupTest(pbtest.PBSeleniumTest):
     """Make sure the popup works correctly."""
 
+    def wait_for_sliders(self, visible=True, timeout=5):
+        def condition(dr):
+            """tests all are invisible"""
+            sliders = dr.find_elements(By.CSS_SELECTOR, "div.clicker")
+            for slider in sliders:
+                if slider.is_displayed():
+                    return False
+            return True
+
+        if visible:
+            condition = EC.visibility_of_all_elements_located(
+                (By.CSS_SELECTOR, "div.clicker"))
+
+        try:
+            WebDriverWait(self.driver, timeout).until(condition)
+        except TimeoutException:
+            pass
+
     def wait_for_page_to_start_loading(self, url, timeout=20):
         """Wait until the title element is present. Use it to work around
         Firefox not updating self.driver.current_url fast enough."""
         try:
             WebDriverWait(self.driver, timeout).until(
-                expected_conditions.presence_of_element_located(
-                    (By.CSS_SELECTOR, "title")))
+                EC.presence_of_element_located((By.CSS_SELECTOR, "title")))
         except TimeoutException:
             # TODO debug info
             print("\n")
@@ -106,8 +123,7 @@ class PopupTest(pbtest.PBSeleniumTest):
         faq_selector = f"a[href='{EFF_URL[EFF_URL.index('#'):]}']"
         try:
             WebDriverWait(self.driver, pbtest.SEL_DEFAULT_WAIT_TIMEOUT).until(
-                expected_conditions.presence_of_element_located(
-                    (By.CSS_SELECTOR, faq_selector)))
+                EC.presence_of_element_located((By.CSS_SELECTOR, faq_selector)))
         except TimeoutException:
             self.fail(f"Unable to find expected element ({faq_selector}) on EFF website")
 
@@ -177,8 +193,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # reveal sliders
         self.driver.find_element(By.ID, 'expand-blocked-resources').click()
-        # TODO retry instead
-        time.sleep(1)
+        self.wait_for_sliders()
 
         # set the domain to user control
         # click input with JavaScript to avoid "Element ... is not clickable" /
@@ -304,8 +319,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # reveal sliders
         self.driver.find_element(By.ID, 'expand-blocked-resources').click()
-        # TODO retry instead
-        time.sleep(1)
+        self.wait_for_sliders()
 
         # verify there is no breakage warning
         breakage_icon = get_breakage_icon()
@@ -354,8 +368,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # reveal sliders
         self.driver.find_element(By.ID, 'expand-blocked-resources').click()
-        # TODO retry instead
-        time.sleep(1)
+        self.wait_for_sliders()
 
         # verify sliders are visible
         assert_visible(sliders)
@@ -375,8 +388,7 @@ class PopupTest(pbtest.PBSeleniumTest):
 
         # hide sliders
         self.driver.find_element(By.ID, 'collapse-blocked-resources').click()
-        # TODO retry instead
-        time.sleep(1)
+        self.wait_for_sliders(visible=False)
 
         # verify sliders are hidden
         assert_hidden(sliders)


### PR DESCRIPTION
Should fix sporadic failures in Edge.