### PR TITLE
Fix errors on aa.com and zagreb.info

### DIFF
--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -202,7 +202,8 @@
                 "wtwc40.com",
                 "wutv29.com",
                 "wvah.com",
-                "wwmt.com"
+                "wwmt.com",
+                "www.zagreb.info"
             ],
             "connect.facebook.net": [
                 "www.redfin.com"


### PR DESCRIPTION
- Address error reports on: 
  - www.aa.com: missing chat widget on https://www.aa.com/i18n/customer-service/contact-american/american-customer-service.jsp
  - www.zagreb.info: almost all links are broken