### PR TITLE
Add sweatshirt promo to popup and move link rotation data to pbConfig

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -57,11 +57,11 @@
     },
     "popup_review_pb": {
         "message": "Enjoying Privacy Badger? Leave a review!",
-        "description": "A link in the popup footer shown 30% of the time instead of 'Donate to EFF'."
+        "description": "A link in the popup footer shown sometimes instead of 'Donate to EFF'."
     },
     "popup_sweatshirt_promo": {
         "message": "Show your support with a new Privacy Badger sweatshirt!",
-        "description": "A link in the popup footer shown about a third of the time instead of 'Donate to EFF'."
+        "description": "A link in the popup footer shown sometimes instead of 'Donate to EFF'."
     },
     "version": {
         "message": "version $VERSION_STRING$",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -61,7 +61,7 @@
     },
     "popup_sweatshirt_promo": {
         "message": "Show your support with a new Privacy Badger sweatshirt!",
-        "description": "A link in the popup footer shown about a third of the time (while EFF is selling a Privacy Badger sweatshirt)."
+        "description": "A link in the popup footer shown about a third of the time instead of 'Donate to EFF'."
     },
     "version": {
         "message": "version $VERSION_STRING$",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -59,6 +59,10 @@
         "message": "Enjoying Privacy Badger? Leave a review!",
         "description": "A link in the popup footer shown 30% of the time instead of 'Donate to EFF'."
     },
+    "popup_sweatshirt_promo": {
+        "message": "Show your support with a new Privacy Badger sweatshirt!",
+        "description": "A link in the popup footer shown about a third of the time (while EFF is selling a Privacy Badger sweatshirt)."
+    },
     "version": {
         "message": "version $VERSION_STRING$",
         "description": "Version text in the popup footer. For example, \"version 2018.8.1\".",

--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -8,7 +8,7 @@
         "DNT Policy v1.0 dos-line-endings": "c09f71363bb29d0250a1f5524eef36f9ab07669b",
         "DNT Policy v1.0 no-eof-newline": "7861462d500fbb6ccb74c614782f4937377bec76"
     },
