### PR TITLE
fix: prevent TypeErrors when optional extension APIs are unavailable

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -43,6 +43,9 @@ import utils from "./utils.js";
  * firstPartyDomain is not currently supported in Chrome.
  */
 function testCookiesFirstPartyDomain() {
+  if (!chrome.cookies) {
+    return false;
+  }
   try {
     chrome.cookies.getAll({
       firstPartyDomain: null
@@ -125,7 +128,7 @@ function Badger(from_qunit) {
     // set badge text color to white in Firefox 63+
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1474110
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1424620
-    if (utils.hasOwn(chrome.browserAction, 'setBadgeTextColor')) {
+    if (chrome.browserAction && utils.hasOwn(chrome.browserAction, 'setBadgeTextColor')) {
       chrome.browserAction.setBadgeTextColor({ color: "#fff" });
     }
 
@@ -158,7 +161,7 @@ function Badger(from_qunit) {
 
 } /* end of Badger constructor */
 
-Badger.prototype = {
+Badger.prototype = { 
   INITIALIZED: false,
 
   /**
@@ -649,7 +652,7 @@ Badger.prototype = {
               sitefixes[site_host][kind] = [];
             }
             sitefixes[site_host][kind].push(pattern);
-          }
+          } 
         }
       }
 
@@ -1278,7 +1281,7 @@ function startBackgroundListeners() {
     }
   });
 
-  chrome.tabs.onActivated.addListener(function (activeInfo) {
+  chrome.tabs.onActivated.addListener(function (activeInfo) { 
     if (badger.INITIALIZED) {
       badger.updateBadge(activeInfo.tabId);
     }

--- a/src/js/heuristicblocking.js
+++ b/src/js/heuristicblocking.js
@@ -246,6 +246,9 @@ HeuristicBlocker.prototype = {
 
     // get all non-HttpOnly cookies for the top-level frame
     // and pass those to the pixel cookie-share accounting function
+    if (!chrome.cookies) {
+      return;
+    }
     let config = {
       url: tab_url
     };


### PR DESCRIPTION
This change introduces safety guards around calls to the optional `chrome.cookies` and `chrome.browserAction` APIs. In environments where these APIs are unavailable (such as in private window contexts, environments without cookie permissions, or mock/test setups), calling their methods or using utility functions like `utils.hasOwn` directly on them resulted in unexpected `TypeError` exceptions that crashed initialization and request processing.

Specifically:
1. Checked for the existence of `chrome.cookies` in `testCookiesFirstPartyDomain()` inside `src/js/background.js` before attempting to invoke `chrome.cookies.getAll`.
2. Safely guarded the `chrome.browserAction` badge text color modification during `Badger` storage ready initialization in `src/js/background.js` to ensure the extension starts up gracefully if `chrome.browserAction` is not defined.
3. Added an early exit check in `checkForPixelCookieSharing()` within `src/js/heuristicblocking.js` to verify `chrome.cookies` exists before starting pixel cookie share verification.