### PR TITLE
Optimize checking if PB is disabled for a site

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -788,6 +788,9 @@ BadgerStorage.prototype = {
         // combine array settings via intersection/union
         if (prop == "disabledSites" || prop == "widgetReplacementExceptions") {
           self.setItem(prop, utils.concatUniq(self.getItem(prop), mapData[prop]));
+          if (prop == "disabledSites") {
+            badger.initDisabledSitesTrie();
+          }
 
         // string/array map
         } else if (prop == "widgetSiteAllowlist") {
@@ -971,9 +974,9 @@ let _syncStorage = (function () {
     if (!callback) {
       callback = function () {};
     }
-    let obj = {};
-    obj[badgerStore.name] = badgerStore._store;
-    chrome.storage.local.set(obj, function () {
+    let data = {};
+    data[badgerStore.name] = badgerStore._store;
+    chrome.storage.local.set(data, function () {
       if (!chrome.runtime.lastError) {
         callback(null);
         return;

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1663,13 +1663,13 @@ function dispatcher(request, sender, sendResponse) {
   case "downloadCloud": {
     chrome.storage.sync.get("disabledSites", function (store) {
       if (chrome.runtime.lastError) {
-        sendResponse({success: false, message: chrome.runtime.lastError.message});
+        sendResponse({ success: false, message: chrome.runtime.lastError.message });
       } else if (utils.hasOwn(store, "disabledSites")) {
         let disabledSites = utils.concatUniq(
-          badger.getDisabledSites(),
-          store.disabledSites
-        );
+          badger.getSettings().getItem("disabledSites"),
+          store.disabledSites);
         badger.getSettings().setItem("disabledSites", disabledSites);
+        badger.initDisabledSitesTrie();
         sendResponse({
           success: true,
           disabledSites
@@ -1687,13 +1687,13 @@ function dispatcher(request, sender, sendResponse) {
   }
 
   case "uploadCloud": {
-    let obj = {};
-    obj.disabledSites = badger.getDisabledSites();
-    chrome.storage.sync.set(obj, function () {
+    let data = {};
+    data.disabledSites = badger.getSettings().getItem("disabledSites");
+    chrome.storage.sync.set(data, function () {
       if (chrome.runtime.lastError) {
-        sendResponse({success: false, message: chrome.runtime.lastError.message});
+        sendResponse({ success: false, message: chrome.runtime.lastError.message });
       } else {
-        sendResponse({success: true});
+        sendResponse({ success: true });
       }
     });
     // indicate this is an async response to chrome.runtime.onMessage
@@ -1767,7 +1767,7 @@ function dispatcher(request, sender, sendResponse) {
   case "disableOnSite": {
     badger.disableOnSite(request.domain);
     sendResponse({
-      disabledSites: badger.getDisabledSites()
+      disabledSites: badger.getSettings().getItem("disabledSites")
     });
     break;
   }
@@ -1777,7 +1777,7 @@ function dispatcher(request, sender, sendResponse) {
       badger.reenableOnSite(domain);
     });
     sendResponse({
-      disabledSites: badger.getDisabledSites()
+      disabledSites: badger.getSettings().getItem("disabledSites")
     });
     break;
   }

--- a/src/lib/trie.js
+++ b/src/lib/trie.js
@@ -1,0 +1,154 @@
+/*
+ * This file is part of Privacy Badger <https://privacybadger.org/>
+ * Copyright (C) 2025 Electronic Frontier Foundation
+ *
+ * Privacy Badger is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * Privacy Badger is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import utils from "../js/utils.js";
+
+/**
+ * Trie node constructor.
+ *
+ * @param {String?} key
+ */
+function TrieNode(key) {
+  this.key = key;
+  this.parentNode = null;
+  this.stringEndsHere = false;
+  this.children = {};
+}
+
+/**
+ * Iterates through parent nodes to reconstruct the dot-separated string.
+ */
+TrieNode.prototype.getString = function () {
+  let output = [],
+    node = this; // eslint-disable-line consistent-this
+
+  // stop at the root node
+  while (node.key !== null) {
+    output.push(node.key);
+    node = node.parentNode;
+  }
+
+  return output.join('.');
+};
+
+/**
+ * Recursively populates `arr` with full strings
+ * belonging to children of a given TrieNode.
+ *
+ * @param {TrieNode} node
+ * @param {Array} arr
+ */
+function findAll(node, arr) {
+  if (node.stringEndsHere) {
+    arr.push(node.getString());
+  }
+
+  for (let key of Object.keys(node.children)) {
+    findAll(node.children[key], arr);
+  }
+}
+
+/**
+ * Domain trie constructor.
+ */
+function Trie() {
+  this.root = new TrieNode(null);
+}
+
+/*
+ * Inserts a dot-separated domain string into the trie.
+ *
+ * @param {String} domain
+ */
+Trie.prototype.insert = function (domain) {
+  let node = this.root,
+    parts = domain.split('.');
+
+  for (let i = parts.length-1; i >= 0; i--) {
+    let key = parts[i];
+
+    if (!utils.hasOwn(node.children, key)) {
+      node.children[key] = new TrieNode(key);
+      node.children[key].parentNode = node;
+    }
+
+    node = node.children[key];
+
+    if (i == 0) {
+      node.stringEndsHere = true;
+    }
+  }
+};
+
+/**
+ * Returns any subdomains and the domain itself, if inserted directly.
+ *
+ * Note that the order of strings is undefined.
+ *
+ * @param {String} domain
+ *
+ * @returns {Array}
+ */
+Trie.prototype.getDomains = function (domain) {
+  let domains = [],
+    node = this.root,
+    parts = domain.split('.');
+
+  // first navigate to the deepest TrieNode for domain
+  for (let i = parts.length-1; i >= 0; i--) {
+    let key = parts[i];
+    if (!utils.hasOwn(node.children, key)) {
+      // abort if domain isn't fully in the Trie
+      return domains;
+    }
+    node = node.children[key];
+  }
+
+  findAll(node, domains);
+
+  return domains;
+};
+
+/**
+ * Returns whether the domain string, or any of its
+ * parent domain strings were inserted into the trie.
+ *
+ * @param {String} domain
+ *
+ * @returns {Boolean}
+ */
+Trie.prototype.globDomainMatches = function (domain) {
+  let parts = domain.split('.'),
+    node = this.root;
+
+  for (let i = parts.length-1; i >= 0; i--) {
+    let key = parts[i];
+    if (!utils.hasOwn(node.children, key)) {
+      return false;
+    }
+    node = node.children[key];
+    if (node.stringEndsHere) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export {
+  Trie
+};

--- a/src/tests/index.html
+++ b/src/tests/index.html
@@ -48,6 +48,7 @@
     <script type="module" src="tests/options.js"></script>
     <script type="module" src="tests/storage.js"></script>
     <script type="module" src="tests/tabData.js"></script>
+    <script type="module" src="tests/trie.js"></script>
     <!-- URL/host tools: --><script type="module" src="tests/baseDomain.js"></script>
     <script type="module" src="tests/utils.js"></script>
     <script type="module" src="tests/yellowlist.js"></script>

--- a/src/tests/lib/qunit_config.js
+++ b/src/tests/lib/qunit_config.js
@@ -39,6 +39,9 @@
       let store = badger.storage.getStore(store_name);
       BACKUP[store_name] = store.getItemClones();
     });
+
+    BACKUP.disabledSitesTrie = badger.disabledSitesTrie;
+    badger.initDisabledSitesTrie();
   });
 
   QUnit.testDone(() => {
@@ -47,6 +50,8 @@
       let store = badger.storage.getStore(store_name);
       store._store = BACKUP[store_name];
     });
+
+    badger.disabledSitesTrie = BACKUP.disabledSitesTrie;
   });
 
   // kick off tests when we have what we need from Badger

--- a/src/tests/tests/trie.js
+++ b/src/tests/tests/trie.js
@@ -1,0 +1,80 @@
+import { Trie } from "../../lib/trie.js";
+
+QUnit.module("Trie");
+
+QUnit.test("basic functionality", (assert) => {
+  let trackers = [
+    "example.com.eviltracker.net",
+    "track.eviltracker.net",
+    "eviltracker.net",
+    "example.net"
+  ];
+
+  let trie = new Trie();
+
+  for (let tracker of trackers) {
+    trie.insert(tracker);
+  }
+
+  assert.deepEqual(
+    trie.getDomains("track.eviltracker.net"),
+    ["track.eviltracker.net"],
+    "subdomain matches itself");
+
+  assert.deepEqual(
+    trie.getDomains("com.eviltracker.net"),
+    ["example.com.eviltracker.net"],
+    "subdomain of subdomain matches");
+
+  assert.deepEqual(
+    trie.getDomains("eviltracker.net").sort(),
+    trackers.filter(d => d != "example.net").sort(),
+    "eTLD+1 matches itself and all subdomains");
+
+  assert.deepEqual(
+    trie.getDomains("example.com"),
+    [],
+    "no matches");
+});
+
+QUnit.test("subdomains only trie", (assert) => {
+  let trackers = [
+    "example.com.eviltracker.net",
+    "track.eviltracker.net"
+  ];
+
+  let trie = new Trie();
+
+  for (let tracker of trackers) {
+    trie.insert(tracker);
+  }
+
+  assert.deepEqual(
+    trie.getDomains("eviltracker.net").sort(),
+    trackers.sort(),
+    "eTLD+1 does not match itself when not inserted directly");
+});
+
+QUnit.test("glob domain matching", (assert) => {
+  let domains = [
+    "example.com",
+    "sub.example.org"
+  ];
+
+  let trie = new Trie();
+
+  for (let domain of domains) {
+    trie.insert(domain);
+  }
+
+  assert.ok(trie.globDomainMatches("example.com"), "direct match");
+  assert.ok(trie.globDomainMatches("sub.example.com"),
+    "subdomains are included");
+
+  assert.notOk(trie.globDomainMatches("example.net"), "no match");
+
+  assert.ok(trie.globDomainMatches("sub.example.org"),
+    "direct subdomain match");
+  assert.notOk(trie.globDomainMatches("example.org"),
+    "base domain was not inserted");
+});


### PR DESCRIPTION
Fixes #1507

It's possible for `disabledSites` in settings storage and the disabled sites trie in memory to get out of sync if we miss updating the trie after a `disabledSites` update. We might want to subscribe to `disabledSites` changes to avoid this scenario.