### PR TITLE
Skip injectScript() on CSP-restricted pages

### DIFF
--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -476,6 +476,45 @@ function onBeforeSendHeaders(details) {
 }
 
 /**
+ * Checks whether the page's Content-Security-Policy allows inline scripts.
+ *
+ * Returns true when inline scripts are allowed (or when there is no
+ * relevant CSP directive), false when they are blocked.
+ *
+ * Handles multiple CSP headers (all must permit inline scripts for the
+ * result to be true). Treats 'unsafe-inline' as ineffective when nonces
+ * or hashes are also present (CSP Level 3 behaviour).
+ *
+ * @param {Array<{name: string, value: string}>} headers
+ * @returns {Boolean}
+ */
+function inlineScriptsAllowedByCsp(headers) {
+  for (const header of headers) {
+    if (header.name.toLowerCase() !== 'content-security-policy') {
+      continue;
+    }
+    const policy = header.value || '';
+    const scriptSrcMatch = /(?:^|;)\s*script-src\s+([^;]+)/i.exec(policy);
+    const defaultSrcMatch = /(?:^|;)\s*default-src\s+([^;]+)/i.exec(policy);
+    const directive = scriptSrcMatch ? scriptSrcMatch[1] : (defaultSrcMatch ? defaultSrcMatch[1] : null);
+    if (!directive) {
+      continue;
+    }
+    if (/'unsafe-inline'/i.test(directive)) {
+      // In CSP3, 'unsafe-inline' is ignored when nonces, hashes, or
+      // 'strict-dynamic' are present
+      if (/(?:nonce|sha(?:256|384|512))-/i.test(directive) ||
+        /'strict-dynamic'/i.test(directive)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Filters incoming cookies out of the response header.
  *
  * @param {chrome.webRequest.WebRequestDetails} details
@@ -485,6 +524,17 @@ function onBeforeSendHeaders(details) {
 function onHeadersReceived(details) {
   if (!badger.INITIALIZED) {
     return;
+  }
+
+  // Record whether this frame's CSP allows inline script injection.
+  // Content script message handlers check this before enabling features
+  // that rely on injectScript() to avoid CSP-triggered console errors.
+  if ((details.type == 'main_frame' || details.type == 'sub_frame') &&
+    details.tabId >= 0) {
+    let frameData = badger.tabData.getFrameData(details.tabId, details.frameId);
+    if (frameData) {
+      frameData.inlineScriptsAllowed = inlineScriptsAllowedByCsp(details.responseHeaders);
+    }
   }
 
   if (details.type == 'main_frame') {
@@ -1150,6 +1200,21 @@ function getSurrogateWidget(name, data, frame_url) {
   return false;
 }
 
+/**
+ * Checks whether inline script injection is permitted for the frame that
+ * sent a content script message.
+ *
+ * Returns true when inline scripts are allowed (the default when CSP data
+ * has not yet been recorded, e.g. on the first load after install).
+ *
+ * @param {chrome.runtime.MessageSender} sender
+ * @returns {Boolean}
+ */
+function senderAllowsInlineScripts(sender) {
+  let frameData = badger.tabData.getFrameData(sender.tab.id, sender.frameId);
+  return !frameData || frameData.inlineScriptsAllowed !== false;
+}
+
 // NOTE: sender.tab is available for content script (not popup) messages only
 function dispatcher(request, sender, sendResponse) {
   // messages may arrive before Privacy Badger is ready
@@ -1266,7 +1331,8 @@ function dispatcher(request, sender, sendResponse) {
     }
 
     let action = checkAction(sender.tab.id, tab_host, frame_host);
-    sendResponse(action == constants.COOKIEBLOCK || action == constants.USER_COOKIEBLOCK);
+    sendResponse(senderAllowsInlineScripts(sender) &&
+      (action == constants.COOKIEBLOCK || action == constants.USER_COOKIEBLOCK));
 
     break;
   }
@@ -1366,7 +1432,8 @@ function dispatcher(request, sender, sendResponse) {
       frame_host = badger.cnameDomains[frame_host];
     }
 
-    sendResponse(frame_host &&
+    sendResponse(senderAllowsInlineScripts(sender) &&
+      frame_host &&
       badger.isLearningEnabled(sender.tab.id) &&
       badger.isPrivacyBadgerEnabled(tab_host) &&
       utils.isThirdPartyDomain(frame_host, tab_host));
@@ -1386,7 +1453,8 @@ function dispatcher(request, sender, sendResponse) {
       }
     }
 
-    sendResponse(badger.isLearningEnabled(sender.tab.id) &&
+    sendResponse(senderAllowsInlineScripts(sender) &&
+      badger.isLearningEnabled(sender.tab.id) &&
       badger.isPrivacyBadgerEnabled(extractHostFromURL(sender.tab.url)));
 
     break;
@@ -1826,6 +1894,7 @@ function dispatcher(request, sender, sendResponse) {
   case "checkDNT": {
     let tab_host = extractHostFromURL(sender.tab.url);
     sendResponse(
+      senderAllowsInlineScripts(sender) &&
       badger.isDntSignalEnabled(tab_host) &&
       badger.isPrivacyBadgerEnabled(tab_host));
     break;
@@ -2006,5 +2075,6 @@ function startListeners() {
 }
 
 export default {
+  inlineScriptsAllowedByCsp,
   startListeners
 };

--- a/src/tests/index.html
+++ b/src/tests/index.html
@@ -50,6 +50,7 @@
     <script type="module" src="tests/tabData.js"></script>
     <!-- URL/host tools: --><script type="module" src="tests/baseDomain.js"></script>
     <script type="module" src="tests/utils.js"></script>
+    <script type="module" src="tests/webrequest.js"></script>
     <script type="module" src="tests/yellowlist.js"></script>
   </body>
 </html>

--- a/src/tests/tests/webrequest.js
+++ b/src/tests/tests/webrequest.js
@@ -1,0 +1,156 @@
+import webrequest from "../../js/webrequest.js";
+
+let inlineScriptsAllowedByCsp = webrequest.inlineScriptsAllowedByCsp;
+
+function makeHeaders(cspValue) {
+  return [{ name: "Content-Security-Policy", value: cspValue }];
+}
+
+QUnit.module("inlineScriptsAllowedByCsp", function () {
+
+  QUnit.test("no CSP headers", (assert) => {
+    assert.true(inlineScriptsAllowedByCsp([]), "empty headers → allowed");
+    assert.true(inlineScriptsAllowedByCsp([
+      { name: "X-Frame-Options", value: "DENY" }
+    ]), "unrelated headers → allowed");
+  });
+
+  QUnit.test("no script restriction in CSP", (assert) => {
+    assert.true(
+      inlineScriptsAllowedByCsp(makeHeaders("img-src 'self'")),
+      "img-src only → allowed"
+    );
+    assert.true(
+      inlineScriptsAllowedByCsp(makeHeaders("upgrade-insecure-requests")),
+      "upgrade-insecure-requests only → allowed"
+    );
+  });
+
+  QUnit.test("unsafe-inline present, no nonces/hashes/strict-dynamic", (assert) => {
+    assert.true(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'unsafe-inline'")),
+      "script-src 'unsafe-inline' → allowed"
+    );
+    assert.true(
+      inlineScriptsAllowedByCsp(makeHeaders("default-src 'unsafe-inline'")),
+      "default-src 'unsafe-inline' → allowed"
+    );
+    assert.true(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'self' 'unsafe-inline' https://cdn.example.com")),
+      "script-src with 'unsafe-inline' among other sources → allowed"
+    );
+  });
+
+  QUnit.test("script-src without unsafe-inline", (assert) => {
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'self'")),
+      "script-src 'self' → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src https:")),
+      "script-src https: → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'none'")),
+      "script-src 'none' → blocked"
+    );
+  });
+
+  QUnit.test("default-src fallback when no script-src", (assert) => {
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("default-src 'self'")),
+      "default-src 'self', no script-src → blocked"
+    );
+    assert.true(
+      inlineScriptsAllowedByCsp(makeHeaders("default-src 'self'; script-src 'unsafe-inline'")),
+      "script-src overrides restrictive default-src → allowed"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("default-src 'unsafe-inline'; script-src 'self'")),
+      "script-src 'self' overrides permissive default-src → blocked"
+    );
+  });
+
+  QUnit.test("nonce present makes unsafe-inline ineffective", (assert) => {
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'nonce-abc123' 'unsafe-inline'")),
+      "nonce + unsafe-inline → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'nonce-abc123'")),
+      "nonce only → blocked"
+    );
+  });
+
+  QUnit.test("hash present makes unsafe-inline ineffective", (assert) => {
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'sha256-abc123==' 'unsafe-inline'")),
+      "sha256 hash + unsafe-inline → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'sha384-abc123==' 'unsafe-inline'")),
+      "sha384 hash + unsafe-inline → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'sha512-abc123==' 'unsafe-inline'")),
+      "sha512 hash + unsafe-inline → blocked"
+    );
+  });
+
+  QUnit.test("strict-dynamic makes unsafe-inline ineffective", (assert) => {
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'strict-dynamic' 'unsafe-inline'")),
+      "strict-dynamic + unsafe-inline → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'nonce-abc' 'strict-dynamic' 'unsafe-inline'")),
+      "nonce + strict-dynamic + unsafe-inline → blocked"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp(makeHeaders("script-src 'strict-dynamic'")),
+      "strict-dynamic only → blocked"
+    );
+  });
+
+  QUnit.test("multiple CSP headers: all must allow inline scripts", (assert) => {
+    assert.true(
+      inlineScriptsAllowedByCsp([
+        { name: "Content-Security-Policy", value: "script-src 'unsafe-inline'" },
+        { name: "Content-Security-Policy", value: "img-src 'self'" },
+      ]),
+      "two headers, only one has script-src (with unsafe-inline) → allowed"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp([
+        { name: "Content-Security-Policy", value: "script-src 'unsafe-inline'" },
+        { name: "Content-Security-Policy", value: "script-src 'self'" },
+      ]),
+      "two headers, second blocks inline scripts → blocked"
+    );
+  });
+
+  QUnit.test("header name matching is case-insensitive", (assert) => {
+    assert.false(
+      inlineScriptsAllowedByCsp([
+        { name: "content-security-policy", value: "script-src 'self'" }
+      ]),
+      "lowercase header name → still matched"
+    );
+    assert.false(
+      inlineScriptsAllowedByCsp([
+        { name: "CONTENT-SECURITY-POLICY", value: "script-src 'self'" }
+      ]),
+      "uppercase header name → still matched"
+    );
+  });
+
+  QUnit.test("Content-Security-Policy-Report-Only is ignored", (assert) => {
+    assert.true(
+      inlineScriptsAllowedByCsp([
+        { name: "Content-Security-Policy-Report-Only", value: "script-src 'self'" }
+      ]),
+      "report-only header → not enforced, inline scripts allowed"
+    );
+  });
+
+});

