### PR TITLE
Fix tweet replacement on websites that assign window.twttr to a local var

### DIFF
--- a/src/data/web_accessible_resources/twitter.js
+++ b/src/data/web_accessible_resources/twitter.js
@@ -13,7 +13,9 @@
         _e = window.twttr._e;
     }
 
-    window.twttr = {};
+    if (!window.twttr) {
+        window.twttr = {};
+    }
     window.twttr.events = {
         bind: function () {}
     };


### PR DESCRIPTION
Sites might do something like `let c = window.twttr = {...` and then later call `c.widgets.createTweet()` (from inside the `_e` callback array). If we redefine `window.twttr` unconditionally, `c` no longer points to the right place.

For example: https://ftw.usatoday.com/story/sports/nhl/2025/12/19/flyers-radio-announcer-tim-saunders-suspended-todd-fedoruk/87845326007/

Should see if we have a similar situation with YouTube.