### PR TITLE
Stabilize selenium

### DIFF
--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -359,7 +359,7 @@ class PBSeleniumTest(unittest.TestCase):
                 "let done = arguments[arguments.length - 1];"
                 "chrome.runtime.sendMessage({"
                 "  type: 'isBadgerInitialized'"
-                "}, r => done(r));", execute_async=True)
+                "}, r => done(r));", execute_async=True, ignore_js_errors=True)
 
             # also disable the welcome page
             self.driver.execute_async_script(
@@ -452,6 +452,7 @@ class PBSeleniumTest(unittest.TestCase):
 
     def wait_for_script(self, script, *script_args,
         timeout=SEL_DEFAULT_WAIT_TIMEOUT, execute_async=False,
+        ignore_js_errors=False,
         message="Timed out waiting for execute_script to eval to True"):
 
         """Variant of execute_script/execute_async_script
@@ -461,7 +462,12 @@ class PBSeleniumTest(unittest.TestCase):
             if execute_async: return dr.execute_async_script(script, *script_args)
             return dr.execute_script(script, *script_args)
 
-        return WebDriverWait(self.driver, timeout).until(execute_script, message)
+        wait_kwargs = {}
+        if ignore_js_errors:
+            wait_kwargs['ignored_exceptions'] = [JavascriptException]
+
+        return WebDriverWait(self.driver, timeout, **wait_kwargs).until(
+            execute_script, message)
 
     def wait_for_any_text(self, selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         return WebDriverWait(self.driver, timeout).until(

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -13,6 +13,7 @@ from shutil import copytree, which
 from selenium import webdriver
 from selenium.common.exceptions import (
     InvalidArgumentException,
+    JavascriptException,
     NoSuchWindowException,
     TimeoutException,
     WebDriverException,
@@ -182,10 +183,18 @@ class Shim:
         opts.set_capability("goog:loggingPrefs", {'browser': 'ALL'})
 
         for i in range(5):
+            driver = None
             try:
                 driver = webdriver.Chrome(options=opts)
                 driver.webextension.install(self.extension_path)
-            except WebDriverException as ex:
+                driver.get(self.base_url + "skin/options.html")
+                WebDriverWait(
+                    driver, 30, ignored_exceptions=[JavascriptException]).until(
+                        lambda d: d.execute_script(
+                            "return !!(window.chrome && chrome.runtime && chrome.runtime.sendMessage)"))
+            except (TimeoutException, WebDriverException) as ex:
+                if driver:
+                    driver.quit()
                 if i == 0: print("")
                 print(f"ChromeDriver initialization failed: {ex}")
             else:
@@ -211,10 +220,18 @@ class Shim:
         opts.set_capability("unhandledPromptBehavior", "ignore");
 
         for i in range(5):
+            driver = None
             try:
                 driver = webdriver.Edge(options=opts)
                 driver.webextension.install(self.extension_path)
-            except WebDriverException as ex:
+                driver.get(self.base_url + "skin/options.html")
+                WebDriverWait(
+                    driver, 30, ignored_exceptions=[JavascriptException]).until(
+                        lambda d: d.execute_script(
+                            "return !!(window.chrome && chrome.runtime && chrome.runtime.sendMessage)"))
+            except (TimeoutException, WebDriverException) as ex:
+                if driver:
+                    driver.quit()
                 if i == 0: print("")
                 print(f"EdgeDriver initialization failed ({i+1}/5): {ex}", end='')
             else:


### PR DESCRIPTION
Chrome/Edge tests sometimes started interacting with the extension
before its background/runtime was actually ready, causing flaky
failures.