### PR TITLE
fix: change tab order on tracking domains page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ tests/.pytest_cache
 
 pkg
 release-utils/config.sh
+
+# development tooling
+.devcontainer/

--- a/src/js/htmlutils.js
+++ b/src/js/htmlutils.js
@@ -211,11 +211,11 @@ let htmlUtils = {
 <div class="${classes.join(' ')}" data-origin="${fqdn}">
   <div class="origin" role="heading" aria-level="4">
     <span class="ui-icon ui-icon-alert tooltip breakage-warning" title="${breakage_warning_tooltip}"></span>
-    <span class="origin-inner tooltip" title="${domain_tooltip}">${dnt_html}${shield_icon}${fqdn}</span>
+    <span class="origin-inner tooltip" title="${domain_tooltip}">${fqdn}${dnt_html}${shield_icon}</span>
   </div>
-  <a href="" class="removeOrigin">&#10006</a>
   ${htmlUtils.getToggleHtml(fqdn, action, blockedFpScripts)}
   <a href="" class="honeybadgerPowered tooltip" title="${undo_arrow_tooltip}"></a>
+  <a href="" class="removeOrigin">&#10006</a>
 </div>
       `.trim();
     };

--- a/src/skin/options-layout.css
+++ b/src/skin/options-layout.css
@@ -367,7 +367,7 @@ header {
     }
 
     .honeybadgerPowered {
-        left: 470px;
+        left: 475px;
     }
 }
 

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -74,6 +74,7 @@ button {
     height: 40px;
     overflow: hidden;
     line-height: normal;
+    contain: layout;
 }
 .clicker:not(#not-yet-blocked-header):not(#non-trackers-header) {
     direction: ltr;
@@ -117,7 +118,6 @@ button {
 }
 
 .dnt-compliant {
-    float: left;
     display: inline;
     padding-right: 5px;
 }
@@ -127,9 +127,9 @@ button {
     margin-right: 10px;
     width: 20px;
     height: 20px;
-    position: relative;
-    left: 340px;
-    bottom: 15px;
+    position: fixed;
+    left: 345px;
+    bottom: 24px;
 }
 .userset .honeybadgerPowered {
     display: block;


### PR DESCRIPTION
This fixes #3107 

I used [PR #3122](https://github.com/EFForg/privacybadger/pull/3122) as a starting point, and made sure the tests pass and the UI was not affected (too badly). Used flexbox on the tracking domain rows so that tabbing works implicitly with the HTML elements.

Attempted to knock out #3103 also since they are related, but I wasn't able to find a quick, clean way to make the toggle-switch direction-agnostic so I'll leave that for another day.