### PR TITLE
Update license name from GPL v3+ to GPL v3 or later

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Privacy Badger
 Copyright © 2015 Electronic Frontier Foundation and other contributors
 
-Privacy Badger as a whole is presently Licensed GPL v3+, though many portions
+Privacy Badger as a whole is presently Licensed GPL v3 or later, though many portions
 of the code are dual-licensed under other free/open source licenses.
 
 CONTRIBUTORS AGREE TO FREE/OPEN SOURCE DUAL-LICENSING

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ We also hold public meetings using [Jitsi audio conferencing](https://meet.jit.s
 
 ## License
 
-Privacy Badger is licensed under the GPLv3+. See [LICENSE](/LICENSE) for more details.
+Privacy Badger is licensed under the GPL v3 or later. See [LICENSE](/LICENSE) for more details.


### PR DESCRIPTION
I updated the license name used in the README.md and the LICENSE file to use the license name GPL v3 or later instead of GPL v3+, a clearer, more universally agreed on name. This does not change the license itself.