### PR TITLE
Convert nag modal to native dialog element

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -86,9 +86,6 @@ function showNagMaybe() {
   }
 
   function _showNag() {
-    nag.showModal();
-    nag.focus(); // work around autofocus not working as expected in Chrome
-
     // Attach event listeners
     $('#fittslaw').on("click", function (e) {
       e.preventDefault();
@@ -103,6 +100,8 @@ function showNagMaybe() {
         window.close();
       });
     });
+
+    nag.showModal();
   }
 
   function _showError(error_text) {
@@ -110,8 +109,8 @@ function showNagMaybe() {
 
     $('#error-message').text(error_text);
 
-    $('#error-text').show().find('a')
-      .addClass('cta-button')
+    let $cta = $('#error-text').show().find('a');
+    $cta.addClass('cta-button')
       .css({
         borderRadius: '3px',
         display: 'inline-block',
@@ -126,7 +125,7 @@ function showNagMaybe() {
     });
 
     nag.showModal();
-    nag.focus();
+    $cta[0].focus();
   }
 
   if (POPUP_DATA.criticalError) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -64,8 +64,7 @@ function getPromo(linkRotation) {
 
 /* if they aint seen the comic*/
 function showNagMaybe() {
-  var $nag = $("#instruction");
-  var $outer = $("#instruction-outer");
+  let nag = document.getElementById('instruction');
   let intro_page_url = chrome.runtime.getURL("/skin/firstRun.html");
 
   function _setSeenComic(cb) {
@@ -76,13 +75,11 @@ function showNagMaybe() {
   }
 
   function _hideNag() {
-    $nag.fadeOut();
-    $outer.fadeOut();
+    nag.close();
   }
 
   function _showNag() {
-    $nag.show();
-    $outer.show();
+    nag.showModal();
     // Attach event listeners
     $('#fittslaw').on("click", function (e) {
       e.preventDefault();
@@ -118,8 +115,7 @@ function showNagMaybe() {
       _hideNag();
     });
 
-    $nag.show();
-    $outer.show();
+    nag.showModal();
   }
 
   if (POPUP_DATA.criticalError) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -75,7 +75,14 @@ function showNagMaybe() {
   }
 
   function _hideNag() {
-    nag.close();
+    function _closeDialog() {
+      nag.removeEventListener('transitionend', _closeDialog);
+      nag.close();
+      nag.classList.remove('closing');
+    }
+
+    nag.addEventListener('transitionend', _closeDialog);
+    nag.classList.add('closing');
   }
 
   function _showNag() {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -87,6 +87,8 @@ function showNagMaybe() {
 
   function _showNag() {
     nag.showModal();
+    nag.focus(); // work around autofocus not working as expected in Chrome
+
     // Attach event listeners
     $('#fittslaw').on("click", function (e) {
       e.preventDefault();
@@ -94,6 +96,7 @@ function showNagMaybe() {
         _hideNag();
       });
     });
+
     $("#intro-reminder-btn").on("click", function () {
       chrome.tabs.create({ url: intro_page_url });
       _setSeenComic(() => {
@@ -123,6 +126,7 @@ function showNagMaybe() {
     });
 
     nag.showModal();
+    nag.focus();
   }
 
   if (POPUP_DATA.criticalError) {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -267,6 +267,7 @@ button.cta-button:focus-visible, a.cta-button:focus-visible {
 }
 
 #instruction {
+    --transition-duration: 400ms;
     position: fixed;
     top: 0;
     left: 0;
@@ -287,10 +288,19 @@ button.cta-button:focus-visible, a.cta-button:focus-visible {
     border: none;
     border-radius: 4px;
     width: calc(100% - 46px);
+    transition: opacity var(--transition-duration);
 }
 
 #instruction::backdrop {
     background: rgba(0, 0, 0, 0.1);
+    transition: opacity var(--transition-duration);
+}
+
+#instruction.closing {
+    opacity: 0;
+}
+#instruction.closing::backdrop {
+    opacity: 0;
 }
 
 .instruction-logo {

--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -266,39 +266,33 @@ button.cta-button:focus-visible, a.cta-button:focus-visible {
     overflow-wrap: anywhere;
 }
 
-#instruction-outer {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 99;
-  background-color: #000;
-  opacity: 0.1;
-  width: 100%;
-  height: 100%;
-}
 #instruction {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 100;
-  background-color: #fff;
-  color: #333;
-  text-align: start;
-  margin: 8px;
-  padding: 15px;
-  font-size: 15px;
-  box-shadow:
-  0 2.8px 2.2px rgba(0, 0, 0, 0.034),
-  0 6.7px 5.3px rgba(0, 0, 0, 0.048),
-  0 12.5px 10px rgba(0, 0, 0, 0.06),
-  0 22.3px 17.9px rgba(0, 0, 0, 0.072),
-  0 41.8px 33.4px rgba(0, 0, 0, 0.086),
-  0 100px 80px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  width: calc(100% - 46px);
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 100;
+    background-color: #fff;
+    color: #333;
+    text-align: start;
+    margin: 8px;
+    padding: 15px;
+    font-size: 15px;
+    box-shadow:
+    0 2.8px 2.2px rgba(0, 0, 0, 0.034),
+    0 6.7px 5.3px rgba(0, 0, 0, 0.048),
+    0 12.5px 10px rgba(0, 0, 0, 0.06),
+    0 22.3px 17.9px rgba(0, 0, 0, 0.072),
+    0 41.8px 33.4px rgba(0, 0, 0, 0.086),
+    0 100px 80px rgba(0, 0, 0, 0.12);
+    border: none;
+    border-radius: 4px;
+    width: calc(100% - 46px);
 }
+
+#instruction::backdrop {
+    background: rgba(0, 0, 0, 0.1);
+}
+
 .instruction-logo {
     align-self: center;
     flex-shrink: 0;
@@ -701,8 +695,9 @@ a.overlay-close:hover {
     #instruction {
         box-shadow: none;
     }
-    #instruction-outer {
-        opacity: 0.6;
+
+    #instruction::backdrop {
+        background: rgba(0, 0, 0, 0.6);
     }
 
     button,

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -64,9 +64,7 @@
 
 <div id="popup-content">
 
-  <div id="instruction-outer">
-  </div>
-  <div id="instruction" role="dialog" aria-modal="true">
+  <dialog id="instruction" autofocus closedby="none">
     <a href="" id="fittslaw" role="button" aria-label="i18n_report_close">
       <img src="../icons/close.svg" alt="">
     </a>
@@ -89,8 +87,7 @@
       </div>
       <div style="color:#cc0000" id="error-message"></div>
     </div>
-
-  </div><!-- end of div#instruction -->
+  </dialog><!-- end of dialog#instruction -->
 
 <div id="privacy-badger-header">
 

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -64,7 +64,7 @@
 
 <div id="popup-content">
 
-  <dialog id="instruction" autofocus closedby="none">
+  <dialog id="instruction" closedby="none">
     <a href="" id="fittslaw" role="button" aria-label="i18n_report_close">
       <img src="../icons/close.svg" alt="">
     </a>
@@ -77,7 +77,7 @@
           <div class="i18n_intro_text2" style="margin-top:0.5em"></div>
         </div>
       </div>
-      <button id="intro-reminder-btn" class="i18n_first_run_text pbButton cta-button"></button>
+      <button id="intro-reminder-btn" class="i18n_first_run_text pbButton cta-button" autofocus></button>
     </div>
 
     <div id="error-text" style="display:none">


### PR DESCRIPTION
Per the discussion in closed pull request #3206 , this code update converts the nag modal to a native dialog element configured as  a modal, improving semantics and providing focus trapping in the process. A few key points:

- Opens as a modal, using `.showModal()` method, provides focus-trapping
- In keeping with prior behavior, the nag does not dismiss with Esc key, since Esc key closes entire extension popup. Nag modal will persist until user interaction with either the close button or the `button#intro-reminder-btn`
- Scrim opacity is handled through the `::backdrop` pseudo-element, so `div#instruction-outer` has been removed

Fixes #3141