-    "link_rotation" : [
+    "popup_promos": [
         {
             "url": "https://supporters.eff.org/donate/support-privacy-badger",
             "text": "popup_donate_to_eff",
@@ -16,7 +16,7 @@
             "odds": 0.35
         },
         {
-            "url": "https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/",
+            "url": null,
             "text": "popup_review_pb",
             "icon": "ui-icon-star",
             "odds": 0.3

--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -8,6 +8,26 @@
         "DNT Policy v1.0 dos-line-endings": "c09f71363bb29d0250a1f5524eef36f9ab07669b",
         "DNT Policy v1.0 no-eof-newline": "7861462d500fbb6ccb74c614782f4937377bec76"
     },
+    "link_rotation" : [
+        {
+            "url": "https://supporters.eff.org/donate/support-privacy-badger",
+            "text": "popup_donate_to_eff",
+            "icon": "ui-icon-heart",
+            "odds": 0.35
+        },
+        {
+            "url": "https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/",
+            "text": "popup_review_pb",
+            "icon": "ui-icon-star",
+            "odds": 0.3
+        },
+        {
+            "url": "https://supporters.eff.org/donate/spring--pb",
+            "text": "popup_sweatshirt_promo",
+            "icon": "ui-icon-cart",
+            "odds": 0.35
+        }
+    ],
     "sitefixes": {
         "gpc": [
             "www.costco.com",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -656,19 +656,22 @@ Badger.prototype = {
       self.getPrivateSettings().setItem('sitefixes', sitefixes);
     }
 
-    if (utils.hasOwn(data, 'link_rotation')) {
-      let linkRotation = data.link_rotation;
-      // Remove the review link from the rotation if we don't have a link for the browser's extension store
-      if (!utils.hasOwn(constants.REVIEW_LINKS, constants.BROWSER)) {
-        linkRotation = linkRotation.filter(link => link.text !== "popup_review_pb");
-      }
-      // Update the review link for the user's browser
-      for (let link of linkRotation) {
-        if (link.text === "popup_review_pb") {
-          link.url = constants.REVIEW_LINKS[constants.BROWSER];
+    if (utils.hasOwn(data, 'popup_promos')) {
+      let popupPromos = data.popup_promos;
+
+      if (utils.hasOwn(constants.REVIEW_LINKS, constants.BROWSER)) {
+        // Set the review link for the user's browser
+        for (let promo of popupPromos) {
+          if (promo.text === "popup_review_pb") {
+            promo.url = constants.REVIEW_LINKS[constants.BROWSER];
+          }
         }
+      } else {
+        // Remove the review promo from rotation when no review URL was defined
+        popupPromos = popupPromos.filter(promo => promo.text !== "popup_review_pb");
       }
-      self.getPrivateSettings().setItem('linkRotation', linkRotation);
+
+      self.getPrivateSettings().setItem('popupPromos', popupPromos);
     }
   },
 
@@ -884,16 +887,9 @@ Badger.prototype = {
       gpcDisabledSites: {},
       ignoredSiteBases: [],
       nextPbconfigUpdateTime: 0,
+      popupPromos: [],
       showLearningPrompt: false,
-      sitefixes: {},
-      linkRotation: [
-        {
-          url: "https://supporters.eff.org/donate/support-privacy-badger",
-          text: "popup_donate_to_eff",
-          icon: "ui-icon-heart",
-          odds: 1.0
-        }
-      ],
+      sitefixes: {}
     };
     for (let key of Object.keys(privateDefaultSettings)) {
       if (!privateStore.hasItem(key)) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -655,6 +655,21 @@ Badger.prototype = {
 
       self.getPrivateSettings().setItem('sitefixes', sitefixes);
     }
+
+    if (utils.hasOwn(data, 'link_rotation')) {
+      let linkRotation = data.link_rotation;
+      // Remove the review link from the rotation if we don't have a link for the browser's extension store
+      if (!utils.hasOwn(constants.REVIEW_LINKS, constants.BROWSER)) {
+        linkRotation = linkRotation.filter(link => link.text !== "popup_review_pb");
+      }
+      // Update the review link for the user's browser
+      for (let link of linkRotation) {
+        if (link.text === "popup_review_pb") {
+          link.url = constants.REVIEW_LINKS[constants.BROWSER];
+        }
+      }
+      self.getPrivateSettings().setItem('linkRotation', linkRotation);
+    }
   },
 
   /**
@@ -870,7 +885,15 @@ Badger.prototype = {
       ignoredSiteBases: [],
       nextPbconfigUpdateTime: 0,
       showLearningPrompt: false,
-      sitefixes: {}
+      sitefixes: {},
+      linkRotation: [
+        {
+          url: "https://supporters.eff.org/donate/support-privacy-badger",
+          text: "popup_donate_to_eff",
+          icon: "ui-icon-heart",
+          odds: 1.0
+        }
+      ],
     };
     for (let key of Object.keys(privateDefaultSettings)) {
       if (!privateStore.hasItem(key)) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -37,25 +37,29 @@ const DOMAIN_TOOLTIP_CONF = {
 };
 
 /**
- * Use weighted random selection to get the link to display at the bottom of the popup.
+ * Use weighted random selection to get the link
+ * to display at the bottom of the popup.
+ *
+ * @returns {?Object}
  */
-function getLink() {
-  let linkRotation = POPUP_DATA.linkRotation;
+function getPromo() {
+  let linkRotation = POPUP_DATA.popupPromos;
 
-  // Select a random number between 0 and the sum of the odds in the link rotation. They normally add up to 1, but won't if a link is removed (i.e. for a browser missing a review link)
+  // Select a random number between 0 and the sum of odds in link rotation.
+  // They normally add up to 1, but won't if a link is removed
+  // (i.e. for a browser missing a review link).
   let total_odds = linkRotation.reduce((sum, link) => sum + (link.odds || 0), 0);
   let rand = Math.random() * total_odds;
 
   let cumulative_odds = 0;
-  for (let link of linkRotation) {
-    cumulative_odds += (link.odds || 0);
+  for (let promo of linkRotation) {
+    cumulative_odds += (promo.odds || 0);
     if (rand < cumulative_odds) {
-      return link;
+      return promo;
     }
   }
 
-  // Fallback in case of errors
-  return linkRotation[linkRotation.length - 1];
+  return null;
 }
 
 /* if they aint seen the comic*/
@@ -273,10 +277,15 @@ function init() {
     visibility: 'visible'
   });
 
-  let link = getLink();
-  $("#cta-link").attr("href", link.url);
-  $('#cta-text').text(chrome.i18n.getMessage(link.text));
-  $('#cta-icon').addClass(link.icon);
+  let promo = getPromo();
+  if (promo) {
+    let promo_text = chrome.i18n.getMessage(promo.text);
+    if (promo_text && promo.url && promo.icon) {
+      $("#cta-link").attr("href", promo.url);
+      $('#cta-text').text(promo_text);
+      $('#cta-icon').addClass(promo.icon);
+    }
+  }
 
   window.POPUP_INITIALIZED = true;
 }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -40,28 +40,13 @@ const DOMAIN_TOOLTIP_CONF = {
  * Use weighted random selection to get the link to display at the bottom of the popup.
  */
 function getLink() {
-  let linkRotation = [
-    {
-      url: "https://supporters.eff.org/donate/support-privacy-badger",
-      text: "popup_donate_to_eff",
-      icon: "ui-icon-heart",
-      odds: 1.0
-    }
-  ];
-  if (utils.hasOwn(constants.REVIEW_LINKS, constants.BROWSER)) {
-    linkRotation[0].odds = 0.7;
+  let linkRotation = POPUP_DATA.linkRotation;
 
-    linkRotation.push({
-      url: constants.REVIEW_LINKS[constants.BROWSER],
-      text: "popup_review_pb",
-      icon: "ui-icon-star",
-      odds: 0.3 // Odds of all links should add up to 1
-    });
-  }
+  // Select a random number between 0 and the sum of the odds in the link rotation. They normally add up to 1, but won't if a link is removed (i.e. for a browser missing a review link)
+  let total_odds = linkRotation.reduce((sum, link) => sum + (link.odds || 0), 0);
+  let rand = Math.random() * total_odds;
 
-  let rand = Math.random();
   let cumulative_odds = 0;
-
   for (let link of linkRotation) {
     cumulative_odds += (link.odds || 0);
     if (rand < cumulative_odds) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -283,7 +283,7 @@ function init() {
     if (promo_text && promo.url && promo.icon) {
       $("#cta-link").attr("href", promo.url);
       $('#cta-text').text(promo_text);
-      $('#cta-icon').addClass(promo.icon);
+      $('#cta-icon').removeClass('ui-icon-heart').addClass(promo.icon);
     }
   }
 

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1419,6 +1419,7 @@ function dispatcher(request, sender, sendResponse) {
       sendResponse({
         criticalError: badger.criticalError,
         isAndroid: badger.isAndroid,
+        linkRotation: badger.getPrivateSettings().getItem("linkRotation"),
         noTabData: true,
         settings: { seenComic: true },
       });
@@ -1455,6 +1456,7 @@ function dispatcher(request, sender, sendResponse) {
       errorText: badger.tabData._tabData[tab_id].errorText,
       isAndroid: badger.isAndroid,
       isOnFirstParty: utils.firstPartyProtectionsEnabled(tab_host),
+      linkRotation: badger.getPrivateSettings().getItem("linkRotation"),
       noTabData: false,
       trackers,
       settings: badger.getSettings().getItemClones(),

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -1419,8 +1419,8 @@ function dispatcher(request, sender, sendResponse) {
       sendResponse({
         criticalError: badger.criticalError,
         isAndroid: badger.isAndroid,
-        linkRotation: badger.getPrivateSettings().getItem("linkRotation"),
         noTabData: true,
+        popupPromos: badger.getPrivateSettings().getItem("popupPromos"),
         settings: { seenComic: true },
       });
       break;
@@ -1456,8 +1456,8 @@ function dispatcher(request, sender, sendResponse) {
       errorText: badger.tabData._tabData[tab_id].errorText,
       isAndroid: badger.isAndroid,
       isOnFirstParty: utils.firstPartyProtectionsEnabled(tab_host),
-      linkRotation: badger.getPrivateSettings().getItem("linkRotation"),
       noTabData: false,
+      popupPromos: badger.getPrivateSettings().getItem("popupPromos"),
       trackers,
       settings: badger.getSettings().getItemClones(),
       showLearningPrompt: badger.getPrivateSettings().getItem("showLearningPrompt"),

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -183,7 +183,7 @@
 
 <footer>
   <div id="donate">
-    <a id="cta-link" href="https://supporters.eff.org/donate/support-privacy-badger" target="_blank" style="text-decoration: none;"><span id="cta-icon" class="ui-icon" style="color:#ec1e1e"></span> <span id="cta-text" class="i18n_popup_donate_to_eff" style="text-decoration: underline;"></span></a>
+    <a id="cta-link" href="https://supporters.eff.org/donate/support-privacy-badger" target="_blank" style="text-decoration: none;"><span id="cta-icon" class="ui-icon ui-icon-heart" style="color:#ec1e1e"></span> <span id="cta-text" class="i18n_popup_donate_to_eff" style="text-decoration: underline;"></span></a>
   </div>
   <div id="version" class="i18n_version"></div>
 </footer>


### PR DESCRIPTION
- Add promotion of the new Privacy Badger sweatshirt to the popup link rotation
- Move link rotation data to pbConfig so that we can update remotely if/when links need to change
<img width="519" height="383" alt="Screenshot 2026-05-27 at 2 57 45 PM" src="https://github.com/user-attachments/assets/08cf6474-43c4-4c27-a386-654a36dcbc44" />
