### PR TITLE
Fix keyboard navigation going through hidden elements in popup

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -202,7 +202,7 @@ function init() {
   });
 
   $("#error").on("click", function() {
-    $('#overlay').toggleClass('active');
+    showOverlay("#overlay");
     // Show YouTube message on error reporting form
     if (POPUP_DATA.tabHost === "www.youtube.com" || POPUP_DATA.tabHost === "m.youtube.com") {
       $('#report-youtube-message').html(chrome.i18n.getMessage("popup_info_youtube") + " " + chrome.i18n.getMessage('learn_more_link', ['<a target=_blank href="https://privacybadger.org/#Is-Privacy-Badger-breaking-YouTube">privacybadger.org</a>']));
@@ -273,7 +273,7 @@ function init() {
   });
   $("#share-close").on("click", function (e) {
     e.preventDefault();
-    $("#share-overlay").toggleClass('active', false);
+    hideOverlay("#share-overlay");
   });
   $("#copy-button").on("click", function() {
     $("#share-output").select();
@@ -330,10 +330,10 @@ function clearSavedErrorText() {
  * Close the error reporting overlay
  */
 function closeOverlay() {
-  $('#overlay').toggleClass('active', false);
   $("#report-success").hide();
   $("#report-fail").hide();
   $("#error-input").val("");
+  hideOverlay("#overlay");
 }
 
 /**
@@ -459,7 +459,7 @@ function deactivateOnSite() {
  * Open the share overlay
  */
 function share() {
-  $("#share-overlay").toggleClass('active');
+  showOverlay("#share-overlay");
   let share_msg = chrome.i18n.getMessage("share_base_message");
 
   // only add language about found trackers if we actually found trackers
@@ -657,7 +657,7 @@ function refreshPopup() {
   }
   // show error layout if the user was writing an error report
   if (utils.hasOwn(POPUP_DATA, 'errorText') && POPUP_DATA.errorText) {
-    $('#overlay').toggleClass('active');
+    showOverlay("#overlay");
   }
 
   // show sliders when sliders were shown last,
@@ -900,6 +900,32 @@ function getTab(callback) {
  */
 function setPopupData(data) {
   POPUP_DATA = data;
+}
+
+let lastFocused;
+function showOverlay(overlayId) {
+  // Store last focused element to return to after closing overlay via tab navigation
+  lastFocused = $(document.activeElement);
+
+  $(overlayId).toggleClass('active');
+  $('#popup-content').toggleClass('hidden');
+  // Focus on the first focusable element focus to an element, per ARIA guidance for dialogs/modals (https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+  const focusable = $(overlayId).find(
+    'button, [href], input, select, textarea, iframe, [tabindex]:not([tabindex="-1"])'
+  );
+  if (focusable.length) {
+    focusable[0].focus();
+  }
+}
+
+function hideOverlay(overlayId) {
+  $(overlayId).toggleClass('active', false);
+  $('#popup-content').toggleClass('hidden', false);
+
+  // Return focus to the element that invoked it, per ARIA guidance for dialogs/modals (https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+  if (lastFocused && lastFocused.length) {
+    lastFocused.focus();
+  }
 }
 
 $(function () {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -902,29 +902,31 @@ function setPopupData(data) {
   POPUP_DATA = data;
 }
 
-let lastFocused;
-function showOverlay(overlayId) {
+let $lastFocused;
+function showOverlay(overlay_id) {
   // Store last focused element to return to after closing overlay via tab navigation
-  lastFocused = $(document.activeElement);
+  $lastFocused = $(document.activeElement);
 
-  $(overlayId).toggleClass('active');
+  $(overlay_id).toggleClass('active');
   $('#popup-content').toggleClass('hidden');
-  // Focus on the first focusable element focus to an element, per ARIA guidance for dialogs/modals (https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
-  const focusable = $(overlayId).find(
+
+  // Focus on the first focusable element, per ARIA guidance for dialogs/modals
+  // https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+  let $focusables = $(overlay_id).find(
     'button, [href], input, select, textarea, iframe, [tabindex]:not([tabindex="-1"])'
   );
-  if (focusable.length) {
-    focusable[0].focus();
+  if ($focusables.length) {
+    $focusables[0].focus();
   }
 }
-
-function hideOverlay(overlayId) {
-  $(overlayId).toggleClass('active', false);
+function hideOverlay(overlay_id) {
+  $(overlay_id).toggleClass('active', false);
   $('#popup-content').toggleClass('hidden', false);
 
-  // Return focus to the element that invoked it, per ARIA guidance for dialogs/modals (https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
-  if (lastFocused && lastFocused.length) {
-    lastFocused.focus();
+  // Return focus to the element that invoked it,
+  // per ARIA guidance for dialogs/modals
+  if ($lastFocused && $lastFocused.length) {
+    $lastFocused.focus();
   }
 }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -202,7 +202,7 @@ a.removeOrigin:hover {
 }
 
 /* popup only (not options page) */
-body#main #blockedResourcesContainer, #special-browser-page, #disabled-site-message, #first-run-page {
+body#main #blockedResourcesContainer, #special-browser-page, #disabled-site-message, #first-run-page, #popup-content {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -416,13 +416,21 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #d
   box-sizing: border-box;
   color: #ccc;
   background: url("/skin/background.png");
-  transition: opacity .1s ease;
+  /* Delay visibility  change to show opacity transition when overlay is closed */
+  transition: visibility 0s 0.1s, opacity 0.1s ease;
   overflow-y: auto;
+  visibility: hidden;
 }
 div.overlay.active {
   z-index: 31;
   opacity: 1;
+  visibility: visible;
+  transition: opacity 0.1s ease;
 }
+div#popup-content.hidden {
+    visibility: hidden;
+}
+
 #error-input {
     display: block;
     width: 98%;

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -416,7 +416,7 @@ body#main #pbInstructions a:hover, #firstparty-protections-container a:hover, #d
   box-sizing: border-box;
   color: #ccc;
   background: url("/skin/background.png");
-  /* Delay visibility  change to show opacity transition when overlay is closed */
+  /* Delay visibility change to show opacity transition when overlay is closed */
   transition: visibility 0s 0.1s, opacity 0.1s ease;
   overflow-y: auto;
   visibility: hidden;

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -33,6 +33,35 @@
 <script type="module" src="/js/popup.js"></script>
 </head>
 <body id="main">
+
+<div id="overlay" class="overlay" role="dialog" aria-modal="true">
+  <div>
+    <a href="" id="report-close" class="i18n_report_close overlay-close" role="button"></a>
+    <h1 class="i18n_report_broken_site overlay-title"></h1>
+  </div>
+  <div id="report-youtube-message-container" style="display:none">
+    <div id="report-youtube-message"></div>
+  </div>
+  <label id="report-label" for="error-input" class="i18n_report_input_label"></label>
+  <textarea id="error-input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
+  <div id="report-controls">
+    <button id="report-button" class="i18n_report_button pbButton"></button>
+    <button id="report-cancel" class="i18n_report_cancel pbButton"></button>
+  </div>
+  <div id="report-success" class="i18n_report_success" style="display:none"></div>
+  <div id="report-fail" class="i18n_report_fail" style="display:none"></div>
+  <p id="report-terms" class="i18n_report_terms"></p>
+</div>
+<div id="share-overlay" class="overlay" role="dialog" aria-modal="true">
+  <div>
+    <a href="" id="share-close" class="i18n_report_close overlay-close" role="button"></a>
+    <h1 class="i18n_share_title overlay-title"></h1>
+  </div>
+  <textarea id="share-output" spellcheck="false"></textarea>
+  <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
+</div>
+
+<div id="popup-content">
   <div id="instruction-outer">
   </div>
   <div id="instruction">
@@ -71,33 +100,6 @@
     </div>
 
   </div><!-- end of div#instruction -->
-
-  <div id="overlay" class="overlay">
-    <div>
-      <a href="" id="report-close" class="i18n_report_close overlay-close" role="button"></a>
-      <h1 class="i18n_report_broken_site overlay-title"></h1>
-    </div>
-    <div id="report-youtube-message-container" style="display:none">
-      <div id="report-youtube-message"></div>
-    </div>
-    <label id="report-label" for="error-input" class="i18n_report_input_label"></label>
-    <textarea id="error-input" maxlength="300" rows=3 placeholder="i18n_error_input"></textarea>
-    <div id="report-controls">
-      <button id="report-button" class="i18n_report_button pbButton"></button>
-      <button id="report-cancel" class="i18n_report_cancel pbButton"></button>
-    </div>
-    <div id="report-success" class="i18n_report_success" style="display:none"></div>
-    <div id="report-fail" class="i18n_report_fail" style="display:none"></div>
-    <p id="report-terms" class="i18n_report_terms"></p>
-  </div>
-  <div id="share-overlay" class="overlay">
-    <div>
-      <a href="" id="share-close" class="i18n_report_close overlay-close" role="button"></a>
-      <h1 class="i18n_share_title overlay-title"></h1>
-    </div>
-    <textarea id="share-output" spellcheck="false"></textarea>
-    <button id="copy-button" class="i18n_copy_button_initial pbButton"></button>
-  </div>
 
 <div id="privacy-badger-header">
 
@@ -183,5 +185,6 @@
   </div>
   <div id="version" class="i18n_version"></div>
 </footer>
+</div>
 </body>
 </html>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -52,6 +52,7 @@
   <div id="report-fail" class="i18n_report_fail" style="display:none"></div>
   <p id="report-terms" class="i18n_report_terms"></p>
 </div>
+
 <div id="share-overlay" class="overlay" role="dialog" aria-modal="true">
   <div>
     <a href="" id="share-close" class="i18n_report_close overlay-close" role="button"></a>
@@ -62,6 +63,7 @@
 </div>
 
 <div id="popup-content">
+
   <div id="instruction-outer">
   </div>
   <div id="instruction">
@@ -185,6 +187,8 @@
   </div>
   <div id="version" class="i18n_version"></div>
 </footer>
-</div>
+
+</div><!-- end of div#popup-content -->
+
 </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/EFForg/privacybadger/issues/3105

- Prevent keyboard navigation through hidden elements while preserving overlay transition effect
  - I used `visibility: hidden` instead of `display: none` to preserve the transition
- Follow ARIA guidelines for focus after opening and closing a modal/dialogue
  - NOTE: I don't think ARIA guidelines about "Esc" key being used to exit a modal/dialogue can be followed because "Esc" already closes extension popups. I don't think we should interfere with this behavior?
- Tested on Firefox and Chrome with VoiceOver screenreader navigation and tab navigation 
- Known issue: Tab navigation doesn't loop on the overlay on Firefox. It does on Chrome. I could address this by trapping focus manually (https://zachpatrick.com/blog/how-to-trap-focus-inside-modal-to-make-it-ada-compliant)