### PR TITLE
Fix slow seed data ingestion / data merge

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -656,11 +656,16 @@ BadgerPen.prototype = {
 
   /**
    * Helps update fp_scripts.
+   *
+   * @param {String} script_fqdn
+   * @param {Array} script_paths one or more script path strings
    */
-  recordFingerprintingScript: function (script_fqdn, script_path) {
+  recordFingerprintingScript: function (script_fqdn, script_paths) {
     let fpStore = this.getStore('fp_scripts'),
       entry = fpStore.getItem(script_fqdn) || {};
-    entry[script_path] = 1;
+    for (let path of script_paths) {
+      entry[path] = 1;
+    }
     fpStore.setItem(script_fqdn, entry);
   }
 };
@@ -899,9 +904,8 @@ BadgerStorage.prototype = {
         if (!snitchItem) {
           continue;
         }
-        for (let script_path in mapData[script_fqdn]) {
-          badger.storage.recordFingerprintingScript(script_fqdn, script_path);
-        }
+        badger.storage.recordFingerprintingScript(script_fqdn,
+          Object.keys(mapData[script_fqdn]));
       }
     }
   },

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -772,7 +772,7 @@ function recordFingerprinting(tab_id, msg) {
           badger.storage.recordTrackingDetails(
             script_base, document_base, 'canvas');
           badger.storage.recordFingerprintingScript(
-            script_host, script_path);
+            script_host, [script_path]);
         }
       }
       // This is a canvas write


### PR DESCRIPTION
Caused when incoming data includes fingerprinting script hosts with lots of script path entries.

Here are some seed data loading times observed on an older device in Firefox and Chrome (forced MV2).

Current seed data before this patch: ~4.5 seconds
After: ~1 second

Seed data with many more `fp_scripts` entries before this patch: 45-60+ seconds
After: ~1 second

Needs verification on MV3 side post merge.

Follows up on #2891