### PR TITLE
Add EFFector sign-up link to Privacy Badger popup

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -63,6 +63,10 @@
         "message": "Show your support with a new Privacy Badger sweatshirt!",
         "description": "A link in the popup footer shown sometimes instead of 'Donate to EFF'."
     },
+    "popup_effector_signup": {
+        "message": "Get the latest privacy news from EFF",
+        "description": "A link in the popup footer shown sometimes instead of 'Donate to EFF'."
+    },
     "version": {
         "message": "version $VERSION_STRING$",
         "description": "Version text in the popup footer. For example, \"version 2018.8.1\".",

--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -13,19 +13,25 @@
             "url": "https://supporters.eff.org/donate/support-privacy-badger",
             "text": "popup_donate_to_eff",
             "icon": "ui-icon-heart",
-            "odds": 0.35
+            "odds": 0.25
         },
         {
             "url": null,
             "text": "popup_review_pb",
             "icon": "ui-icon-star",
-            "odds": 0.3
+            "odds": 0.25
         },
         {
             "url": "https://supporters.eff.org/donate/spring--pb",
             "text": "popup_sweatshirt_promo",
             "icon": "ui-icon-cart",
-            "odds": 0.35
+            "odds": 0.25
+        },
+        {
+            "url": "https://eff.org/pbeff",
+            "text": "popup_effector_signup",
+            "icon": "ui-icon-mail-closed",
+            "odds": 0.25
         }
     ],
     "sitefixes": {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -620,7 +620,7 @@ a.overlay-close:hover {
 .ui-icon.ui-icon-caret-d, .ui-icon.ui-icon-caret-u {
     font-size: 18px;
 }
-#cta-icon.ui-icon-star {
+#cta-icon.ui-icon-star, #cta-icon.ui-icon-mail-closed {
    margin-bottom: 2px;
    font-size: 18px;
    color: #F6C324 !important;


### PR DESCRIPTION
- Added EFFector sign-up to the link rotation at the bottom of the popup. 
- Privacy Badger users can sign up for EFF's newsletter to be notified about news, events, and campaigns.

<img width="513" height="391" alt="Screenshot 2026-06-11 at 5 10 33 PM" src="https://github.com/user-attachments/assets/a888d7b9-a419-462d-815d-b7f7f3d43aba" />
