### PR TITLE
Add focus indicator to CTA buttons/links in popup

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -226,6 +226,10 @@ button.cta-button, a.cta-button {
 button.cta-button:hover, a.cta-button:hover {
     background-color: #f58728;
 }
+button.cta-button:focus-visible, a.cta-button:focus-visible {
+    border: 2px solid #333;
+    outline: none;
+}
 
 .clickerContainer {
     max-height: 290px;
@@ -638,6 +642,9 @@ a.overlay-close:hover {
     }
     a.cta-button:hover {
         color: #fff;
+    }
+    button.cta-button:focus-visible, a.cta-button:focus-visible {
+        border: 2px solid #fff;
     }
 
     /* popup only (not options page) */

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -66,7 +66,7 @@
 
   <div id="instruction-outer">
   </div>
-  <div id="instruction">
+  <div id="instruction" role="dialog" aria-modal="true">
     <a href="" id="fittslaw" role="button" aria-label="i18n_report_close">
       <img src="../icons/close.svg" alt="">
     </a>


### PR DESCRIPTION
Fixes #3139

The `role="dialog"` and `aria-modal="true"` are for marking the nudge/critical error/important update notification overlay as what it is, a modal. It doesn't actually prevent keyboard nav from going out of bounds, that's still an issue.