### PR TITLE
fix: widen domain tooltip to prevent long-URL cutoffs (Fixes #3221)

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -32,7 +32,7 @@ let BREAKAGE_NOTE_DOMAINS = {
 };
 
 const DOMAIN_TOOLTIP_CONF = {
-  maxWidth: 300,
+  maxWidth: 400,
   side: 'bottom',
 };
 


### PR DESCRIPTION
## Description

Fixes #3221.

The domain tooltip was configured with `maxWidth: 300`, which caused long URLs (especially those containing UUIDs like `[long-uuid].cws.conviva.com`) to be cut off in the popup.

Increased `maxWidth` from 300 to 400 to accommodate the full URL display. The popup itself is 430px wide, so a 400px maxWidth tooltip fits comfortably within the visible area.

## Testing

- Verified the change passes ESLint
- The change is minimal — only adjusting the maxWidth configuration value