### PR TITLE
Move list of CDN-hosted fingerprinters to pbconfig

### DIFF
--- a/scripts/prune_seed_json.py
+++ b/scripts/prune_seed_json.py
@@ -1,26 +1,14 @@
 #!/usr/bin/env python3
 
 import json
-import subprocess
 import sys
 
 from collections import OrderedDict
 
 
 def prune_fp_scripts(data):
-    export_js = """
-// shim just enough for constants.js to load
-globalThis.chrome = { runtime: { getURL: ()=>{} } };
-const { default: constants } = await import('./src/js/constants.js');
-process.stdout.write(JSON.stringify(Array.from(constants.FP_CDN_DOMAINS)));"""
-
-    try:
-        cmd = ["node", "--experimental-default-type=module", f'--eval={export_js}']
-        fp_cdn_domains = subprocess.run(
-            cmd, capture_output=True, check=True, text=True).stdout.strip()
-    except subprocess.CalledProcessError as ex:
-        print(ex.stderr, file=sys.stderr)
-        raise ex
+    with open("./src/data/pbconfig.json", encoding='utf-8') as pbconfig:
+        fp_cdn_domains = json.load(pbconfig)['fp_cdn_domains']
 
     new_fp_scripts = {}
     for domain in data['fp_scripts']:

--- a/src/data/pbconfig.json
+++ b/src/data/pbconfig.json
@@ -8,6 +8,18 @@
         "DNT Policy v1.0 dos-line-endings": "c09f71363bb29d0250a1f5524eef36f9ab07669b",
         "DNT Policy v1.0 no-eof-newline": "7861462d500fbb6ccb74c614782f4937377bec76"
     },
+    "fp_cdn_domains": [
+        "d.alicdn.com",
+        "s3.us-west-2.amazonaws.com",
+        "fp-cdn.azureedge.net",
+        "sdtagging.azureedge.net",
+        "cdnjs.cloudflare.com",
+        "d1af033869koo7.cloudfront.net",
+        "d38xvr37kwwhcm.cloudfront.net",
+        "dlthst9q2beh8.cloudfront.net",
+        "cdn.jsdelivr.net",
+        "gadasource.storage.googleapis.com"
+    ],
     "popup_promos": [
         {
             "url": "https://supporters.eff.org/donate/support-privacy-badger",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -673,6 +673,14 @@ Badger.prototype = {
 
       self.getPrivateSettings().setItem('popupPromos', popupPromos);
     }
+
+    if (utils.hasOwn(data, 'fp_cdn_domains')) {
+      let fpCdnDomains = {};
+      for (let fqdn of data.fp_cdn_domains) {
+        fpCdnDomains[fqdn] = true;
+      }
+      self.getPrivateSettings().setItem('fpCdnDomains', fpCdnDomains);
+    }
   },
 
   /**

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -49,19 +49,6 @@ let exports = {
     edge: "https://microsoftedge.microsoft.com/addons/detail/privacy-badger/mkejgcgkdlddbggjhhflekkondicpnop",
     opera: "https://addons.opera.com/en/extensions/details/privacy-badger/",
   },
-
-  FP_CDN_DOMAINS: new Set([
-    'd.alicdn.com',
-    's3.us-west-2.amazonaws.com',
-    'fp-cdn.azureedge.net',
-    'sdtagging.azureedge.net',
-    'cdnjs.cloudflare.com',
-    'd1af033869koo7.cloudfront.net',
-    'd38xvr37kwwhcm.cloudfront.net',
-    'dlthst9q2beh8.cloudfront.net',
-    'cdn.jsdelivr.net',
-    'gadasource.storage.googleapis.com',
-  ]),
 };
 
 exports.BLOCKED_ACTIONS = new Set([

--- a/src/js/webrequest.js
+++ b/src/js/webrequest.js
@@ -139,7 +139,7 @@ function onBeforeRequest(details) {
   // hosted by (user)cookieblocked CDNs
   if (type == 'script' || sw_request) {
     if (action == constants.COOKIEBLOCK || action == constants.USER_COOKIEBLOCK) {
-      if (constants.FP_CDN_DOMAINS.has(request_host)) {
+      if (utils.hasOwn(badger.getPrivateSettings().getItem('fpCdnDomains'), request_host)) {
         let fpScripts = badger.storage.getStore('fp_scripts').getItem(request_host);
 
         if (fpScripts) {


### PR DESCRIPTION
Following up on #2891 

Because we only block scripts that belong to this list of domains **and** that have matching entries in `fp_scripts` (which we prune at seed generation: 43dafdc48eb02cb108d4907541a2737b10fb3a90), this is mostly so that we can quickly remove entries if needed.

We may next want to update `fp_cdn_domains` in pbconfig to hold optional metadata so that we can specify wildcard script URL patterns to block for certain domains, to work around randomly generated paths or filenames.