--- a/tests/selenium/csp_test.py
+++ b/tests/selenium/csp_test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+import http.server
+import threading
+import time
+import unittest
+
+import pytest
+
+import pbtest
+
+
+# Simple HTTP server that serves pages with and without a restrictive CSP.
+# Privacy Badger reads the Content-Security-Policy response header to decide
+# whether to call injectScript(); we need real HTTP headers to test that.
+
+_CSP_PATH = "/csp"
+_NO_CSP_PATH = "/no-csp"
+
+_PAGE_BODY = (
+    b"<!DOCTYPE html>"
+    b"<html><head></head><body></body></html>"
+)
+
+
+class _CspHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        if self.path == _CSP_PATH:
+            self.send_header("Content-Security-Policy", "script-src 'self'")
+        self.send_header("Content-Length", str(len(_PAGE_BODY)))
+        self.end_headers()
+        self.wfile.write(_PAGE_BODY)
+
+    def log_message(self, *args):
+        pass  # suppress server noise to keep test output clean
+
+
+# Start the server once for the whole test module.
+_server = http.server.HTTPServer(("127.0.0.1", 0), _CspHandler)
+_server_port = _server.server_address[1]
+threading.Thread(target=_server.serve_forever, daemon=True).start()
+
+
+class CspInjectScriptTest(pbtest.PBSeleniumTest):
+    """Tests that Privacy Badger does not trigger CSP violations.
+
+    Privacy Badger uses injectScript() to inject page scripts for fingerprinting
+    detection, supercookie detection, cookie/localStorage clobbering, and DNT.
+    On pages with a restrictive Content-Security-Policy, these injections are
+    blocked by the browser and generate errors in the browser console.
+
+    Privacy Badger reads the Content-Security-Policy response header in the
+    background service worker and gates injectScript()-dependent features on
+    whether inline scripts are allowed.  This test verifies that no CSP
+    violation errors appear in the browser console when visiting a page with
+    a restrictive CSP.
+
+    Without our fix, detectFingerprinting (and the other message handlers)
+    would return true even for CSP-restricted pages, causing injectScript()
+    to be called and CSP violation errors to appear in the browser log.
+
+    Note: browser log access (self.logs) is Chrome-only.
+    """
+
+    def setUp(self):
+        # Enable local learning so detectFingerprinting returns true —
+        # this ensures injectScript() would be attempted without our fix.
+        self.load_url(self.options_url)
+        self.wait_for_script("return window.OPTIONS_INITIALIZED")
+        self.find_el_by_css('a[href="#tab-general-settings"]').click()
+        self.find_el_by_css('#local-learning-checkbox').click()
+
+    def _csp_violations(self):
+        return [
+            msg for msg in self.logs
+            if "content security policy" in msg.lower()
+            or "refused to execute inline script" in msg.lower()
+        ]
+
+    @pytest.mark.flaky(reruns=5, condition=pbtest.shim.browser_type in ("chrome", "edge"))
+    def test_no_csp_violations_on_csp_restricted_page(self):
+        """Privacy Badger must not trigger CSP violations on CSP-restricted pages."""
+        if self.driver.capabilities.get("browserName") == "firefox":
+            self.skipTest("browser log API not available in Firefox")
+
+        # Flush any pre-existing log entries.
+        _ = self.logs
+
+        self.load_url(f"http://127.0.0.1:{_server_port}{_CSP_PATH}")
+        time.sleep(3)
+
+        violations = self._csp_violations()
+        assert not violations, (
+            "Privacy Badger triggered CSP violations on a page with "
+            f"Content-Security-Policy: script-src 'self': {violations}"
+        )
+
+    @pytest.mark.flaky(reruns=5, condition=pbtest.shim.browser_type in ("chrome", "edge"))
+    def test_no_csp_violations_on_normal_page(self):
+        """Baseline: no CSP violations on a page without a CSP."""
+        if self.driver.capabilities.get("browserName") == "firefox":
+            self.skipTest("browser log API not available in Firefox")
+
+        _ = self.logs
+
+        self.load_url(f"http://127.0.0.1:{_server_port}{_NO_CSP_PATH}")
+        time.sleep(3)
+
+        violations = self._csp_violations()
+        assert not violations, (
+            f"Unexpected CSP violations on a page with no CSP: {violations}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pages with a restrictive Content-Security-Policy block inline script injection via injectScript(), which pollutes the browser console and the Errors button on chrome://extensions/ without providing any benefit.

Fix this by reading the Content-Security-Policy response header in onHeadersReceived() and recording whether inline scripts are allowed on the frame data object. The four message handlers that gate features relying on injectScript() — detectFingerprinting, detectSupercookies, checkClobberingEnabled, and checkDNT — now return false when the frame's CSP blocks inline scripts, so injectScript() is never called.

CSP parsing handles:
- script-src falling back to default-src
- 'unsafe-inline' (allows injection)
- nonces and hashes (make 'unsafe-inline' ineffective, per CSP3)
- 'strict-dynamic' (also makes 'unsafe-inline' ineffective)
- multiple CSP headers (all must permit inline scripts)

Add QUnit unit tests for the CSP parsing logic.
Add Selenium test for CSP-restricted injectScript() suppression

The @pytest.mark.flaky(reruns=5) decorator matches the pattern used by other Chrome/Edge tests in this suite that share a known BiDi timing issue on first browser startup.

Related: #3053