### PR TITLE
Make tooltip content in popup screenreader-accessible

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -115,6 +115,16 @@
         "message": "Move the slider right to allow a domain",
         "description": "Domain slider list header tooltip."
     },
+    "popup_slider_label": {
+        "message": "Blocking options for $DOMAIN$",
+        "description": "Screenreader-accessible label for domain sliders",
+        "placeholders": {
+            "domain": {
+                "content": "$1",
+                "example": "example.com"
+            }
+        }
+    },
     "badger_status_block": {
         "message": "Blocked $DOMAIN$",
         "description": "Tooltip shown over a domain name with a red slider in the domain slider list. This is a status (\"example.com was blocked\"), not an action (\"click here to block example.com\").",

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -126,7 +126,7 @@ let htmlUtils = {
       let id = fqdn.replace(/\./g, '-');
       return `
 <div class="switch-container ${action}">
-  <div class="switch-toggle switch-3 switch-candy">
+  <div class="switch-toggle switch-3 switch-candy" role="radiogroup" aria-label="${i18n.getMessage('popup_slider_label', fqdn)}">
     <input id="block-${id}" name="${fqdn}" value="${constants.BLOCK}" type="radio" aria-label="${tooltips.block}" ${is_checked(constants.BLOCK, action)}>
     <label title="${tooltips.block}" class="tooltip" for="block-${id}"></label>
     <input id="cookieblock-${id}" name="${fqdn}" value="${constants.COOKIEBLOCK}" type="radio" aria-label="${tooltips.cookieblock}" ${is_checked(constants.COOKIEBLOCK, action)}>

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -150,7 +150,7 @@ let htmlUtils = {
     return function () {
       return `
       <div class="dnt-compliant">
-        <a target=_blank href="https://privacybadger.org/#-I-am-an-online-advertising-tracking-company.--How-do-I-stop-Privacy-Badger-from-blocking-me"><img src="${dnt_icon_url}"></a>
+        <a target=_blank href="https://privacybadger.org/#-I-am-an-online-advertising-tracking-company.--How-do-I-stop-Privacy-Badger-from-blocking-me" aria-label="${i18n.getMessage('dnt_tooltip')}"><img src="${dnt_icon_url}" alt=""></a>
       </div>
       `.trim();
     };
@@ -201,7 +201,7 @@ let htmlUtils = {
 
       let shield_icon = '';
       if (blockedFpScripts) {
-        shield_icon = '<span class="ui-icon ui-icon-shield"></span>';
+        shield_icon = '<span class="ui-icon ui-icon-shield" aria-hidden="true"></span>';
       }
 
       // construct HTML for domain
@@ -209,13 +209,13 @@ let htmlUtils = {
 
       return `
 <div class="${classes.join(' ')}" data-origin="${fqdn}">
-  <div class="origin" role="heading" aria-level="4">
-    <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}"></span>
+  <div class="origin" role="heading" aria-level="4" aria-label="${domain_tooltip}">
+    <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}" aria-label="${breakage_warning_tooltip}" role="img"></span>
     <span class="origin-inner tooltip" title="${domain_tooltip}">${dnt_html}${shield_icon}${fqdn}</span>
   </div>
   <a href="" class="removeOrigin">&#10006</a>
   ${htmlUtils.getToggleHtml(fqdn, action, blockedFpScripts)}
