### PR TITLE
Fix welcome page header text overlapping with EFF logo in some locales

### DIFF
--- a/src/skin/css/firstRun.css
+++ b/src/skin/css/firstRun.css
@@ -369,6 +369,10 @@ ul ul,ol ul,ul ol,ol ol {
     max-width: 3rem;
     margin-inline-end: 0.2rem;
 }
+.top-bar span {
+  margin: 0 4rem;
+  text-align: center;
+}
 @media print, screen and (min-width: 40em) {
     .top-bar img {
         margin-inline-end: 1rem;
@@ -378,6 +382,9 @@ ul ul,ol ul,ul ol,ol ol {
       flex-wrap:nowrap;
       font-size: 0.9rem;
       padding: 0.75rem 0.5rem 0.75rem;
+    }
+    .top-bar span {
+      margin: 0 6rem;
     }
 }
 .top-bar-title {


### PR DESCRIPTION
- Fixes https://github.com/EFForg/privacybadger/issues/3185
- Follows up on https://github.com/EFForg/privacybadger/pull/3184
- Screenshots of French locale at various screen sizes: 

<img width="504"  alt="Screenshot 2026-05-28 at 10 26 44 AM" src="https://github.com/user-attachments/assets/50883a4e-921f-447d-8a2f-4a09a4d37ae2" />
<img width="338"  alt="Screenshot 2026-05-28 at 10 27 25 AM" src="https://github.com/user-attachments/assets/6de61fc8-707d-44ae-9b8b-1cc5439d8fc4" />
<img width="694"  alt="Screenshot 2026-05-28 at 10 28 05 AM" src="https://github.com/user-attachments/assets/14fb8c73-0a1e-4f2b-a6bc-2e2bf9935134" />
