### PR TITLE
fix: allow popup content to scroll when page zoom > 100% (Fixes #1113) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/skin/popup.css
+++ b/src/skin/popup.css
@@ -49,6 +49,7 @@ body#main.is-android {
 body#main {
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
 }
 
 @font-face {

--- a/src/skin/popup.html
+++ b/src/skin/popup.html
@@ -17,7 +17,7 @@
  - along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  -->
 
-<html style="visibility:hidden; overflow:hidden">
+<html style="visibility:hidden; overflow:auto">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Description
Fixes #1113 — Popup content is cut off when browser zoom is set to more than 100%.

## Changes
1. **src/skin/popup.css**: Added `overflow-y: auto` to `body#main` so the popup content becomes scrollable when it exceeds the available height.
2. **src/skin/popup.html**: Changed `<html>` style from `overflow:hidden` to `overflow:auto` to allow the viewport to scroll when needed.

## Root Cause
The `<html>` element had `overflow:hidden` and `body#main` had no overflow property, which meant that when the browser zoom level exceeded 100% and the popup content grew larger than the popup's maximum height, the excess content was silently clipped with no way for the user to scroll to see it.

## Testing
- Verified the popup renders correctly at 100% zoom (no visual change)
- At 150%+ zoom, the popup content is now scrollable, and all options are accessible