-  <a href="" class="honeybadgerPowered tooltip" title="${undo_arrow_tooltip}"></a>
+  <a href="" class="honeybadgerPowered tooltip" title="${undo_arrow_tooltip}" aria-label="${undo_arrow_tooltip}"></a>
 </div>
       `.trim();
     };

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -795,7 +795,7 @@ function refreshPopup() {
     $('#instructions-many-trackers').html(chrome.i18n.getMessage(
       "popup_instructions", [
         POPUP_DATA.trackerCount,
-        "<a target='_blank' title='" + htmlUtils.escape(chrome.i18n.getMessage("what_is_a_tracker")) + "' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"
+        "<a target='_blank' title='" + htmlUtils.escape(chrome.i18n.getMessage("what_is_a_tracker")) + "' aria-description='" + htmlUtils.escape(chrome.i18n.getMessage("what_is_a_tracker")) + "' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"
       ]
     )).find(".tooltip").tooltipster();
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -573,6 +573,11 @@ function createBreakageNote(domain, i18n_message_key) {
     autoClose: false,
     content: chrome.i18n.getMessage(i18n_message_key),
     functionReady: function (tooltip) {
+      // Add aria-hidden to ensure that the tooltip isn't read twice by screenreaders
+      // It should be read along with the selected slider option (via aria-describedby), and not where it's inserted at the end of the popup DOM
+      $(tooltip.elementTooltip()).attr({role: "tooltip", "aria-hidden": "true"});
+      $slider_allow .closest(".switch-toggle").find("input:checked").attr("aria-describedby", tooltip.elementTooltip().id);
+
       // close on tooltip click/tap
       $(tooltip.elementTooltip()).on('click', function (e) {
         e.preventDefault();
@@ -677,11 +682,13 @@ function refreshPopup() {
     $('#expand-blocked-resources').hide();
     $('#collapse-blocked-resources').show();
     $('#blockedResources').show();
+    $("#tracker-list-header").attr("aria-expanded", true);
 
   } else {
     $('#expand-blocked-resources').show();
     $('#collapse-blocked-resources').hide();
     $('#blockedResources').hide();
+    $("#tracker-list-header").attr("aria-expanded", false);
   }
 
   let domainsArr = [];

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -512,6 +512,7 @@ function toggleBlockedResourcesHandler(e) {
     $("#collapse-blocked-resources").show();
     $("#expand-blocked-resources").hide();
     $("#blockedResources").slideDown();
+    $("#tracker-list-header").attr("aria-expanded", true);
     chrome.runtime.sendMessage({
       type: "updateSettings",
       data: { showExpandedTrackingSection: true }
@@ -520,6 +521,7 @@ function toggleBlockedResourcesHandler(e) {
     $("#collapse-blocked-resources").hide();
     $("#expand-blocked-resources").show();
     $("#blockedResources").slideUp();
+    $("#tracker-list-header").attr("aria-expanded", false);
     chrome.runtime.sendMessage({
       type: "updateSettings",
       data: { showExpandedTrackingSection: false }

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -142,6 +142,7 @@ function loadI18nStrings() {
     'placeholder',
     'title',
     'aria-label',
+    'aria-description',
   ];
 
   // get all the elements that contain one or more of these attributes

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -110,7 +110,7 @@
   </div>
 
   <div id="badger-title-div">
-    <a href="https://www.eff.org/" target="_blank"><img id='header-red-eff-logo' src="./images/EFF-red.svg" width="48" alt="" title="i18n_intro_by_eff" class="tooltip" data-tooltipster='{"distance":20,"maxWidth":180}'></a>
+    <a href="https://www.eff.org/" target="_blank" aria-label="i18n_intro_by_eff"><img id='header-red-eff-logo' src="./images/EFF-red.svg" width="48" alt="" title="i18n_intro_by_eff" class="tooltip" data-tooltipster='{"distance":20,"maxWidth":180}'></a>
     <h2><span class="i18n_name"></span></h2>
   </div>
 
@@ -147,14 +147,14 @@
       </span>
     </button>
     <div class="basic-header" id="instructions-no-trackers" style="display:none">
-      <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
+      <span class="i18n_popup_instructions_no_trackers" data-i18n_contents_placeholders="<a target='_blank' aria-description='i18n_what_is_a_tracker' title='i18n_what_is_a_tracker' class='tooltip' href='https://privacybadger.org/#What-is-a-third-party-tracker'>"></span>
       <span id="no-third-parties" class="i18n_popup_blocked" style="display:none"></span>
     </div>
   </div>
   <div id="blockedResources" style="display:none">
     <div class="keyContainer">
       <div class="key">
-        <img src="/icons/UI-icons-red.svg" class="tooltip" title="i18n_tooltip_block"><img src="/icons/UI-icons-yellow.svg" class="tooltip" title="i18n_tooltip_cookieblock"><img src="/icons/UI-icons-green.svg" class="tooltip" title="i18n_tooltip_allow">
+        <img src="/icons/UI-icons-red.svg" class="tooltip" title="i18n_tooltip_block" alt="i18n_tooltip_block"><img src="/icons/UI-icons-yellow.svg" class="tooltip" title="i18n_tooltip_cookieblock" alt="i18n_tooltip_cookieblock"><img src="/icons/UI-icons-green.svg" class="tooltip" title="i18n_tooltip_allow" alt="i18n_tooltip_allow">
       </div>
     </div>
     <div id="blockedResourcesInner" class="clickerContainer"></div>

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -139,7 +139,7 @@
 
 <div id="blockedResourcesContainer">
   <div id="pbInstructions">
-    <button class="toggle-header" id="tracker-list-header" style="display:none">
+    <button class="toggle-header" id="tracker-list-header" style="display:none" aria-expanded="false" aria-controls="blockedResources">
       <span class="toggle-header-title" id="instructions-many-trackers"></span>
       <span class="toggle-header-icon">
         <span id="expand-blocked-resources" class="ui-icon ui-icon-caret-d" style="display:none"></span>


### PR DESCRIPTION
**Addresses:**
- https://github.com/EFForg/privacybadger/issues/3138
- https://github.com/EFForg/privacybadger/issues/3132
- https://github.com/EFForg/privacybadger/issues/3131
- Made the collapsed/expanded state of the tracker list screenreader-accessible
- Added `role="radiogroup"` and an aria-label to the slider group to provide screenreaders with more context for slider buttons

Tested with the VoiceOver screenreader on MacOS

**Test instructions:**
- Navigate to each of the elements that have a tooltip:
  - EFF logo
  -  "trackers" link
  - Icons above the tracker list representing the slider options
  - Domains in the tracker list
  -  Domain slider options
  - Breakage warning tooltip
  - "Click to return control" tooltip
  - Google sign-in warning tooltip
  - DNT icon
- To see the breakage warning tooltip, move a slider in the yellow (cookie-block) position to the red (block) position
<img width="385" height="95" alt="Screenshot 2025-09-19 at 5 00 06 PM" src="https://github.com/user-attachments/assets/6c280513-60e0-46ea-a6bb-c1bd181ecc12" />

- To see the "Click to return control" tooltip, move a slider to any position
<img width="422" height="98" alt="Screenshot 2025-09-19 at 4 58 03 PM" src="https://github.com/user-attachments/assets/6ae2cb22-d9f4-43c3-956a-a42617947de2" />

- To see the "DNT" icon, visit https://www.nytimes.com/ and scroll down the tracker list to the domain with the DNT icon
<img width="364" height="73" alt="Screenshot 2025-09-19 at 5 02 37 PM" src="https://github.com/user-attachments/assets/396fd23f-b9e0-49ce-a690-1bff45e89f75" />

- To see the Google sign-in warning tooltip, visit https://stackoverflow.com/ or another site with Google sign-in
 <img width="436" height="187" alt="Screenshot 2025-09-19 at 4 56 31 PM" src="https://github.com/user-attachments/assets/9d80b8c8-60de-436d-84b4-55c118ca269b" />