### PR TITLE
Fix YouTube video link for non-JS embeds

### DIFF
--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -499,7 +499,15 @@ function createReplacementWidget(widget, elToReplace) {
     // use the frame URL for framed widgets
     if (elToReplace.src) {
       widget_url = elToReplace.src;
-      if (widget_url.startsWith("https://embed.bsky.app/embed/")) {
+      if (widget.name == "YouTube") {
+        let yuri = (new URL(widget_url)),
+          ypath = yuri.pathname.slice(1).split("/");
+        if (ypath.length == 2 && ypath[0] == "embed" &&
+            ypath[1].length == 11 && ypath[1] != "videoseries") {
+          let ysearch = (yuri.search ? "&" + yuri.search.slice(1) : "");
+          widget_url = "https://www.youtube.com/watch?v=" + ypath[1] + ysearch;
+        }
+      } else if (widget_url.startsWith("https://embed.bsky.app/embed/")) {
         // Bluesky
         let buri = (new URL(widget_url)).pathname.split("/");
         if (buri[2] && buri[2].startsWith("did:") && buri[4]) {

--- a/src/js/contentscripts/socialwidgets.js
+++ b/src/js/contentscripts/socialwidgets.js
@@ -499,7 +499,19 @@ function createReplacementWidget(widget, elToReplace) {
     // use the frame URL for framed widgets
     if (elToReplace.src) {
       widget_url = elToReplace.src;
-      if (widget_url.startsWith("https://embed.bsky.app/embed/")) {
+      if (widget.name == "YouTube") {
+        let yuri = (new URL(widget_url)),
+          ypath = yuri.pathname.slice(1).split("/");
+        if (ypath.length == 2 && ypath[0] == "embed" &&
+            ypath[1].length == 11) {
+          if (ypath[1] == "videoseries" || ypath[1] == "live_stream") {
+            widget_url = null;
+          } else {
+            let ysearch = (yuri.search ? "&" + yuri.search.slice(1) : "");
+            widget_url = "https://www.youtube.com/watch?v=" + ypath[1] + ysearch;
+          }
+        }
+      } else if (widget_url.startsWith("https://embed.bsky.app/embed/")) {
         // Bluesky
         let buri = (new URL(widget_url)).pathname.split("/");
         if (buri[2] && buri[2].startsWith("did:") && buri[4]) {


### PR DESCRIPTION
Our video link for YouTube iframe placeholders currently results in an "Error 153 / Video player configuration error" page, forcing an extra click to get to the actual video page. Sometimes getting to the actual video page is fully broken, [for example](https://www.youtube.com/embed/H4dGpz6cnHo?list=PLVAh-MgDVqvDUEq6qDXqORBioE4Yhol_z) (from https://aftermath.site/backrooms-movie-parsons-youtube/).

This fix currently passes on all existing parameters, including junk like "&feature=oembed". It seems better to pass on too much (doesn't do anything) than too little (some expected functionality is missing).

Video ID validation is currently limited to checking length (eleven characters) and that it isn't "videoseries" (a variant list embed type that happens to be eleven characters long). Are there any other 11-character sequences that we should exclude? As far as video ID validation goes, it's better to have false negatives than false positives.

Could add a special case to handle properly generating a video link for "/embed/videoseries" embeds.

This follows up on 23bb32498, which was the same fix but for YT API-inserted embeds.